### PR TITLE
fix(resy): use strip_url_scheme instead of buggy lstrip chain

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -13,7 +13,7 @@ from loguru import logger
 from playwright.async_api import Page
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path, strip_url_scheme
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -276,7 +276,7 @@ class ResyUrlMatch(BaseMetric):
 
         # Basic normalization
         normalized = url.lower().strip()
-        normalized = normalized.lstrip("http://").lstrip("https://").lstrip("www.")
+        normalized = strip_url_scheme(normalized)
 
         # Parse URL components
         parsed = urlparse("http://" + normalized)


### PR DESCRIPTION
## Summary

- Fix the same `lstrip` misuse bug that was fixed for apartments in [#29](https://github.com/yutori-ai/navi-bench/pull/29) — the resy URL match file was missed in that PR
- Replace the buggy `.lstrip(\"http://\").lstrip(\"https://\").lstrip(\"www.\")` chain with the existing `strip_url_scheme()` helper from `navi_bench.base`
- `lstrip(chars)` treats its argument as a set of characters, not a prefix, so it can corrupt URLs whose hostname starts with `h/t/p/:/`

cc @dhruvbatra (authored the original fix in #29), @vamsi-aribandi

## Test plan
- [ ] Reuses the existing `strip_url_scheme` helper already validated in #29
- [ ] Identical output for all well-formed URLs
- [ ] No other `lstrip(\"http` instances remain in the codebase (verified via grep)

https://claude.ai/code/session_01SJ9FBWZXz9J9Vx4xhZXiNw"

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJ9FBWZXz9J9Vx4xhZXiNw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small refactor to URL normalization that replaces an incorrect `lstrip`-based scheme removal with a shared helper, reducing the chance of corrupting hostnames during comparison.
> 
> **Overview**
> Fixes Resy URL normalization by replacing the buggy chained `.lstrip("http://").lstrip("https://").lstrip("www.")` logic with the shared `strip_url_scheme()` helper.
> 
> This ensures scheme/`www` stripping is prefix-based (not character-set based), preventing malformed normalized URLs and improving URL match accuracy in `ResyUrlMatch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18a81e30300ec45db6bcfd22a0640885f3fadc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->