### PR TITLE
refactor(resy_url_match): use shared strip_url_scheme helper

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -13,7 +13,7 @@ from loguru import logger
 from playwright.async_api import Page
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path, strip_url_scheme
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -276,7 +276,7 @@ class ResyUrlMatch(BaseMetric):
 
         # Basic normalization
         normalized = url.lower().strip()
-        normalized = normalized.lstrip("http://").lstrip("https://").lstrip("www.")
+        normalized = strip_url_scheme(normalized)
 
         # Parse URL components
         parsed = urlparse("http://" + normalized)


### PR DESCRIPTION
## Summary

`ResyUrlMatch._normalize_url` still had the same buggy
`.lstrip("http://").lstrip("https://").lstrip("www.")` chain that PR #29 fixed
in `ApartmentsUrlMatch._normalize_url`. `str.lstrip(chars)` treats its argument
as a *character set*, not a prefix — the chain happens to produce the right
result for well-formed URLs but corrupts hostnames whose leading characters
fall in `{h,t,p,s,:,/,w,.}` (e.g. `tap.com/...` would become `ap.com/...`).

PR #29 introduced `strip_url_scheme()` in `navi_bench/base.py` and migrated the
apartments caller; its commit message explicitly noted that "callers in
apartments/resy URL match can switch off the buggy lstrip chain", but only the
apartments caller was migrated. This finishes that migration: ResyUrlMatch now
delegates to the same shared helper.

## Why it's safe

- **No behavioral change for the URLs the tests exercise.** `resy.com` (and
  every other tested host) does not start with characters that the lstrip
  bug would clip, so output is identical for well-formed inputs.
- **Same pattern already shipped.** This is a copy of the apartments fix
  applied to the resy caller — easy to verify from the diff alone.
- **One file, two-line change.**

## Test plan

- [x] `rg "lstrip\(\"http"` confirms the buggy pattern is gone from `navi_bench/`.
- [ ] Existing eval suites for resy URL matching continue to pass (no change
      expected for well-formed URLs).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F7p8tQNdHrGxEHiqZWRmZL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes URL normalization by replacing a buggy `lstrip`-based scheme/`www` removal with the shared `strip_url_scheme` helper; behavior should match for well-formed URLs while preventing hostname corruption in edge cases.
> 
> **Overview**
> Updates `ResyUrlMatch._normalize_url` to use the shared `strip_url_scheme` helper (imported from `navi_bench.base`) instead of the local chained `str.lstrip("http://")/"https://"/"www."` logic.
> 
> This removes the subtle `lstrip` charset bug during scheme/`www` stripping and aligns Resy URL normalization with the already-shipped helper used elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 034cb07ecfb2aafd4f0bcd1483ae10e5504d7012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->