### PR TITLE
refactor(dates): reuse clamp_day from relative_dates

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -1,12 +1,11 @@
 """Unified utilities for parsing and evaluating dynamic date expressions."""
 
-import calendar
 import re
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from navi_bench.base import UserMetadata
-from navi_bench.relative_dates import parse_relative_dates
+from navi_bench.relative_dates import clamp_day, parse_relative_dates
 
 
 _MONTH_STYLE_OPTIONS = {"short", "long"}
@@ -209,15 +208,11 @@ def initialize_placeholder_map(
             normalized = []
             for d_str in iso_dates:
                 d = date.fromisoformat(d_str)
-                clamped_day = min(d.day, calendar.monthrange(base_date.year, d.month)[1])
-                normalized.append(date(base_date.year, d.month, clamped_day))
+                normalized.append(clamp_day(base_date.year, d.month, d.day))
 
             if normalized and min(normalized) <= base_date:
                 next_year = base_date.year + 1
-                bumped = []
-                for d in normalized:
-                    clamped_day = min(d.day, calendar.monthrange(next_year, d.month)[1])
-                    bumped.append(date(next_year, d.month, clamped_day))
+                bumped = [clamp_day(next_year, d.month, d.day) for d in normalized]
                 iso_dates = [d.isoformat() for d in bumped]
                 resolved_desc = f"{resolved_desc}, {next_year}"
             else:


### PR DESCRIPTION
## Summary

`initialize_placeholder_map` in `dates.py` had two inline copies of the day-clamping logic:

```python
clamped_day = min(d.day, calendar.monthrange(year, d.month)[1])
normalized.append(date(year, d.month, clamped_day))
```

`relative_dates.py` already exports a `clamp_day(y, m, day) -> date` helper that does exactly this. Replacing the two inline calculations with `clamp_day` calls:

- removes the awkward two-line pattern
- drops the now-unused `import calendar` from `dates.py`
- collapses the second loop into a one-line list comprehension

## Why it's safe

- `clamp_day` is a pure helper imported elsewhere in the package; the new call sites pass the same `(year, month, day)` triple the inline code constructed.
- No public API changes — only internal logic in `initialize_placeholder_map`.
- Smoke-tested locally with `next Friday`, `December 25`, `this Saturday`, and `in 2 weeks` against `initialize_placeholder_map`; all produce identical output to `main`.

## Test plan

- [x] Spot-check that `clamp_day` returns identical values for the boundary cases the inline code handled (e.g. Feb 31 → Feb 28/29, Apr 31 → Apr 30).
- [x] `python -c "from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata"` succeeds.
- [ ] CI passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_018NqW7YgXD1KCFTeVemVQox)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes day-clamping logic; behavior should remain the same but affects date normalization for string-parsed placeholders (including year bumping) in `initialize_placeholder_map`.
> 
> **Overview**
> Refactors `initialize_placeholder_map` in `dates.py` to reuse the shared `clamp_day` helper from `relative_dates.py` when normalizing string-parsed ISO dates and when bumping them to the next year.
> 
> This removes duplicated `calendar.monthrange` clamping logic (and the `calendar` import) and simplifies the year-bump loop into a list comprehension, without changing placeholder behavior for dynamic expressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba8faf86dc0928ce97a5041f94fe26b5dba02cac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->