### PR TITLE
refactor(base): extract build_task_config helper for per-domain wrappers

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -7,7 +7,7 @@ from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path, strip_url_scheme
+from navi_bench.base import BaseMetric, BaseTaskConfig, build_task_config, strip_url_scheme
 from navi_bench.dates import initialize_user_metadata
 
 
@@ -271,10 +271,13 @@ def generate_task_config(
     url: str = "https://www.apartments.com",
 ) -> BaseTaskConfig:
     user_metadata = initialize_user_metadata(timezone, location, timestamp)
-
-    eval_target = get_import_path(ApartmentsUrlMatch)
-    eval_config = {"_target_": eval_target, "gt_url": gt_url}
-    return BaseTaskConfig(url=url, task=task, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=task,
+        user_metadata=user_metadata,
+        eval_class=ApartmentsUrlMatch,
+        eval_kwargs={"gt_url": gt_url},
+    )
 
 
 if __name__ == "__main__":

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -204,6 +204,23 @@ class BaseTaskConfig(BaseModel):
     eval_config: dict[str, Any]
 
 
+def build_task_config(
+    *,
+    url: str,
+    task: str,
+    user_metadata: UserMetadata,
+    eval_class: type,
+    eval_kwargs: dict[str, Any] | None = None,
+) -> BaseTaskConfig:
+    """Build a BaseTaskConfig from a metric eval class and its kwargs.
+
+    The `_target_` import path is derived from `eval_class` so per-domain
+    wrappers don't have to repeat the `get_import_path(...)` + dict build.
+    """
+    eval_config = {"_target_": get_import_path(eval_class), **(eval_kwargs or {})}
+    return BaseTaskConfig(url=url, task=task, user_metadata=user_metadata, eval_config=eval_config)
+
+
 class BaseMetric:
     async def update(self, /, **kwargs) -> Any: ...
 

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -5,7 +5,7 @@ from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, build_task_config
 from navi_bench.dates import initialize_user_metadata
 
 
@@ -94,11 +94,13 @@ def generate_task_config(
     timestamp: int | None = None,
 ) -> BaseTaskConfig:
     user_metadata = initialize_user_metadata(timezone, location, timestamp)
-
-    eval_target = get_import_path(CraigslistUrlMatch)
-    eval_config = {"_target_": eval_target, "gt_urls": gt_urls}
-
-    return BaseTaskConfig(url=url, task=task, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=task,
+        user_metadata=user_metadata,
+        eval_class=CraigslistUrlMatch,
+        eval_kwargs={"gt_urls": gt_urls},
+    )
 
 
 if __name__ == "__main__":

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -8,7 +8,7 @@ from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, build_task_config
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 from navi_bench.google_flights.google_flights_pb2 import Info
 
@@ -229,9 +229,13 @@ def generate_task_config(
     resolved_gt_info = resolve_date_references(gt_info, resolved_values)
     rendered_task = render_task_statement(task, resolved_placeholders)
 
-    eval_target = get_import_path(GoogleFlightsSearchMatch)
-    eval_config = {"_target_": eval_target, "gt_info": resolved_gt_info}
-    return BaseTaskConfig(url=url, task=rendered_task, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=rendered_task,
+        user_metadata=user_metadata,
+        eval_class=GoogleFlightsSearchMatch,
+        eval_kwargs={"gt_info": resolved_gt_info},
+    )
 
 
 if __name__ == "__main__":

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -13,7 +13,7 @@ from playwright.async_api import Page
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, build_task_config
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -841,23 +841,24 @@ def generate_task_config_random(
         f"{date_label} ({date_natural}) for {party_size} {'person' if party_size == 1 else 'people'}."
     )
 
-    # Create evaluator queries
-    eval_target = get_import_path(OpenTableInfoGathering)
-    eval_config = {
-        "_target_": eval_target,
-        "queries": [
-            [
-                {
-                    "restaurant_names": [restaurant_name.lower()],
-                    "dates": date_strs,
-                    "times": meal_time_slots,
-                    "party_sizes": [party_size],
-                }
-            ]
-        ],
-    }
-
-    return BaseTaskConfig(url=url, task=task_description, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=task_description,
+        user_metadata=user_metadata,
+        eval_class=OpenTableInfoGathering,
+        eval_kwargs={
+            "queries": [
+                [
+                    {
+                        "restaurant_names": [restaurant_name.lower()],
+                        "dates": date_strs,
+                        "times": meal_time_slots,
+                        "party_sizes": [party_size],
+                    }
+                ]
+            ],
+        },
+    )
 
 
 def _render_placeholders_in_queries_any(
@@ -945,10 +946,13 @@ def generate_task_config_deterministic(
     else:
         raise ValueError(f"Invalid mode: {mode}")
 
-    eval_target = get_import_path(OpenTableInfoGathering)
-    eval_config = {"_target_": eval_target, "queries": queries}
-
-    return BaseTaskConfig(url=url, task=rendered_task, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=rendered_task,
+        user_metadata=user_metadata,
+        eval_class=OpenTableInfoGathering,
+        eval_kwargs={"queries": queries},
+    )
 
 
 if __name__ == "__main__":

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -13,7 +13,7 @@ from loguru import logger
 from playwright.async_api import Page
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path, strip_url_scheme
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, build_task_config, strip_url_scheme
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -1027,11 +1027,13 @@ def generate_task_config_random(
         f"https://resy.com/cities/{city_slug}/venues/{venue_slug}?date={date_str}&seats={party_size}&time={time_hhmm}"
     )
 
-    # Create evaluator config
-    eval_target = get_import_path(ResyUrlMatch)
-    eval_config = {"_target_": eval_target, "queries": [[resy_url]]}
-
-    return BaseTaskConfig(url=url, task=task_description, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=task_description,
+        user_metadata=user_metadata,
+        eval_class=ResyUrlMatch,
+        eval_kwargs={"queries": [[resy_url]]},
+    )
 
 
 def _render_placeholders_in_queries_any(
@@ -1136,10 +1138,13 @@ def generate_task_config_deterministic(
     else:
         raise ValueError(f"Invalid mode: {mode}")
 
-    eval_target = get_import_path(ResyUrlMatch)
-    eval_config = {"_target_": eval_target, "queries": queries}
-
-    return BaseTaskConfig(url=url, task=rendered_task, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=rendered_task,
+        user_metadata=user_metadata,
+        eval_class=ResyUrlMatch,
+        eval_kwargs={"queries": queries},
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Six per-domain `generate_task_config*` functions (apartments, craigslist, google_flights, resy ×2, opentable ×2) ended with the same 3-line idiom: `get_import_path(<MetricClass>)` + `eval_config = {"_target_": ..., **<kwargs>}` + `return BaseTaskConfig(...)`.
- Add `build_task_config(*, url, task, user_metadata, eval_class, eval_kwargs)` in `navi_bench/base.py`. The `_target_` import path is derived from `eval_class` via `get_import_path`, which becomes an implementation detail of the helper.
- Each wrapper now passes the metric class and its kwargs directly to `build_task_config`.

## Why this is safe
- **Dataset rows unchanged.** Serialized `task_generation_config_json` rows reference the per-domain wrapper functions (e.g. `navi_bench.apartments.apartments_url_match.generate_task_config`), not internals. Their public signatures are preserved exactly.
- **Behavior preserved.** `BaseTaskConfig` is built from the same `url`, `task`, `user_metadata`, and the same `_target_` + eval kwargs. Only the construction path changed.
- **Verified by `__main__` smoke tests.** Ran each refactored module's `if __name__ == "__main__"` block locally:
  - `python -m navi_bench.apartments.apartments_url_match` ✅
  - `python -m navi_bench.craigslist.craigslist_url_match` ✅
  - `python -m navi_bench.google_flights.google_flights_search_match` ✅
  - `python -m navi_bench.resy.resy_url_match` ✅
  - `python -m navi_bench.opentable.opentable_info_gathering` ✅
  Each instantiates the eval class from the generated config and prints the same expected output.

## Files touched (6)
- `navi_bench/base.py` — adds `build_task_config`
- `navi_bench/apartments/apartments_url_match.py` — 1 site
- `navi_bench/craigslist/craigslist_url_match.py` — 1 site
- `navi_bench/google_flights/google_flights_search_match.py` — 1 site
- `navi_bench/resy/resy_url_match.py` — 2 sites
- `navi_bench/opentable/opentable_info_gathering.py` — 2 sites

## Test plan
- [x] AST validation on all six modified files
- [x] `__main__` smoke test passes for each refactored module

https://claude.ai/code/session_01RcST3DLYVmfDsV1p3sXNRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcST3DLYVmfDsV1p3sXNRu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes `BaseTaskConfig.eval_config` construction; behavior should remain the same but any mistake would affect task config generation across multiple domains.
> 
> **Overview**
> Introduces `build_task_config` in `navi_bench/base.py` to standardize building `BaseTaskConfig` from an eval class plus kwargs (including auto-populating `_target_` via `get_import_path`).
> 
> Refactors per-domain `generate_task_config*` helpers (Apartments, Craigslist, Google Flights, OpenTable, Resy) to call `build_task_config` instead of manually assembling `eval_config`, removing repeated boilerplate while keeping wrapper signatures intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c466606e0b1471077666d89086dfffac68287ef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->