### PR TITLE
Fix date resolution bug and add apartments.com geolocation

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -63,7 +63,9 @@ async def build_browser(
     context = None
 
     try:
-        need_to_set_location = "opentable.com" in task_config.url or "resy.com" in task_config.url
+        need_to_set_location = (
+            "apartments.com" in task_config.url or "opentable.com" in task_config.url or "resy.com" in task_config.url
+        )
 
         use_local_browser = "apartments.com" not in task_config.url and "resy.com" not in task_config.url
         if not use_local_browser and not os.getenv("BROWSER_CDP_URL"):


### PR DESCRIPTION
## Summary
- Fix `initialize_placeholder_map` in `navi_bench/dates.py`: string-parsed dates like "February 28th" were resolving to next year even when still in the future, due to `_month_ref_to_year_month` using the 15th as a proxy for month comparison. Now normalizes to `base_date.year` and only bumps when `min(dates) <= base_date`.
- Add `apartments.com` to `need_to_set_location` in `evaluation/browser.py` so geolocation is set correctly for apartment searches.

## Test plan
- [x] Verified fix on navi_bench tasks (opentable + resy) — 2 date corrections, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches date parsing/normalization logic used across tasks and could shift resolved dates around year boundaries or leap days. Browser change is small but affects site-specific geolocation behavior for evaluation.
> 
> **Overview**
> Fixes `initialize_placeholder_map` date resolution so *string-parsed* placeholders (e.g., month/day literals) are normalized to `base_date.year` and only bumped to next year when the earliest resolved date is `<= base_date`; also clamps invalid days for the target year (e.g., Feb 29 handling). Dynamic `{now() + timedelta(...)}` placeholders keep the previous behavior of simply filtering out past dates.
> 
> Updates browser evaluation setup to treat `apartments.com` like `opentable.com`/`resy.com` for location spoofing by including it in `need_to_set_location`, ensuring geolocation is set when creating the Playwright context / CDP session.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 792c7561567aa0392eead63d063d785081e4afbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->