### PR TITLE
refactor(eval_n1): merge duplicate retry/except branches in _predict

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -335,20 +335,10 @@ Today is: {dt.strftime("%A")}"""
 
             except OpenAIAuthError:
                 raise
-            except RETRYABLE_API_ERRORS:
-                if attempt == max_attempts:
-                    logger.opt(exception=True).error(
-                        f"[{step_idx}] Failed to get valid response: {content=}. No more attempts."
-                    )
+            except Exception as e:
+                # Non-retryable APIStatusError subclasses (e.g. BadRequestError) should propagate.
+                if isinstance(e, APIStatusError) and not isinstance(e, RETRYABLE_API_ERRORS):
                     raise
-                logger.opt(exception=True).warning(
-                    f"[{step_idx}] Failed to get valid response: {content=}. Retrying in {delay:.2f}s..."
-                )
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, max_delay)
-            except APIStatusError:
-                raise
-            except Exception:
                 if attempt == max_attempts:
                     logger.opt(exception=True).error(
                         f"[{step_idx}] Failed to get valid response: {content=}. No more attempts."


### PR DESCRIPTION
## Structural issue

In `evaluation/eval_n1.py::_predict`, the inner retry loop had two `except` branches with **byte-identical bodies**:

```python
except RETRYABLE_API_ERRORS:
    if attempt == max_attempts:
        logger.opt(exception=True).error(...)
        raise
    logger.opt(exception=True).warning(...)
    await asyncio.sleep(delay)
    delay = min(delay * 2, max_delay)
except APIStatusError:
    raise
except Exception:
    if attempt == max_attempts:
        logger.opt(exception=True).error(...)   # identical
        raise
    logger.opt(exception=True).warning(...)     # identical
    await asyncio.sleep(delay)                   # identical
    delay = min(delay * 2, max_delay)            # identical
```

The two retry blocks differ only in which exceptions reach them; the handler logic is the same.

## Refactor

Collapse both retry branches into one `except Exception` and keep the "raise non-retryable APIStatusError" decision as a single `isinstance` guard:

```python
except OpenAIAuthError:
    raise
except Exception as e:
    if isinstance(e, APIStatusError) and not isinstance(e, RETRYABLE_API_ERRORS):
        raise
    # ... shared retry-with-backoff body ...
```

## Why this is safe

Behavior is preserved exactly:

| Exception | Original path | New path |
|---|---|---|
| `OpenAIAuthError` | raised by 1st except | raised by 1st except (unchanged) |
| Inside `RETRYABLE_API_ERRORS` (`APIConnectionError`, `APITimeoutError`, `RateLimitError`, `InternalServerError`) | matched by 2nd except → retry | matched by `Exception`, isinstance guard fails (it _is_ retryable) → retry |
| `APIStatusError` not in `RETRYABLE_API_ERRORS` (e.g. `BadRequestError`) | matched by 4th except → raise | matched by `Exception`, isinstance guard succeeds → raise |
| Anything else | matched by 5th except → retry | matched by `Exception`, isinstance guard fails → retry |

`RETRYABLE_API_ERRORS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)` — all four are valid in `isinstance`.

## Diff

`evaluation/eval_n1.py` — 3 insertions, 13 deletions.

---
_Generated by [Claude Code](https://claude.ai/code/session_019iubieU61aJ2fyn7SMhEaR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only restructures exception handling in `evaluation/eval_n1.py::_predict` to remove duplicate retry logic; behavior should remain the same aside from potential edge cases in exception type matching.
> 
> **Overview**
> Refactors `evaluation/eval_n1.py::_predict` to **collapse duplicated retry/backoff `except` blocks** into a single `except Exception` handler.
> 
> Non-retryable `APIStatusError` subclasses (e.g. `BadRequestError`) are now explicitly re-raised via an `isinstance` guard, while retryable API errors and other exceptions continue to use the same retry-with-exponential-backoff flow and final-attempt error logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73917da9b57ae5d85f0257eee2f4fc5679fc2c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->