### PR TITLE
Update README to prefer uv with venv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,20 @@ Want to understand what the benchmark tasks look like? You can run them manually
 
 ### Step 1: Install with Browser Support
 
+We recommend installing with [uv](https://docs.astral.sh/uv/getting-started/installation/):
 ```bash
-# Using uv (recommended)
-uv pip install -e ".[eval]"
+uv sync --extra eval
+source .venv/bin/activate
 python -m playwright install chromium webkit
+```
 
-# Or using pip
+<details>
+<summary>Or, using raw pip:</summary>
+```bash
 pip install -e ".[eval]"
 python -m playwright install chromium webkit
 ```
+</details>
 
 ### Step 2: Run the Demo
 
@@ -73,13 +78,12 @@ We provide an evaluation script for the [Yutori n1](https://yutori.com/blog/intr
 1. Authenticate with Yutori:
 
    ```bash
-   uv pip install yutori
    yutori auth login
    ```
    This will open Yutori in your browser and save your API key locally to `~/.yutori/config.json`.
 
    <details>
-   <summary>Or, set the API key manually</summary>
+   <summary>Or, set the API key manually:</summary>
 
    ```bash
    export YUTORI_API_KEY=yt-...
@@ -123,9 +127,9 @@ The results on the full Navi-Bench dataset may look like:
 ![Sample results](assets/sample-results-navi-bench.png)
 
 Where we print the number of finished/crashed tasks and three scores:
-- Lower Bound: treat crashed tasks as score=0, then average across all the tasks
-- Excl. Crashed: exclude crashed tasks, then average across the rest of the tasks
-- Upper Bound: treat crashed tasks as score=1, then average across all the tasks
+- **Lower Bound**: treat crashed tasks as score=0, then average across all the tasks
+- **Excl. Crashed**: exclude crashed tasks, then average across the rest of the tasks
+- **Upper Bound**: treat crashed tasks as score=1, then average across all the tasks
 
 Results are saved to `results_n1/` by default. The script automatically resumes from existing results, so you can re-run to retry any crashed tasks. To start fresh, delete the directory or pass a different `--eval_save_dir`.
 


### PR DESCRIPTION
## Summary
- Restructure install instructions to recommend `uv sync` with venv activation, moving raw pip to a collapsible section
- Activate `.venv` so subsequent commands don't need `uv run` prefix
- Remove redundant `uv pip install yutori` from eval setup (already included via `uv sync --extra eval`)
- Minor formatting: bold score labels, consistent punctuation in summary tags

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust install commands and formatting; no runtime or API behavior changes.
> 
> **Overview**
> Updates `README.md` install instructions to **prefer `uv sync --extra eval`** and explicitly `source .venv/bin/activate`, moving the raw `pip` flow into a collapsible `<details>` block.
> 
> Cleans up eval setup docs by removing a redundant `uv pip install yutori` step, and makes minor formatting tweaks (punctuation in `<summary>` and bolded score labels in the results section).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 249c9e568ae224aef5fde576b76d80beef91e600. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->