### PR TITLE
refactor(base): tighten async_retry_with_exponential_backoff

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -158,49 +158,33 @@ def async_retry_with_exponential_backoff(
 
     def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
         async def wrapper(*args: Any, **kwargs: Any) -> T:
-            # Initialize variables
             num_retries = 0
             current_delay = delay
 
-            # Loop until a successful response or max_retries is hit or an exception is raised
             while True:
                 try:
                     result = await func(*args, **kwargs)
 
-                    if should_retry_fn is None:
+                    if should_retry_fn is None or not should_retry_fn(result):
                         return result
 
-                    if should_retry_fn(result):
-                        num_retries += 1
-                        if num_retries > max_retries:
-                            return result
-                        current_delay *= exponential_base * (1 + jitter * random.random())
-                        await asyncio.sleep(current_delay)
-                        continue
-                    else:
-                        return result
-
-                # Retry on specified errors
-                except allowed_exceptions as e:
-                    # Increment retries
+                    # should_retry_fn signaled a soft retry; on exhaustion return the
+                    # last result rather than raising.
                     num_retries += 1
+                    if num_retries > max_retries:
+                        return result
+                    current_delay *= exponential_base * (1 + jitter * random.random())
+                    await asyncio.sleep(current_delay)
 
-                    # Check if max retries has been reached
+                except allowed_exceptions as e:
+                    num_retries += 1
                     if num_retries > max_retries:
                         raise Exception(f"Maximum number of retries ({max_retries}) exceeded.") from e
-
-                    # Increment the delay
                     current_delay *= exponential_base * (1 + jitter * random.random())
-
                     logger.info(
                         f"Failed to call {func.__name__}. Retrying in {current_delay} seconds. Error: {repr(e)}"
                     )
-                    # Sleep for the delay
                     await asyncio.sleep(current_delay)
-
-                # Raise exceptions for any errors not specified
-                except Exception as e:
-                    raise e
 
         return wrapper
 


### PR DESCRIPTION
## Summary

Three structural improvements to `async_retry_with_exponential_backoff` in `navi_bench/base.py`. No behavior change.

1. **Drop dead `except Exception as e: raise e` block.** With the default `allowed_exceptions=(Exception,)` it is unreachable, and with a narrower tuple any non-matched exception propagates naturally — the explicit re-raise was a no-op.
2. **Collapse the nested success-path branches.** The two-step `if should_retry_fn is None: return; if should_retry_fn(result): ...; else: return` becomes a single `if should_retry_fn is None or not should_retry_fn(result): return`, with the soft-retry path falling through to the end of the loop body. The explicit `continue` is no longer needed.
3. **Remove low-signal comments** that just restated the next line of code (`# Initialize variables`, `# Increment retries`, etc.).

## Why it's safe

- `should_retry_fn(result)` is still invoked **inside** the try block, so if the predicate itself raises an `allowed_exception` it still triggers a retry (preserved behavior, see test 7 below).
- Exception-path exhaustion still raises `Exception("Maximum number of retries (N) exceeded.") from e`.
- `should_retry_fn`-path exhaustion still returns the last result (no raise).
- The function is widely consumed across `yutori-ai/yutori`; signature, exception types, and retry/backoff semantics are all unchanged.

I verified parity by running the original and refactored implementations side-by-side on:
- success on first try
- retry-then-success (raises ValueError twice, succeeds third)
- exhausted retries (wrapped `Exception` with `__cause__` set)
- non-`allowed_exceptions` propagating untouched
- `should_retry_fn` returning True until exhaustion (returns last result)
- `should_retry_fn` returning False on first call
- `should_retry_fn` itself raising an `allowed_exception` (retried)

All seven scenarios produce identical results between the two implementations.

## Test plan

- [x] Behavior parity script run locally (7/7 cases match)
- [ ] CI passes

https://claude.ai/code/session_0181p9fQDnYBXpRtsfzuYXH9

---
_Generated by [Claude Code](https://claude.ai/code/session_0181p9fQDnYBXpRtsfzuYXH9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to retry helper control flow and comment cleanup, intended to preserve retry/backoff behavior. Main risk is subtle behavioral drift in `should_retry_fn` or exception handling edge cases.
> 
> **Overview**
> Refactors `async_retry_with_exponential_backoff` in `navi_bench/base.py` to simplify the success/soft-retry path by collapsing `should_retry_fn` branching into a single early-return condition and letting the retry path fall through without an explicit `continue`.
> 
> Removes redundant inline comments and drops an unnecessary catch-all `except Exception: raise` block, keeping the existing retry/backoff behavior for `allowed_exceptions` and returning the last result when `should_retry_fn` keeps requesting retries past `max_retries`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5f41f7cd0e55989dc1f6b8cd4a477c6956ee8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->