### PR TITLE
fix(google_flights): correct classmethod param and mutable default arg

### DIFF
--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -110,7 +110,7 @@ class GoogleFlightsSearchMatch(BaseMetric):
         return flight_info
 
     @classmethod
-    def _create_base_info(self, gt_info: dict) -> Info:
+    def _create_base_info(cls, gt_info: dict) -> Info:
         info = Info()
 
         for segment in gt_info["segments"]:
@@ -208,9 +208,10 @@ def generate_task_config(
     timezone: str,
     timestamp: int | None = None,
     url: str = "https://www.google.com/travel/flights",
-    gt_info: list[dict] = [],
+    gt_info: list[dict] | None = None,
     values: dict | None = None,
 ) -> BaseTaskConfig:
+    gt_info = gt_info or []
     values = values or {}
     user_metadata = initialize_user_metadata(timezone, location, timestamp)
     resolved_placeholders, _ = initialize_placeholder_map(user_metadata, values)


### PR DESCRIPTION
## Summary

Daily code cleanup found two latent issues in `google_flights_search_match.py` that were introduced in the original file and missed by recent refactoring passes:

- **`@classmethod` with `self` instead of `cls`**: `_create_base_info` is decorated as a classmethod but its first parameter was named `self`. Renamed to `cls` to match Python convention. No behavioral change — the parameter was never referenced inside the method body.

- **Mutable default argument `gt_info: list[dict] = []`**: `generate_task_config` used a mutable default which is shared across all calls. Replaced with `None` + guard (`gt_info = gt_info or []`), matching the existing pattern already used for the `values` parameter on the next line.

## Context

These issues were spotted on a branch (bee4353) but never merged to main. The recent refactoring wave (#35–#38) by @dhruvbatra touched adjacent code but didn't address these.

## Owners

cc @dhruvbatra (recent refactoring maintainer), @Cysu (original google_flights author)

## Test plan

- [x] `python -m py_compile` passes
- [ ] Existing tests pass (no behavioral change — classmethod rename is cosmetic; mutable default had no callers that relied on shared state)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJtEjMHmSBYy8WRyvt7kiz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are localized and primarily prevent a potential shared-state bug from the mutable default `gt_info` argument, with no expected behavioral impact for normal callers.
> 
> **Overview**
> Fixes two small correctness issues in `google_flights_search_match.py`: `_create_base_info` now uses `cls` as the `@classmethod` first parameter, and `generate_task_config` replaces the mutable default `gt_info=[]` with `None` plus a guard (`gt_info = gt_info or []`) to avoid cross-call state leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f76013d6f97781e388b8d75373d49c5cc8adf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->