### PR TITLE
Extract _safe_update_evaluator helper in eval_n1

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -254,16 +254,19 @@ Today is: {dt.strftime("%A")}"""
             else:
                 raise RuntimeError(f"Unknown action type: {name}")
 
+    async def _safe_update_evaluator() -> None:
+        try:
+            await evaluator.update(url=page.url, page=page, answer_message=answer_message)
+        except Exception:
+            logger.opt(exception=True).warning(f"[{step_idx}] Failed to update evaluator: {page.url}")
+
     async def _fail(
         reason: str,
         exception: Exception | None = None,
         do_evaluator_update: bool = False,
     ) -> tuple[BaseModel, TokenUsage, TimingStats]:
         if do_evaluator_update:
-            try:
-                await evaluator.update(url=page.url, page=page, answer_message=answer_message)
-            except Exception:
-                logger.opt(exception=True).warning(f"[{step_idx}] Failed to update evaluator: {page.url}")
+            await _safe_update_evaluator()
 
         result = await evaluator.compute()
         await recorder.save_messages(messages)
@@ -392,10 +395,7 @@ Today is: {dt.strftime("%A")}"""
 
         tool_call_id_to_observations = {}
 
-        try:
-            await evaluator.update(url=page.url, page=page, answer_message=answer_message)
-        except Exception:
-            logger.opt(exception=True).warning(f"[{step_idx}] Failed to update evaluator: {page.url}")
+        await _safe_update_evaluator()
 
         try:
             message = await _predict(messages)
@@ -420,10 +420,7 @@ Today is: {dt.strftime("%A")}"""
         except Exception as e:
             return await _fail(f"Failed to execute the tool calls: {message.tool_calls}", e, do_evaluator_update=True)
 
-    try:
-        await evaluator.update(url=page.url, page=page, answer_message=answer_message)
-    except Exception:
-        logger.opt(exception=True).warning(f"[{step_idx}] Failed to update evaluator: {page.url}")
+    await _safe_update_evaluator()
 
     result = await evaluator.compute()
 


### PR DESCRIPTION
## What

The same try/except wrapper around `evaluator.update()` was duplicated three times inside `run_agent()` in `evaluation/eval_n1.py`:

1. Inside `_fail()`, guarded by `do_evaluator_update`.
2. At the top of each step in the main loop (before `_predict`).
3. At the end of the loop (before the final `evaluator.compute()`).

All three copies had the same shape — `await evaluator.update(url=page.url, page=page, answer_message=answer_message)` wrapped in `try/except Exception` that logged an identical warning `f"[{step_idx}] Failed to update evaluator: {page.url}"`.

Extract a nested async helper `_safe_update_evaluator()` and call it at each site.

## Why

Three copies of the same best-effort-update pattern mean three places to remember to update if the signature, logging format, or exception handling ever needs to change. The helper captures `evaluator`, `page`, `answer_message`, and `step_idx` via closure, which is why it lives inside `run_agent` rather than at module scope.

## Safety

- No behavior change. The helper contains the exact `try/except/logger.opt(...).warning(...)` from the three removed copies, verbatim.
- `page.url`, `answer_message`, and `step_idx` are captured by closure at call time (same semantics as before — they're already read at call time in the original inline blocks, not at function-definition time).
- Syntax-checked (`python -c "import ast; ast.parse(open('evaluation/eval_n1.py').read())"` passes). No unit tests exist for this module.

https://claude.ai/code/session_01CDaW5SRypoHMBLW1CXx95k

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDaW5SRypoHMBLW1CXx95k)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that deduplicates error-handled `evaluator.update()` calls without changing evaluation logic; main risk is an unintended closure/ordering mistake, but the helper preserves the same try/except behavior.
> 
> **Overview**
> Extracts a nested async helper `*_safe_update_evaluator()*` in `evaluation/eval_n1.py` to centralize the try/except logging wrapper around `evaluator.update()`.
> 
> Replaces three duplicated inline update blocks (in `_fail()`, before `_predict()` each step, and before final `evaluator.compute()`) with calls to the helper to keep evaluator update behavior consistent and easier to maintain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527f9f6acd1a3ff78a2f5e54e3c06ccc55f05aff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->