### PR TITLE
Ignore "ss" query param for apartments.com verifier

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -21,7 +21,7 @@ class FinalResult(BaseModel):
 
 @beartype
 class ApartmentsUrlMatch(BaseMetric):
-    IGNORED_PARAMS = ("io",)
+    IGNORED_PARAMS = ("io", "ss")
 
     def __init__(self, gt_url: str | list[str]) -> None:
         super().__init__()


### PR DESCRIPTION
apartments.com now supports smart search (natural language query gets converted to filters directly, to some extent). It will add a ss=… query param to the URL, which we shall ignore

<img width="5938" height="2724" alt="image" src="https://github.com/user-attachments/assets/8a60eae1-424d-4193-9eb2-dd414ec875ac" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates apartments.com URL normalization to disregard the smart-search query parameter.
> 
> - Expands `IGNORED_PARAMS` in `ApartmentsUrlMatch` to include `"ss"` (in addition to `"io"`) so `ss=` no longer affects match scoring
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7da2bcfa693a9db6450a102243771bf1007aff0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->