### PR TITLE
refactor: use statistics.median in TimingStats

### DIFF
--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from statistics import median
 
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -60,11 +61,7 @@ class TimingStats(BaseModel):
     def median_time_ms(self) -> float:
         if not self.times_ms:
             return 0.0
-        sorted_times = sorted(self.times_ms)
-        n = len(sorted_times)
-        if n % 2 == 0:
-            return (sorted_times[n // 2 - 1] + sorted_times[n // 2]) / 2
-        return sorted_times[n // 2]
+        return median(self.times_ms)
 
     @property
     def p95_time_ms(self) -> float:


### PR DESCRIPTION
## Summary

Replace the hand-rolled median computation in `TimingStats.median_time_ms` with `statistics.median` from the standard library.

## Why

`evaluation/stats.py` reimplemented median by sorting `times_ms` and branching on even/odd length. That's exactly what `statistics.median` already does — using the stdlib removes 5 lines of logic in favor of a canonical, well-tested function, and makes the intent immediately obvious at the call site.

## Why it's safe

- `statistics.median` is equivalent to the existing implementation: for odd-length input it returns the middle element; for even-length input it returns the average of the two middle elements.
- The existing empty-list guard is preserved (`statistics.median` raises `StatisticsError` on empty input, which we don't want to surface).
- `p95_time_ms` is intentionally **not** switched to `statistics.quantiles` — that uses linear interpolation while the current code uses nearest-rank indexing, so swapping them would shift reported percentiles. Left unchanged.
- No call sites change. The property keeps the same name, signature, and return type.

## Test plan

- [x] No behavioral change — verified by equivalence of `statistics.median` and the hand-rolled formulas on odd- and even-length inputs.
- [x] Empty-list guard preserved.
- [x] Single-file diff, reviewable at a glance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to timing statistics computation; behavior should remain the same aside from relying on the standard library implementation.
> 
> **Overview**
> Simplifies `TimingStats.median_time_ms` in `evaluation/stats.py` by replacing the custom median calculation with Python’s standard-library `statistics.median` (keeping the empty-list guard) and adding the corresponding import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a04cabda9b9c9882c7b0041539a5663e680b2964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->