### PR TITLE
refactor(eval_n1): extract _sleep_or_reraise helper for retry backoff

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -302,6 +302,25 @@ Today is: {dt.strftime("%A")}"""
                 logger.info(f"[{step_idx}] Trimmed {removed} old screenshot(s); payload ~{size_mb:.2f} MB")
 
         delay = initial_delay
+
+        async def _sleep_or_reraise(attempt: int, content: object) -> None:
+            """Back off before the next attempt, or re-raise the current exception when out of retries.
+
+            Called from within an ``except`` block; bare ``raise`` re-raises
+            the exception currently being handled.
+            """
+            nonlocal delay
+            if attempt == max_attempts:
+                logger.opt(exception=True).error(
+                    f"[{step_idx}] Failed to get valid response: {content=}. No more attempts."
+                )
+                raise
+            logger.opt(exception=True).warning(
+                f"[{step_idx}] Failed to get valid response: {content=}. Retrying in {delay:.2f}s..."
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, max_delay)
+
         for attempt in range(1, max_attempts + 1):
             content = None
             try:
@@ -333,29 +352,11 @@ Today is: {dt.strftime("%A")}"""
             except OpenAIAuthError:
                 raise
             except RETRYABLE_API_ERRORS:
-                if attempt == max_attempts:
-                    logger.opt(exception=True).error(
-                        f"[{step_idx}] Failed to get valid response: {content=}. No more attempts."
-                    )
-                    raise
-                logger.opt(exception=True).warning(
-                    f"[{step_idx}] Failed to get valid response: {content=}. Retrying in {delay:.2f}s..."
-                )
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, max_delay)
+                await _sleep_or_reraise(attempt, content)
             except APIStatusError:
                 raise
             except Exception:
-                if attempt == max_attempts:
-                    logger.opt(exception=True).error(
-                        f"[{step_idx}] Failed to get valid response: {content=}. No more attempts."
-                    )
-                    raise
-                logger.opt(exception=True).warning(
-                    f"[{step_idx}] Failed to get valid response: {content=}. Retrying in {delay:.2f}s..."
-                )
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, max_delay)
+                await _sleep_or_reraise(attempt, content)
 
     while step_idx < config.eval_max_steps:
         step_idx += 1


### PR DESCRIPTION
## Summary

The two retry `except` blocks in `_predict` (inside `run_agent`) had identical 8-line bodies — log + sleep + exponential backoff, or re-raise when out of attempts. They were split because `except APIStatusError: raise` sits between them to intentionally short-circuit non-retryable HTTP errors (400, 401, etc.) while keeping `RETRYABLE_API_ERRORS` (includes `RateLimitError` and `InternalServerError`, which are also `APIStatusError` subclasses) and catch-all `Exception` in the retry path.

Consolidate the two identical bodies into a single nested async helper `_sleep_or_reraise` called from both retry branches.

## Why this is safe

- **No behavioral change.** The helper is called from within the `except` block, so bare `raise` re-raises the currently handled exception (verified:
  ```python
  async def inner():
      raise
  try:
      raise ValueError("x")
  except ValueError:
      await inner()  # re-raises ValueError("x")
  ```
  ).
- **Same control flow.** `OpenAIAuthError` and `APIStatusError` (non-retryable) still bubble up immediately; `RETRYABLE_API_ERRORS` and generic `Exception` still take the retry path.
- **Same backoff math.** `delay` is updated via `nonlocal`, matching the previous inline update.
- **Ruff clean.**

## Test plan

- [ ] `ruff check evaluation/eval_n1.py` — passes
- [ ] AST parse — passes
- [ ] No changes to callers; import surface unchanged

https://claude.ai/code/session_01Nd5YonaxpvJpMddFKkT439

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd5YonaxpvJpMddFKkT439)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that consolidates duplicated retry logic without changing retry conditions or backoff math. Main risk is subtle exception-flow differences if the helper is ever called outside an `except` block, but current usage remains within the same handlers.
> 
> **Overview**
> Refactors `_predict` in `evaluation/eval_n1.py` to deduplicate the retry/backoff code used for `RETRYABLE_API_ERRORS` and the generic `Exception` retry path.
> 
> Introduces a nested async helper ` _sleep_or_reraise()` that performs the existing log + sleep + exponential backoff and re-raises when attempts are exhausted, preserving the existing behavior where `OpenAIAuthError` and non-retryable `APIStatusError` still bubble up immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18497bd2dd98a9ab2ce95b2889b511bc9e2581f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->