### PR TITLE
refactor(craigslist): delegate user-metadata init to shared helper

### DIFF
--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -1,13 +1,12 @@
-from datetime import datetime
 from typing import TypedDict
 from urllib.parse import parse_qs, urlparse
-from zoneinfo import ZoneInfo
 
 from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path
+from navi_bench.dates import initialize_user_metadata
 
 
 IGNORE_URL_PARAMS = ("isTrusted",)
@@ -92,10 +91,9 @@ def generate_task_config(
     location: str,
     timezone: str,
     gt_urls: list[list[str]],
+    timestamp: int | None = None,
 ) -> BaseTaskConfig:
-    tz_info = ZoneInfo(timezone)
-    timestamp = int(datetime.now(tz_info).timestamp())
-    user_metadata = UserMetadata(location=location, timezone=timezone, timestamp=timestamp)
+    user_metadata = initialize_user_metadata(timezone, location, timestamp)
 
     eval_target = get_import_path(CraigslistUrlMatch)
     eval_config = {"_target_": eval_target, "gt_urls": gt_urls}


### PR DESCRIPTION
## What

`navi_bench/craigslist/craigslist_url_match.py::generate_task_config` was the lone outlier constructing `UserMetadata` inline from scratch:

```python
tz_info = ZoneInfo(timezone)
timestamp = int(datetime.now(tz_info).timestamp())
user_metadata = UserMetadata(location=location, timezone=timezone, timestamp=timestamp)
```

Every other metric module (`apartments/apartments_url_match.py`, `google_flights/google_flights_search_match.py`, `resy/resy_url_match.py`, `opentable/opentable_info_gathering.py`) already delegates to `navi_bench.dates.initialize_user_metadata`, which exists precisely to centralize this construction.

This PR brings craigslist in line:

```python
user_metadata = initialize_user_metadata(timezone, location, timestamp)
```

and adds an optional `timestamp: int | None = None` parameter so its `generate_task_config` signature matches the other metric modules.

## Why it's an improvement

- Removes 3 lines of duplicated logic and 3 now-unused imports (`datetime`, `ZoneInfo`, `UserMetadata`).
- Makes the five `generate_task_config` functions structurally uniform — future changes to `UserMetadata` construction (e.g., tz validation) propagate automatically.
- Enables deterministic tests that pin `timestamp`, matching what the other modules already support.

## Why it's safe

- **No behavioral change for existing call sites.** Unix timestamps are absolute instants: `datetime.now(tz).timestamp()` and the helper's `datetime.now().timestamp()` produce the same integer. The resulting `UserMetadata` is bit-identical.
- **`timestamp` is optional** — existing callers that don't pass it fall through to the same `int(datetime.now().timestamp())` path.
- **1-file diff.** Zero external call sites need updating.
- The three `__main__` sample rows in the file continue to pass through unchanged.

No overlap with open PRs #21/#22 (which touch `dates.py` option-validation internals) or #24 (URL prefix stripping).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRAQGvQoGDG16u1dwvRcba)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `UserMetadata` is constructed for Craigslist task configs and adds an optional `timestamp` parameter; behavior should remain the same unless callers start passing custom timestamps.
> 
> **Overview**
> Refactors `craigslist_url_match.generate_task_config` to delegate `UserMetadata` creation to the shared `initialize_user_metadata` helper, aligning it with other domains.
> 
> Adds an optional `timestamp: int | None = None` parameter to `generate_task_config` for deterministic config generation, and removes now-unused inline timezone/timestamp construction imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5be82500628b0db55ea7cc1f7bcf831a77c46b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->