### PR TITLE
Fix lstrip misuse in apartments URL scheme stripping

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -7,7 +7,7 @@ from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path, strip_url_scheme
 from navi_bench.dates import initialize_user_metadata
 
 
@@ -211,7 +211,7 @@ class ApartmentsUrlMatch(BaseMetric):
 
         # Basic normalization
         normalized = url.lower().strip()
-        normalized = normalized.lstrip("http://").lstrip("https://").lstrip("www.")
+        normalized = strip_url_scheme(normalized)
 
         # Parse URL components
         parsed = urlparse("http://" + normalized)

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -20,6 +20,17 @@ def get_import_path(obj: Any) -> str:
     return f"{obj.__module__}.{obj.__qualname__}"
 
 
+def strip_url_scheme(url: str) -> str:
+    """Strip http(s):// scheme and a leading www. prefix for URL normalization.
+
+    Assumes the input has already been lowercased; the common url.lower().strip()
+    step is performed by callers.
+    """
+    for scheme in ("https://", "http://"):
+        url = url.removeprefix(scheme)
+    return url.removeprefix("www.")
+
+
 def omni_import(path: str):
     """
     Import a module, class, function, or attribute given its absolute path.


### PR DESCRIPTION
## Summary

`navi_bench/apartments/apartments_url_match.py` (line 214) contained:

```python
normalized = normalized.lstrip("http://").lstrip("https://").lstrip("www.")
```

`str.lstrip(chars)` treats its argument as a **set of characters**, not a prefix. So `.lstrip("http://")` strips any of the characters `h`, `t`, `p`, `:`, `/` from the left. It happens to work for typical URLs but is a latent bug — a URL whose host starts with one of those characters (e.g. `https://hotpads.com` after the scheme is stripped) would have extra characters chewed off.

## Change

- Added `strip_url_scheme(url)` helper in `navi_bench/base.py` that uses `str.removeprefix` (Python 3.9+; `pyproject.toml` already pins `requires-python = ">=3.10"`).
- Replaced the buggy `lstrip` chain in `ApartmentsUrlMatch._normalize_url` with a call to the new helper.

## Safety

For all well-formed URLs beginning with `https://www.apartments.com/...` (the shape exercised by the existing test/dataset rows in this file), `removeprefix` produces identical output to the accidental `lstrip` behavior. The fix only diverges where the `lstrip` chain was silently over-stripping — those were always latent bugs.

## Follow-up

`navi_bench/resy/resy_url_match.py` line 279 has the same buggy pattern. Scoping that to a follow-up PR so this one can land quickly and the helper is available in `navi_bench.base` for the resy switch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKFRU124p3Ycc8XZZjt9Cv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only URL normalization prefix-stripping to avoid incorrect `lstrip` behavior, with minimal surface area and no data/auth impact.
> 
> **Overview**
> Fixes a latent URL normalization bug in `ApartmentsUrlMatch` by replacing the unsafe `lstrip("http://")/...` chain with a new shared helper.
> 
> Adds `strip_url_scheme()` in `navi_bench/base.py` (using `removeprefix`) and updates `navi_bench/apartments/apartments_url_match.py` to use it so URL comparisons don’t accidentally strip leading host characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50273bbb12a3ad3c392ebd3f37a04dbc99559fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->