### PR TITLE
Extract duplicated option-validation helper in dates.py

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -90,6 +90,24 @@ def _parse_dynamic_options(raw: str | None) -> dict[str, str]:
     return options
 
 
+def _get_validated_option(
+    options: dict[str, str],
+    key: str,
+    default: str,
+    allowed: set[str],
+    label: str | None = None,
+) -> str:
+    """Return ``options[key]`` (or ``default``) after checking membership in ``allowed``.
+
+    ``label`` overrides ``key`` in the error message when they differ
+    (e.g. key="month" surfaces as "month style").
+    """
+    value = options.get(key, default)
+    if value not in allowed:
+        raise ValueError(f"{label or key} must be one of: " + ", ".join(allowed))
+    return value
+
+
 def resolve_placeholder_values(
     text: str,
     base_date: date,
@@ -118,13 +136,8 @@ def resolve_placeholder_values(
             raise ValueError("timedelta end offset cannot be smaller than the start offset")
 
         options = _parse_dynamic_options(match.group("options"))
-        month_style = options.get("month", "short")
-        if month_style not in _MONTH_STYLE_OPTIONS:
-            raise ValueError("month style must be one of: " + ", ".join(_MONTH_STYLE_OPTIONS))
-
-        range_mode = options.get("range", "all")
-        if range_mode not in _RANGE_OPTIONS:
-            raise ValueError("range must be one of: " + ", ".join(_RANGE_OPTIONS))
+        month_style = _get_validated_option(options, "month", "short", _MONTH_STYLE_OPTIONS, label="month style")
+        range_mode = _get_validated_option(options, "range", "all", _RANGE_OPTIONS)
 
         offsets = range(start, end + 1)
         start_date = base_date + timedelta(days=start)
@@ -135,13 +148,8 @@ def resolve_placeholder_values(
         else:
             iso_dates = [(base_date + timedelta(days=offset)).isoformat() for offset in offsets]
 
-        year_style = options.get("year", "none")
-        if year_style not in _YEAR_OPTIONS:
-            raise ValueError("year must be one of: " + ", ".join(_YEAR_OPTIONS))
-
-        prefix_mode = options.get("prefix", "auto")
-        if prefix_mode not in _PREFIX_OPTIONS:
-            raise ValueError("prefix must be one of: " + ", ".join(_PREFIX_OPTIONS))
+        year_style = _get_validated_option(options, "year", "none", _YEAR_OPTIONS)
+        prefix_mode = _get_validated_option(options, "prefix", "auto", _PREFIX_OPTIONS)
 
         if prefix_mode == "none":
             prefix = ""


### PR DESCRIPTION
## What

Extract a private `_get_validated_option()` helper to replace four near-identical validation blocks in `resolve_placeholder_values()` (`navi_bench/dates.py`).

## Why

Each of the four dynamic-placeholder options (`month`, `range`, `year`, `prefix`) was validated with the same three-line pattern:

```python
value = options.get(key, default)
if value not in _ALLOWED_SET:
    raise ValueError(f"{label} must be one of: " + ", ".join(_ALLOWED_SET))
```

Consolidating into one helper eliminates twelve lines of duplicated logic and makes adding a fifth option a one-liner. It also keeps the allowed-set constants and the validation that consumes them next to each other in source.

## Safety

No behavioral change. For each of the four call sites:
- The default value, allowed set, and membership check are unchanged.
- The raised exception type (`ValueError`) is unchanged.
- The error message is unchanged. The `label` argument preserves the single asymmetric message ("month style" rather than the key name "month").

Set iteration order in the error text was already non-deterministic before this PR, so nothing about that changed either.

Scoped to one file; the helper is private (`_` prefix) and not exported.

https://claude.ai/code/session_01YW1c7xudHFVsdxEizVVQX7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `navi_bench/dates.py` that centralizes repeated validation logic; behavior should remain the same aside from minor potential differences in error-string ordering already present due to set joins.
> 
> **Overview**
> Refactors dynamic date placeholder parsing in `navi_bench/dates.py` by extracting repeated option validation into a new private helper, `_get_validated_option()`.
> 
> `resolve_placeholder_values()` now uses this helper to validate `month`, `range`, `year`, and `prefix` options, preserving defaults and raising `ValueError` for unsupported values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018eefb8c12d2609b7e072f7bd48ed55b9243568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->