### PR TITLE
Extract option-validation helper in dates.py

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -90,6 +90,20 @@ def _parse_dynamic_options(raw: str | None) -> dict[str, str]:
     return options
 
 
+def _resolve_option(
+    options: dict[str, str],
+    key: str,
+    default: str,
+    allowed: set[str],
+    label: str | None = None,
+) -> str:
+    """Return ``options[key]`` (or ``default``), validating it is in ``allowed``."""
+    value = options.get(key, default)
+    if value not in allowed:
+        raise ValueError(f"{label or key} must be one of: " + ", ".join(allowed))
+    return value
+
+
 def resolve_placeholder_values(
     text: str,
     base_date: date,
@@ -118,13 +132,8 @@ def resolve_placeholder_values(
             raise ValueError("timedelta end offset cannot be smaller than the start offset")
 
         options = _parse_dynamic_options(match.group("options"))
-        month_style = options.get("month", "short")
-        if month_style not in _MONTH_STYLE_OPTIONS:
-            raise ValueError("month style must be one of: " + ", ".join(_MONTH_STYLE_OPTIONS))
-
-        range_mode = options.get("range", "all")
-        if range_mode not in _RANGE_OPTIONS:
-            raise ValueError("range must be one of: " + ", ".join(_RANGE_OPTIONS))
+        month_style = _resolve_option(options, "month", "short", _MONTH_STYLE_OPTIONS, label="month style")
+        range_mode = _resolve_option(options, "range", "all", _RANGE_OPTIONS)
 
         offsets = range(start, end + 1)
         start_date = base_date + timedelta(days=start)
@@ -135,13 +144,8 @@ def resolve_placeholder_values(
         else:
             iso_dates = [(base_date + timedelta(days=offset)).isoformat() for offset in offsets]
 
-        year_style = options.get("year", "none")
-        if year_style not in _YEAR_OPTIONS:
-            raise ValueError("year must be one of: " + ", ".join(_YEAR_OPTIONS))
-
-        prefix_mode = options.get("prefix", "auto")
-        if prefix_mode not in _PREFIX_OPTIONS:
-            raise ValueError("prefix must be one of: " + ", ".join(_PREFIX_OPTIONS))
+        year_style = _resolve_option(options, "year", "none", _YEAR_OPTIONS)
+        prefix_mode = _resolve_option(options, "prefix", "auto", _PREFIX_OPTIONS)
 
         if prefix_mode == "none":
             prefix = ""


### PR DESCRIPTION
## Summary

`resolve_placeholder_values` in `navi_bench/dates.py` repeated the same option-validation pattern four times — read a value with a default, check membership against an allowed set, raise `ValueError` with a uniform "must be one of: ..." message. Consolidate this into a small `_resolve_option()` helper.

## Why this is an improvement

- Removes 12 lines of near-identical boilerplate (4 repetitions of the same 3-line pattern).
- Makes the validation intent explicit: each call site now reads as "get option with default, from allowed set".
- Adding a new option in the future is a single-line call, not a new 3-line block to copy-paste.

## Why this is safe

- **No behavioral change**: defaults, allowed-set membership check, error text (`"<label> must be one of: <joined>"`), and validation ordering are all preserved.
- The only option that used a custom label (`"month style"`) is passed through explicitly; the rest use their raw key name, matching the previous error messages.
- Scope is one file, one function. Reviewer can verify correctness from the diff alone.

https://claude.ai/code/session_015pXGgHDduTMXtRpkk99fKg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes dynamic placeholder option validation; behavior should remain the same aside from potential minor differences in allowed-value ordering in error messages.
> 
> **Overview**
> Refactors dynamic placeholder option parsing in `resolve_placeholder_values` by extracting repeated “get-with-default + allowed-set validation” into a new `_resolve_option()` helper.
> 
> Replaces the four inline validations (`month`, `range`, `year`, `prefix`) with helper calls, preserving defaults and error wording (with an explicit `month style` label).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb8235b6453e82ae91402f52a2732fdf7acb3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->