### PR TITLE
refactor(eval_n1): extract _handle_task_failure helper

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -443,6 +443,22 @@ Today is: {dt.strftime("%A")}"""
     return result, task_usage, task_timing
 
 
+def _handle_task_failure(
+    e: Exception, attempt: int, max_attempts: int
+) -> tuple[Crashed, TokenUsage, TimingStats] | None:
+    """On the final attempt, log and return a Crashed-result tuple. Otherwise log a
+    retry warning and return None so the caller can continue the retry loop."""
+    if attempt == max_attempts:
+        logger.opt(exception=True).error(f"Failed to run task: {e}. No more attempts.")
+        return (
+            Crashed(score=0.0, exception=str(e), traceback=traceback.format_exc()),
+            TokenUsage(),
+            TimingStats(),
+        )
+    logger.opt(exception=True).warning(f"Failed to run task: {e}. Will retry.")
+    return None
+
+
 async def run_task(
     config: Config, item: DatasetItem, playwright: Playwright, recorder: Recorder, client: AsyncYutoriClient
 ) -> tuple[BaseModel | Crashed, TokenUsage, TimingStats]:
@@ -458,25 +474,15 @@ async def run_task(
                 raise
             except APIStatusError as e:
                 if isinstance(e, (RateLimitError, InternalServerError)):
-                    if attempt == config.eval_max_attempts:
-                        logger.opt(exception=True).error(f"Failed to run task: {e}. No more attempts.")
-                        return (
-                            Crashed(score=0.0, exception=str(e), traceback=traceback.format_exc()),
-                            TokenUsage(),
-                            TimingStats(),
-                        )
-                    logger.opt(exception=True).warning(f"Failed to run task: {e}. Will retry.")
+                    failure = _handle_task_failure(e, attempt, config.eval_max_attempts)
+                    if failure is not None:
+                        return failure
                     continue
                 raise
             except Exception as e:
-                if attempt == config.eval_max_attempts:
-                    logger.opt(exception=True).error(f"Failed to run task: {e}. No more attempts.")
-                    return (
-                        Crashed(score=0.0, exception=str(e), traceback=traceback.format_exc()),
-                        TokenUsage(),
-                        TimingStats(),
-                    )
-                logger.opt(exception=True).warning(f"Failed to run task: {e}. Will retry.")
+                failure = _handle_task_failure(e, attempt, config.eval_max_attempts)
+                if failure is not None:
+                    return failure
 
 
 @cli


### PR DESCRIPTION
## Summary

`run_task` in `evaluation/eval_n1.py` contained two near-identical blocks for the "last attempt → log error + return Crashed tuple / otherwise log warning and retry" pattern: one for `APIStatusError` (when it's a `RateLimitError`/`InternalServerError`) and one for the generic `Exception` branch. Keeping the two in sync (message text, traceback capture, `Crashed` payload) relied on manual discipline.

Extract a single `_handle_task_failure(e, attempt, max_attempts)` helper that returns the Crashed-result tuple on the final attempt and `None` otherwise. Both call sites now delegate to it.

## Why it's safe

- Pure structural extraction — log levels, log messages, `Crashed(...)` construction, and tuple contents are all unchanged.
- The APIStatusError branch still calls `continue` after a non-final failure; the generic Exception branch still falls through to the next loop iteration as before.
- No behavior change.

## Test plan
- [x] File parses / no syntax errors
- [ ] CI (lint + unit tests) green

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDAKe2oEvxb6DwWz4Raz2W)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes existing logging/`Crashed` tuple construction without changing retry behavior or error conditions.
> 
> **Overview**
> Refactors `evaluation/eval_n1.py` by extracting the duplicated “retry vs final attempt” error handling in `run_task` into `_handle_task_failure()`.
> 
> Both the `APIStatusError` (rate limit/internal server) and generic `Exception` paths now delegate to the helper, which logs the same messages and returns the same `Crashed`/empty usage+timing tuple only on the final attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982248c0e328e981b6163216c726d1f67aef331f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->