### PR TITLE
refactor: replace misused lstrip with removeprefix in URL normalization

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -7,7 +7,7 @@ from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path, strip_url_scheme_and_www
 from navi_bench.dates import initialize_user_metadata
 
 
@@ -210,8 +210,7 @@ class ApartmentsUrlMatch(BaseMetric):
             return ""
 
         # Basic normalization
-        normalized = url.lower().strip()
-        normalized = normalized.lstrip("http://").lstrip("https://").lstrip("www.")
+        normalized = strip_url_scheme_and_www(url.lower().strip())
 
         # Parse URL components
         parsed = urlparse("http://" + normalized)

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -20,6 +20,23 @@ def get_import_path(obj: Any) -> str:
     return f"{obj.__module__}.{obj.__qualname__}"
 
 
+def strip_url_scheme_and_www(url: str) -> str:
+    """Strip ``http://``/``https://`` and a leading ``www.`` from ``url``.
+
+    This is the prefix-stripping primitive shared by URL-match metrics. It
+    uses ``str.removeprefix`` rather than ``str.lstrip`` — ``lstrip`` treats
+    its argument as a *character set*, so ``"https://foo".lstrip("http://")``
+    strips any leading ``h``/``t``/``p``/``:``/``/`` characters and ``"ww".lstrip("www.")``
+    would also eat a non-prefix ``ww``.
+
+    The input is not lowercased here; callers that want case-insensitive
+    matching should lower-case before calling.
+    """
+    for prefix in ("https://", "http://", "www."):
+        url = url.removeprefix(prefix)
+    return url
+
+
 def omni_import(path: str):
     """
     Import a module, class, function, or attribute given its absolute path.

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -13,7 +13,7 @@ from loguru import logger
 from playwright.async_api import Page
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path, strip_url_scheme_and_www
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -275,8 +275,7 @@ class ResyUrlMatch(BaseMetric):
             return ""
 
         # Basic normalization
-        normalized = url.lower().strip()
-        normalized = normalized.lstrip("http://").lstrip("https://").lstrip("www.")
+        normalized = strip_url_scheme_and_www(url.lower().strip())
 
         # Parse URL components
         parsed = urlparse("http://" + normalized)


### PR DESCRIPTION
## What

Extract a small `strip_url_scheme_and_www()` helper in `navi_bench/base.py` that correctly strips `http://` / `https://` / `www.` prefixes, and use it from the two URL-match metrics that currently do this by hand:

- `navi_bench/apartments/apartments_url_match.py` (`ApartmentsUrlMatch._normalize_url`)
- `navi_bench/resy/resy_url_match.py` (`ResyUrlMatch._normalize_url`)

## Why

Both metrics use:

```python
url.lstrip("http://").lstrip("https://").lstrip("www.")
```

`str.lstrip` treats its argument as a **set of characters**, not a prefix, so this is semantically incorrect. For example, `"wwapartments.com".lstrip("www.")` returns `"apartments.com"` even though there's no `www.` prefix, and `"https://x".lstrip("http://")` leaves `"s://x"` only because `s` isn't in the char set. It happens to produce the right answer for the well-formed `http[s]://[www.]…` URLs these metrics see in practice, which is why nothing has broken — but the pattern is a well-known foot-gun and it's duplicated in two places.

Replacing it with `str.removeprefix` (available on Python 3.9+, and the project requires `>=3.10`) gives the correct prefix semantics with a single obvious implementation, and de-duplicates the three-call chain.

## Safety

- Behavior is identical on all realistic inputs these metrics accept (`http://…`, `https://…`, optionally with `www.`, and bare `domain.com/…`). Verified with a small standalone script covering the exact URLs used in this repo's task configs (apartments.com, resy.com).
- The only inputs where behavior differs are malformed / `h`-`t`-`p`-`s`-`w` - prefixed strings that do not correspond to a real URL scheme, where the new code is strictly more correct (stops stripping rather than eating characters from a spurious "set").
- Scope: 3 files, ~20 lines. No call sites outside the two metric classes.
- `ruff check` / `ruff format --check` pass on the modified files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M1rBn8wWGLJj9KNNZjLcJ7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to URL normalization in two metrics; behavior should only differ for malformed/edge-case inputs where prior `lstrip` semantics could over-strip characters.
> 
> **Overview**
> Fixes URL normalization prefix stripping by introducing `strip_url_scheme_and_www()` (using `str.removeprefix`) and reusing it in `ApartmentsUrlMatch._normalize_url` and `ResyUrlMatch._normalize_url`, replacing the prior `lstrip("http://")/lstrip("https://")/lstrip("www.")` foot-gun.
> 
> This de-duplicates the logic and makes URL matching less prone to false positives/negatives on nonstandard inputs while keeping intended behavior for well-formed URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da853daead7b7101f05d82741e706b0656b52a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->