### PR TITLE
refactor(relative_dates): extract _year_shift_for_modifier helper

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -160,18 +160,26 @@ def _normalize_modifier(mod: str | None) -> str:
 # ----------------------------------
 # Core selection logic
 # ----------------------------------
-def _choose_occurrence(target_this_year: date, base: date, modifier: str) -> date:
+def _year_shift_for_modifier(target_this_year: date, base: date, modifier: str) -> int:
+    """Year offset (-1, 0, or +1) needed so ``target_this_year`` becomes the occurrence
+    requested by ``modifier`` (``this`` / ``next`` / ``coming`` / ``upcoming`` /
+    ``last`` / ``previous``, or empty for the default upcoming/on-or-after behavior)."""
     modifier = _normalize_modifier(modifier)
     if modifier in ("next", "coming"):
-        return target_this_year if target_this_year > base else target_this_year.replace(year=target_this_year.year + 1)
+        return 0 if target_this_year > base else 1
     if modifier == "this":
-        return (
-            target_this_year if target_this_year >= base else target_this_year.replace(year=target_this_year.year + 1)
-        )
+        return 0 if target_this_year >= base else 1
     if modifier in ("last", "previous"):
-        return target_this_year if target_this_year < base else target_this_year.replace(year=target_this_year.year - 1)
+        return 0 if target_this_year < base else -1
     # default: upcoming/on-or-after
-    return target_this_year if target_this_year >= base else target_this_year.replace(year=target_this_year.year + 1)
+    return 0 if target_this_year >= base else 1
+
+
+def _choose_occurrence(target_this_year: date, base: date, modifier: str) -> date:
+    shift = _year_shift_for_modifier(target_this_year, base, modifier)
+    if shift == 0:
+        return target_this_year
+    return target_this_year.replace(year=target_this_year.year + shift)
 
 
 # ----------------------------------
@@ -357,16 +365,8 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
                 resolver = HOLIDAYS[key]  # function(year) -> date
                 y = base.year
                 d_this = resolver(y)
-
-                if modifier in ("next", "coming"):
-                    out = d_this if d_this > base else resolver(y + 1)
-                elif modifier == "this":
-                    out = d_this if d_this >= base else resolver(y + 1)
-                elif modifier in ("last", "previous"):
-                    out = d_this if d_this < base else resolver(y - 1)
-                else:  # no modifier -> upcoming/on-or-after
-                    out = d_this if d_this >= base else resolver(y + 1)
-
+                shift = _year_shift_for_modifier(d_this, base, modifier)
+                out = d_this if shift == 0 else resolver(y + shift)
                 return out.isoformat() if return_iso else out
     raise ValueError(f"Could not parse relative date description: '{text}'")
 
@@ -398,14 +398,7 @@ def _month_ref_to_year_month(text: str, base: date) -> tuple[int, int]:
         mod = _normalize_modifier(m.group(1))
         mm = MONTHS[m.group(2)]
         this = date(base.year, mm, 15)
-        if mod in ("next", "coming"):
-            return (this.year, mm) if this > base else (this.year + 1, mm)
-        if mod == "this":
-            return (this.year, mm) if this >= base else (this.year + 1, mm)
-        if mod in ("last", "previous"):
-            return (this.year, mm) if this < base else (this.year - 1, mm)
-        # no modifier → upcoming/on-or-after
-        return (this.year, mm) if this >= base else (this.year + 1, mm)
+        return this.year + _year_shift_for_modifier(this, base, mod), mm
 
     raise ValueError(f"Could not resolve month reference: '{text}'")
 


### PR DESCRIPTION
## What

The "this/next/coming/upcoming/last/previous" → year-offset logic was written out three times in `navi_bench/relative_dates.py`:

1. `_choose_occurrence` — returns a `date` adjusted via `target.replace(year=...)`.
2. The holiday block inside `parse_relative_date` — calls `resolver(y ± 1)` because computed holidays (Easter, Memorial Day, etc.) don't move with `date.replace`.
3. `_month_ref_to_year_month`'s explicit-month branch — returns a `(year, month)` tuple.

All three encode the same four-branch decision (`next`/`coming` → strictly future, `this` → on-or-after, `last`/`previous` → strictly past, no modifier → on-or-after).

This PR pulls that decision into a single `_year_shift_for_modifier(target_this_year, base, modifier) -> int` returning `-1`, `0`, or `+1`. The three call sites delegate to it, so the modifier semantics live in one place. Net: 18 added, 25 removed.

## Why it's safe

- Pure extraction — no behavioral change.
- The `__main__` example block produces byte-for-byte identical output (verified by diff against `main`).
- Spot-checked edge cases: each modifier at the boundary date (target equal to / one day before / one day after `base`), `upcoming` aliasing to `next`, the no-modifier default, and holidays whose date varies year-to-year (Easter, Thanksgiving).

## Why it's an improvement

The modifier semantics now exist in exactly one place, so a future change to (say) how `this` handles equality only needs to be made once, instead of being kept in sync across three structurally-different return shapes (`date`, `(int, int)`, `resolver(y+k)`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJ2K2gYyr4WmFNqRPoSbDK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes repeated year-selection logic for modifiers; main risk is subtle off-by-one behavior changes around boundary dates, but the change is a straightforward extraction.
> 
> **Overview**
> Refactors `navi_bench/relative_dates.py` to centralize the *modifier* (e.g. `this`/`next`/`coming`/`last`) year-selection rules into a new `_year_shift_for_modifier(...) -> int` helper.
> 
> Updates `_choose_occurrence`, holiday resolution in `parse_relative_date`, and the explicit-month branch of `_month_ref_to_year_month` to use the shared year-shift result instead of duplicating the branching logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b82a93de51462cd64374130dd53032ffb84d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->