### PR TITLE
refactor(recorder): extract shared _save_text helper for file-write boilerplate

### DIFF
--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -62,6 +62,18 @@ class Recorder:
         finally:
             logger.remove(handler_id)
 
+    async def _save_text(self, filename: str, build_content: Callable[[], str], kind: str) -> None:
+        save_path = osp.join(self.item_dir, filename)
+        try:
+            content = build_content()
+            async with aiofiles.open(save_path, "w") as f:
+                await f.write(content)
+        except Exception:
+            logger.opt(exception=True).error(f"Failed to save {kind} to: {save_path}")
+
+    async def _save_json(self, filename: str, build_data: Callable[[], dict], kind: str) -> None:
+        await self._save_text(filename, lambda: json.dumps(build_data(), indent=2), kind)
+
     async def save_html(
         self,
         messages: list[dict],
@@ -69,44 +81,28 @@ class Recorder:
         coord_space_width: int | None = None,
         coord_space_height: int | None = None,
     ) -> None:
-        save_path = osp.join(self.item_dir, "visualization.html")
-        try:
+        def build_html() -> str:
             kwargs = {"task_id": self.task_id, "messages": messages, "result": result}
             if coord_space_width is not None:
                 kwargs["coord_space_width"] = coord_space_width
             if coord_space_height is not None:
                 kwargs["coord_space_height"] = coord_space_height
-            html_content = generate_visualization_html(**kwargs)
-            async with aiofiles.open(save_path, "w") as f:
-                await f.write(html_content)
-        except Exception:
-            logger.opt(exception=True).error(f"Failed to save HTML visualization to: {save_path}")
+            return generate_visualization_html(**kwargs)
+
+        await self._save_text("visualization.html", build_html, "HTML visualization")
 
     async def save_messages(self, messages: list[dict]) -> None:
-        save_path = osp.join(self.item_dir, "messages.jsonl")
-        try:
+        def serialize(obj):
+            if hasattr(obj, "model_dump"):
+                return obj.model_dump()
+            elif hasattr(obj, "__dict__"):
+                return obj.__dict__
+            return str(obj)
 
-            def serialize(obj):
-                if hasattr(obj, "model_dump"):
-                    return obj.model_dump()
-                elif hasattr(obj, "__dict__"):
-                    return obj.__dict__
-                return str(obj)
+        def build_content() -> str:
+            return "\n".join(json.dumps(message, default=serialize) for message in messages)
 
-            async with aiofiles.open(save_path, "w") as f:
-                lines = [json.dumps(message, default=serialize) for message in messages]
-                await f.write("\n".join(lines))
-        except Exception:
-            logger.opt(exception=True).error(f"Failed to save messages to: {save_path}")
-
-    async def _save_json(self, filename: str, build_data: Callable[[], dict], kind: str) -> None:
-        save_path = osp.join(self.item_dir, filename)
-        try:
-            data = build_data()
-            async with aiofiles.open(save_path, "w") as f:
-                await f.write(json.dumps(data, indent=2))
-        except Exception:
-            logger.opt(exception=True).error(f"Failed to save {kind} to: {save_path}")
+        await self._save_text("messages.jsonl", build_content, "messages")
 
     async def _load_json(self, filename: str, deserialize: Callable[[dict], T], kind: str) -> T | None:
         load_path = osp.join(self.item_dir, filename)


### PR DESCRIPTION
## What

`evaluation/recorder.py` had four methods (`save_html`, `save_messages`, `_save_json`, plus its three callers `save_result` / `save_usage` / `save_timing` that go through `_save_json`) repeating the same "build a path under `self.item_dir`, write a string asynchronously, log a kind-tagged error on any exception" pattern.

Pulled the shared part out into one helper:

```python
async def _save_text(self, filename, build_content, kind):
    save_path = osp.join(self.item_dir, filename)
    try:
        content = build_content()
        async with aiofiles.open(save_path, "w") as f:
            await f.write(content)
    except Exception:
        logger.opt(exception=True).error(f"Failed to save {kind} to: {save_path}")
```

`_save_json` is now a one-liner over `_save_text`, and `save_html` / `save_messages` build their content via inner closures and delegate. The async `_load_json` (separate read path) is left alone.

## Why

Three nearly-identical `try: aiofiles.open; await f.write(...); except: logger.opt(exception=True).error(f"Failed to save {kind} to: {save_path}")` blocks is exactly the shape of bug where one of them quietly drifts — different log wording, different exception handling, a missing try block on a future fifth method. Centralizing it makes the intent ("best-effort artifact write, log on failure") explicit in one place.

It also tightens the existing `_save_json` helper: the `data = build_data()` two-step is no longer needed because both calls now happen inside `build_content()` under the same try block.

## Why it's safe (no behavior change)

- **Error log strings unchanged.** Every site that used to log `f"Failed to save HTML visualization to: {save_path}"` / `"...messages..."` / `"...{kind}..."` now goes through `f"Failed to save {kind} to: {save_path}"` with `kind="HTML visualization"` / `"messages"` / passthrough — same final strings.
- **Same exception coverage.** `build_content()` is called inside the helper's `try`, so every exception that was previously swallowed (model_dump, json.dumps, generate_visualization_html, file open, file write) is still swallowed. `save_messages`'s inner `serialize` function is now defined outside the try block, but `def` itself never raises — only invoking `serialize` does, and that still happens inside `build_content()` under the helper's try.
- **`_save_json` semantics preserved.** Wrapped as `lambda: json.dumps(build_data(), indent=2)`; `build_data()` and `json.dumps` both run inside `_save_text`'s try block, just like before.
- **No call sites change.** All public methods (`save_html`, `save_messages`, `save_result`, `save_usage`, `save_timing`, plus the loaders) keep the same signatures and return types.

## Test plan

- [x] `python -c "import ast; ast.parse(open('evaluation/recorder.py').read())"` — syntax OK
- [x] Manually traced every public method's error message and exception-coverage path
- [x] Diff is single-file and reviewable on its own

---
_Generated by [Claude Code](https://claude.ai/code/session_017xyP4iVF92xS1PvZa654qd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that consolidates repeated async file-write and error-logging logic; main risk is unintended changes to exception coverage or log messages on save failures.
> 
> **Overview**
> Refactors `evaluation/recorder.py` to extract shared async file-write logic into a new `_save_text()` helper that handles path construction, writing, and best-effort error logging.
> 
> `save_html` and `save_messages` now build their content via small closures and delegate to `_save_text`, and `_save_json` becomes a one-liner wrapper over `_save_text` to standardize JSON serialization + write behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c016d811a648a806a7d90085ecce4ffa90482c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->