### PR TITLE
Add payload trimming to prevent oversized API requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ eval = [
     "datasets>=2.14.0",
     "openai>=1.69.0",
     "tabulate>=0.9.0",
-    "yutori>=0.3.5",
+    "yutori>=0.4.0",
 ]
 dev = [
     "pytest>=7.0.0",


### PR DESCRIPTION
## Summary

- Adds automatic payload trimming before each n1 API call during evaluations
- Bumps `yutori` dependency floor to `>=0.4.0` (required for `yutori.n1`)
- Fixes pre-existing unused variable lint warning

## Motivation

Long evaluation runs accumulate base64-encoded screenshots in the message history. On complex tasks that require many browsing steps, the payload can exceed the n1 API's ~10MB request size limit, causing the evaluation to fail mid-run.

The yutori SDK (v0.4.0) now provides a `trim_images_to_fit` utility (adapted from the [n1-brightdata](https://github.com/meirk-brd/n1-brightdata) project) that intelligently removes old screenshots while keeping the most recent ones for context. This PR integrates it into the eval script.

## Changes

- Import `trim_images_to_fit` from `yutori.n1.payload`
- Call it at the start of `_predict()` before sending to the API
- Add `eval_max_request_bytes` (default 9.5MB) and `eval_keep_recent_screenshots` (default 6) to `Config`
- Bump `yutori>=0.3.5` → `yutori>=0.4.0` in `pyproject.toml`
- Remove unused `observations` variable assignment (F841)

## Test plan

- [x] Script compiles cleanly
- [x] Dependent SDK change: https://github.com/yutori-ai/yutori-sdk-python/pull/new/feat/n1-payload-utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core eval request path by mutating the message history before each model call; incorrect trimming thresholds could change agent behavior or still allow occasional request-size failures.
> 
> **Overview**
> Prevents evaluation runs from failing due to oversized n1 requests by trimming older screenshot images from the chat `messages` payload before each API call.
> 
> Adds `Config` knobs (`eval_max_request_bytes`, `eval_keep_recent_screenshots`) and logs when screenshots are removed, bumps `yutori` to `>=0.4.0` to use `yutori.n1.payload.trim_images_to_fit`, and removes an unused variable assignment in tool execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6912a6496be9a4979b30ff74a7e441bad791aef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->