### PR TITLE
refactor(recorder): extract shared JSON save/load helpers

### DIFF
--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -95,64 +95,44 @@ class Recorder:
         except Exception:
             logger.opt(exception=True).error(f"Failed to save messages to: {save_path}")
 
-    async def save_result(self, result: BaseModel) -> None:
-        save_path = osp.join(self.item_dir, "result.json")
+    async def _save_json(self, filename: str, data: dict, kind: str) -> None:
+        save_path = osp.join(self.item_dir, filename)
         try:
-            dic = {"_target_": get_import_path(type(result)), **result.model_dump(mode="json", exclude_none=True)}
             async with aiofiles.open(save_path, "w") as f:
-                await f.write(json.dumps(dic, indent=2))
+                await f.write(json.dumps(data, indent=2))
         except Exception:
-            logger.opt(exception=True).error(f"Failed to save result to: {save_path}")
+            logger.opt(exception=True).error(f"Failed to save {kind} to: {save_path}")
+
+    async def _load_json(self, filename: str, kind: str) -> dict | None:
+        load_path = osp.join(self.item_dir, filename)
+        if not osp.exists(load_path):
+            return None
+        try:
+            async with aiofiles.open(load_path, "r") as f:
+                content = await f.read()
+            return json.loads(content)
+        except Exception:
+            logger.opt(exception=True).error(f"Failed to load {kind} from: {load_path}")
+            return None
+
+    async def save_result(self, result: BaseModel) -> None:
+        dic = {"_target_": get_import_path(type(result)), **result.model_dump(mode="json", exclude_none=True)}
+        await self._save_json("result.json", dic, "result")
 
     async def load_result(self) -> BaseModel | None:
-        load_path = osp.join(self.item_dir, "result.json")
-        if not osp.exists(load_path):
-            return None
-        try:
-            async with aiofiles.open(load_path, "r") as f:
-                content = await f.read()
-            dic = json.loads(content)
-            return instantiate(dic)
-        except Exception:
-            logger.opt(exception=True).error(f"Failed to load result from: {load_path}")
-            return None
+        dic = await self._load_json("result.json", "result")
+        return instantiate(dic) if dic is not None else None
 
     async def save_usage(self, usage: BaseModel) -> None:
-        save_path = osp.join(self.item_dir, "usage.json")
-        try:
-            async with aiofiles.open(save_path, "w") as f:
-                await f.write(json.dumps(usage.model_dump(mode="json"), indent=2))
-        except Exception:
-            logger.opt(exception=True).error(f"Failed to save usage to: {save_path}")
+        await self._save_json("usage.json", usage.model_dump(mode="json"), "usage")
 
     async def load_usage(self, cls: type[BaseModel]) -> BaseModel | None:
-        load_path = osp.join(self.item_dir, "usage.json")
-        if not osp.exists(load_path):
-            return None
-        try:
-            async with aiofiles.open(load_path, "r") as f:
-                content = await f.read()
-            return cls.model_validate(json.loads(content))
-        except Exception:
-            logger.opt(exception=True).error(f"Failed to load usage from: {load_path}")
-            return None
+        dic = await self._load_json("usage.json", "usage")
+        return cls.model_validate(dic) if dic is not None else None
 
     async def save_timing(self, timing: TimingStats) -> None:
-        save_path = osp.join(self.item_dir, "timing.json")
-        try:
-            async with aiofiles.open(save_path, "w") as f:
-                await f.write(json.dumps(timing.model_dump(mode="json"), indent=2))
-        except Exception:
-            logger.opt(exception=True).error(f"Failed to save timing to: {save_path}")
+        await self._save_json("timing.json", timing.model_dump(mode="json"), "timing")
 
     async def load_timing(self) -> TimingStats | None:
-        load_path = osp.join(self.item_dir, "timing.json")
-        if not osp.exists(load_path):
-            return None
-        try:
-            async with aiofiles.open(load_path, "r") as f:
-                content = await f.read()
-            return TimingStats.model_validate(json.loads(content))
-        except Exception:
-            logger.opt(exception=True).error(f"Failed to load timing from: {load_path}")
-            return None
+        dic = await self._load_json("timing.json", "timing")
+        return TimingStats.model_validate(dic) if dic is not None else None

--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -102,8 +102,9 @@ class Recorder:
     async def _save_json(self, filename: str, build_data: Callable[[], dict], kind: str) -> None:
         save_path = osp.join(self.item_dir, filename)
         try:
+            data = build_data()
             async with aiofiles.open(save_path, "w") as f:
-                await f.write(json.dumps(build_data(), indent=2))
+                await f.write(json.dumps(data, indent=2))
         except Exception:
             logger.opt(exception=True).error(f"Failed to save {kind} to: {save_path}")
 

--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -1,8 +1,10 @@
 import functools
 import json
 import os
+from collections.abc import Callable
 from contextlib import contextmanager
 from os import path as osp
+from typing import TypeVar
 
 import aiofiles
 from loguru import logger
@@ -11,6 +13,8 @@ from pydantic import BaseModel
 from evaluation.stats import TimingStats
 from evaluation.vis import generate_visualization_html
 from navi_bench.base import get_import_path, instantiate
+
+T = TypeVar("T")
 
 
 def log_formatter(record: dict, *, colorize: bool = True) -> str:
@@ -95,44 +99,44 @@ class Recorder:
         except Exception:
             logger.opt(exception=True).error(f"Failed to save messages to: {save_path}")
 
-    async def _save_json(self, filename: str, data: dict, kind: str) -> None:
+    async def _save_json(self, filename: str, build_data: Callable[[], dict], kind: str) -> None:
         save_path = osp.join(self.item_dir, filename)
         try:
             async with aiofiles.open(save_path, "w") as f:
-                await f.write(json.dumps(data, indent=2))
+                await f.write(json.dumps(build_data(), indent=2))
         except Exception:
             logger.opt(exception=True).error(f"Failed to save {kind} to: {save_path}")
 
-    async def _load_json(self, filename: str, kind: str) -> dict | None:
+    async def _load_json(self, filename: str, deserialize: Callable[[dict], T], kind: str) -> T | None:
         load_path = osp.join(self.item_dir, filename)
         if not osp.exists(load_path):
             return None
         try:
             async with aiofiles.open(load_path, "r") as f:
                 content = await f.read()
-            return json.loads(content)
+            return deserialize(json.loads(content))
         except Exception:
             logger.opt(exception=True).error(f"Failed to load {kind} from: {load_path}")
             return None
 
     async def save_result(self, result: BaseModel) -> None:
-        dic = {"_target_": get_import_path(type(result)), **result.model_dump(mode="json", exclude_none=True)}
-        await self._save_json("result.json", dic, "result")
+        await self._save_json(
+            "result.json",
+            lambda: {"_target_": get_import_path(type(result)), **result.model_dump(mode="json", exclude_none=True)},
+            "result",
+        )
 
     async def load_result(self) -> BaseModel | None:
-        dic = await self._load_json("result.json", "result")
-        return instantiate(dic) if dic is not None else None
+        return await self._load_json("result.json", instantiate, "result")
 
     async def save_usage(self, usage: BaseModel) -> None:
-        await self._save_json("usage.json", usage.model_dump(mode="json"), "usage")
+        await self._save_json("usage.json", lambda: usage.model_dump(mode="json"), "usage")
 
     async def load_usage(self, cls: type[BaseModel]) -> BaseModel | None:
-        dic = await self._load_json("usage.json", "usage")
-        return cls.model_validate(dic) if dic is not None else None
+        return await self._load_json("usage.json", cls.model_validate, "usage")
 
     async def save_timing(self, timing: TimingStats) -> None:
-        await self._save_json("timing.json", timing.model_dump(mode="json"), "timing")
+        await self._save_json("timing.json", lambda: timing.model_dump(mode="json"), "timing")
 
     async def load_timing(self) -> TimingStats | None:
-        dic = await self._load_json("timing.json", "timing")
-        return TimingStats.model_validate(dic) if dic is not None else None
+        return await self._load_json("timing.json", TimingStats.model_validate, "timing")


### PR DESCRIPTION
## Summary

The six methods `save_result`/`load_result`, `save_usage`/`load_usage`, and `save_timing`/`load_timing` on `Recorder` (evaluation/recorder.py:98-158) had identical JSON I/O skeletons — `aiofiles.open(...).write(json.dumps(..., indent=2))` on the save side, `osp.exists` guard + `aiofiles.open(...).read() + json.loads` on the load side, both wrapped in a `try/except Exception: logger.opt(exception=True).error(...)`. The only differences were the filename, the human-readable kind label in the error message, and the pydantic serialize/deserialize step.

This PR extracts two private helpers, `_save_json(filename, data, kind)` and `_load_json(filename, kind)`, that own the disk I/O and error logging. Each of the six public methods collapses to a single serialize-and-dispatch line (save) or load-and-validate line (load).

## Why this is a structural improvement

- Removes ~20 lines of near-duplicate I/O scaffolding (22 insertions, 42 deletions).
- Each save/load artifact now reads as "this is how the pydantic model maps to/from the JSON dict," with disk + error handling concerns factored out.
- Adding a fourth `save_<x>` / `load_<x>` pair (e.g. `save_trace`) becomes a one-liner instead of a new copy of the try/except skeleton.
- Error messages ("Failed to save/load X to/from: ...") become uniform by construction instead of by convention.

## Why it is safe

- **No on-disk format change.** `_save_json` preserves `indent=2`. `save_result` still prepends `_target_` and passes `exclude_none=True`; `save_usage`/`save_timing` still use the default `model_dump(mode="json")`. A `result.json`/`usage.json`/`timing.json` written by `main` is byte-identical to one written by this branch.
- **No call-site change.** All six public signatures are unchanged; `load_*` still returns `None` when the file is missing or malformed, preserving the `... or TokenUsage()` / `... or TimingStats()` fallback pattern at `evaluation/eval_n1.py:511-512`.
- **Blast radius = 1 file.** Only `evaluation/recorder.py` is touched.
- No existing tests in this repo; behavior is verified by diff inspection (helpers are drop-in replacements for the inlined I/O).

https://claude.ai/code/session_011atHq5iCyFirWENFtja71q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor isolated to `evaluation/recorder.py` that centralizes JSON file I/O and error logging; behavior should remain the same but a bug in the shared helper would affect all result/usage/timing persistence.
> 
> **Overview**
> **Refactors `Recorder` JSON persistence** by extracting shared async helpers `_save_json` and `_load_json` that handle file paths, `aiofiles` I/O, JSON (de)serialization, and uniform error logging.
> 
> Updates `save_result`/`load_result`, `save_usage`/`load_usage`, and `save_timing`/`load_timing` to delegate to these helpers, reducing duplicated try/except scaffolding while keeping the same filenames and serialized payload shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11fe92933f223c4c799f13cd785b1622cf06deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->