### PR TITLE
refactor(dates): extract shared option-validation helper

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -89,6 +89,21 @@ def _parse_dynamic_options(raw: str | None) -> dict[str, str]:
     return options
 
 
+def _get_validated_option(
+    options: dict[str, str],
+    key: str,
+    default: str,
+    allowed: set[str],
+    *,
+    label: str | None = None,
+) -> str:
+    """Look up a dynamic-placeholder option and validate it against ``allowed``."""
+    value = options.get(key, default)
+    if value not in allowed:
+        raise ValueError(f"{label or key} must be one of: " + ", ".join(allowed))
+    return value
+
+
 def resolve_placeholder_values(
     text: str,
     base_date: date,
@@ -117,13 +132,10 @@ def resolve_placeholder_values(
             raise ValueError("timedelta end offset cannot be smaller than the start offset")
 
         options = _parse_dynamic_options(match.group("options"))
-        month_style = options.get("month", "short")
-        if month_style not in _MONTH_STYLE_OPTIONS:
-            raise ValueError("month style must be one of: " + ", ".join(_MONTH_STYLE_OPTIONS))
-
-        range_mode = options.get("range", "all")
-        if range_mode not in _RANGE_OPTIONS:
-            raise ValueError("range must be one of: " + ", ".join(_RANGE_OPTIONS))
+        month_style = _get_validated_option(
+            options, "month", "short", _MONTH_STYLE_OPTIONS, label="month style"
+        )
+        range_mode = _get_validated_option(options, "range", "all", _RANGE_OPTIONS)
 
         offsets = range(start, end + 1)
         start_date = base_date + timedelta(days=start)
@@ -134,13 +146,8 @@ def resolve_placeholder_values(
         else:
             iso_dates = [(base_date + timedelta(days=offset)).isoformat() for offset in offsets]
 
-        year_style = options.get("year", "none")
-        if year_style not in _YEAR_OPTIONS:
-            raise ValueError("year must be one of: " + ", ".join(_YEAR_OPTIONS))
-
-        prefix_mode = options.get("prefix", "auto")
-        if prefix_mode not in _PREFIX_OPTIONS:
-            raise ValueError("prefix must be one of: " + ", ".join(_PREFIX_OPTIONS))
+        year_style = _get_validated_option(options, "year", "none", _YEAR_OPTIONS)
+        prefix_mode = _get_validated_option(options, "prefix", "auto", _PREFIX_OPTIONS)
 
         if prefix_mode == "none":
             prefix = ""


### PR DESCRIPTION
## What

Extract the four-times-repeated `options.get(...) -> validate-against-allowed-set -> ValueError` pattern in `navi_bench/dates.py::resolve_placeholder_values` into a single `_get_validated_option` helper.

Before:
```python
month_style = options.get("month", "short")
if month_style not in _MONTH_STYLE_OPTIONS:
    raise ValueError("month style must be one of: " + ", ".join(_MONTH_STYLE_OPTIONS))

range_mode = options.get("range", "all")
if range_mode not in _RANGE_OPTIONS:
    raise ValueError("range must be one of: " + ", ".join(_RANGE_OPTIONS))
# ...same shape for year and prefix
```

After:
```python
month_style = _get_validated_option(
    options, "month", "short", _MONTH_STYLE_OPTIONS, label="month style"
)
range_mode = _get_validated_option(options, "range", "all", _RANGE_OPTIONS)
# ...same one-liner shape for year and prefix
```

## Why

Four near-identical 3-line blocks become four call sites of one helper. Adding a future option becomes a single line instead of three. Centralizing the lookup-then-validate keeps the error-message format consistent.

## Why this is safe

No behavior change:

- Each call passes the same `default` and `allowed` set as before.
- Error messages are byte-for-byte identical: the helper interpolates `{label or key}` (the `month` option keeps its custom `"month style"` label via the new `label` kwarg; the others use `key` directly, which already matched the original wording).
- The set object reused across versions, so `", ".join(allowed)` produces the same iteration order in both.
- Smoke-tested locally: ran every option (defaults and explicit overrides for `month`/`range`/`year`/`prefix`) and every invalid value; output and error messages matched the pre-refactor strings.

Single file, +21/-14 lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJRn6NEmMbzaX2vihdZcVc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to dynamic placeholder option lookup/validation, intended to preserve existing defaults and error messages. Main risk is subtle behavior drift if validation/error formatting differs, but call sites pass the same allowed sets and defaults.
> 
> **Overview**
> Refactors dynamic placeholder option handling in `navi_bench/dates.py` by introducing `_get_validated_option()` and replacing four repeated `options.get(...)` + allowed-set validation blocks in `resolve_placeholder_values()`.
> 
> Behavior is intended to stay the same (same defaults/allowed sets), while centralizing validation and allowing a custom label for the `month` error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c267063e88f2ee98985cb7fa17fc4f2aa5dcba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->