### PR TITLE
fix: lstrip bug in resy, classmethod param, mutable default

### DIFF
--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -110,7 +110,7 @@ class GoogleFlightsSearchMatch(BaseMetric):
         return flight_info
 
     @classmethod
-    def _create_base_info(self, gt_info: dict) -> Info:
+    def _create_base_info(cls, gt_info: dict) -> Info:
         info = Info()
 
         for segment in gt_info["segments"]:
@@ -208,9 +208,10 @@ def generate_task_config(
     timezone: str,
     timestamp: int | None = None,
     url: str = "https://www.google.com/travel/flights",
-    gt_info: list[dict] = [],
+    gt_info: list[dict] | None = None,
     values: dict | None = None,
 ) -> BaseTaskConfig:
+    gt_info = gt_info or []
     values = values or {}
     user_metadata = initialize_user_metadata(timezone, location, timestamp)
     resolved_placeholders, _ = initialize_placeholder_map(user_metadata, values)

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -13,7 +13,7 @@ from loguru import logger
 from playwright.async_api import Page
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path, strip_url_scheme
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -276,7 +276,7 @@ class ResyUrlMatch(BaseMetric):
 
         # Basic normalization
         normalized = url.lower().strip()
-        normalized = normalized.lstrip("http://").lstrip("https://").lstrip("www.")
+        normalized = strip_url_scheme(normalized)
 
         # Parse URL components
         parsed = urlparse("http://" + normalized)


### PR DESCRIPTION
## Summary\n\n- **Fix `lstrip` misuse in resy URL normalization**: `str.lstrip()` strips a *character set*, not a prefix — `\"https://resy.com\".lstrip(\"https://\")` strips all chars in `{h,t,p,s,:,/}` from the left, corrupting URLs. Replaced with `strip_url_scheme()` from `base.py`, matching the fix already applied to `apartments_url_match.py` in commit 625caa8.\n- **Fix `@classmethod` with `self` parameter** in `google_flights_search_match.py`: `_create_base_info` is decorated `@classmethod` but used `self` as the first param. Changed to `cls`.\n- **Fix mutable default argument** in `google_flights_search_match.py`: `gt_info: list[dict] = []` → `gt_info: list[dict] | None = None` with `gt_info = gt_info or []` in the body, following the same pattern already used for the `values` parameter in the same function.\n\ncc @dhruvbatra (recent refactor work on base.py)\n\n## Test plan\n\n- [ ] Resy URL normalization correctly strips `http://`, `https://`, and `www.` prefixes without corrupting the rest of the URL\n- [ ] `_create_base_info` still works as a classmethod\n- [ ] `generate_task_config` handles `gt_info=None` and explicit list inputs correctly\n\nhttps://claude.ai/code/session_01UZ8sT9MiG6rbw3T2rgyc7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ8sT9MiG6rbw3T2rgyc7p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized fixes to URL normalization and task-config helpers; behavior changes are limited to comparison/initialization edge cases.
> 
> **Overview**
> Fixes a Resy URL normalization bug by replacing incorrect `lstrip("http://")`/`lstrip("https://")` usage with the shared `strip_url_scheme()` helper, preventing corrupted host/path comparisons.
> 
> Cleans up Google Flights evaluator helpers by correcting the `@classmethod` parameter name (`self`→`cls`) and removing a mutable default (`gt_info=[]`) in `generate_task_config`, initializing `gt_info` safely inside the function.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee4353ad3c85723f3cdb012d001fd03a739042c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->