### PR TITLE
refactor(base): extract basic_normalize_url helper

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -1,13 +1,13 @@
 import json
 import re
 from typing import TypedDict
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode
 
 from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, get_import_path, strip_url_scheme
+from navi_bench.base import BaseMetric, BaseTaskConfig, basic_normalize_url, get_import_path
 from navi_bench.dates import initialize_user_metadata
 
 
@@ -206,23 +206,9 @@ class ApartmentsUrlMatch(BaseMetric):
 
     def _normalize_url(self, url: str) -> str:
         """Normalize URL by treating locations as sets so order doesn't matter."""
-        if not url:
-            return ""
-
-        # Basic normalization
-        normalized = url.lower().strip()
-        normalized = strip_url_scheme(normalized)
-
-        # Parse URL components
-        parsed = urlparse("http://" + normalized)
-
-        # Only apply location normalization for apartments.com
-        if "apartments.com" not in parsed.netloc:
-            # For non-apartments.com URLs, just return basic normalization
-            result = parsed.netloc + parsed.path
-            if parsed.query:
-                result += "?" + parsed.query
-            return result.rstrip("/")
+        parsed, fallback = basic_normalize_url(url, "apartments.com")
+        if parsed is None:
+            return fallback
 
         # Extract locations from both path and query parameters
         path_parts = [part for part in parsed.path.split("/") if part]

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -6,6 +6,7 @@ import types
 from datetime import datetime
 from functools import cached_property
 from typing import Any, Awaitable, Callable, Iterable, Type, TypeVar, Union, get_args, get_origin
+from urllib.parse import ParseResult, urlparse
 
 from datasets import Features, Value
 from loguru import logger
@@ -29,6 +30,31 @@ def strip_url_scheme(url: str) -> str:
     for scheme in ("https://", "http://"):
         url = url.removeprefix(scheme)
     return url.removeprefix("www.")
+
+
+def basic_normalize_url(url: str, target_domain: str) -> tuple[ParseResult | None, str]:
+    """Apply the opening of URL normalization shared across navi-bench domain matchers.
+
+    Lowercases, strips http(s)://www., and runs ``urlparse`` on the result. When the URL's
+    netloc matches ``target_domain``, returns ``(parsed, "")`` so the caller can proceed with
+    its domain-specific normalization. Otherwise returns ``(None, fallback)`` where fallback
+    is a basic-normalized "netloc + path[?query]" string with any trailing slash stripped —
+    this is the form domain matchers return as-is for off-domain URLs.
+
+    Empty input returns ``(None, "")``.
+    """
+    if not url:
+        return None, ""
+
+    normalized = strip_url_scheme(url.lower().strip())
+    parsed = urlparse("http://" + normalized)
+
+    if target_domain not in parsed.netloc:
+        result = parsed.netloc + parsed.path
+        if parsed.query:
+            result += "?" + parsed.query
+        return None, result.rstrip("/")
+    return parsed, ""
 
 
 def omni_import(path: str):

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -13,7 +13,7 @@ from loguru import logger
 from playwright.async_api import Page
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path, strip_url_scheme
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, basic_normalize_url, get_import_path
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -327,23 +327,9 @@ class ResyUrlMatch(BaseMetric):
                               This is used when "no availability" is detected, since the entire day is
                               unavailable regardless of party size or time slot.
         """
-        if not url:
-            return ""
-
-        # Basic normalization
-        normalized = url.lower().strip()
-        normalized = strip_url_scheme(normalized)
-
-        # Parse URL components
-        parsed = urlparse("http://" + normalized)
-
-        # Only apply normalization for resy.com
-        if "resy.com" not in parsed.netloc:
-            # For non-resy.com URLs, just return basic normalization
-            result = parsed.netloc + parsed.path
-            if parsed.query:
-                result += "?" + parsed.query
-            return result.rstrip("/")
+        parsed, fallback = basic_normalize_url(url, "resy.com")
+        if parsed is None:
+            return fallback
 
         # Extract city and venue name from path
         # Expected format: /cities/{city}/venues/{venue}


### PR DESCRIPTION
## Summary

`ApartmentsUrlMatch._normalize_url` (`navi_bench/apartments/apartments_url_match.py`) and `ResyUrlMatch._normalize_url` (`navi_bench/resy/resy_url_match.py`) both opened with the same 13-line preamble:

```python
if not url:
    return ""

# Basic normalization
normalized = url.lower().strip()
normalized = strip_url_scheme(normalized)
parsed = urlparse("http://" + normalized)

# Only apply normalization for <domain>
if "<domain>" not in parsed.netloc:
    result = parsed.netloc + parsed.path
    if parsed.query:
        result += "?" + parsed.query
    return result.rstrip("/")
```

Pull this preamble into `navi_bench.base.basic_normalize_url(url, target_domain)`, which returns either `(None, fallback_str)` for empty/off-domain inputs or `(ParseResult, "")` for on-domain URLs. Both call sites collapse to:

```python
parsed, fallback = basic_normalize_url(url, "<domain>")
if parsed is None:
    return fallback
```

## Why it's safe

- Pure structural refactor; no behavior change. Every branch of the original code (empty, off-domain with query, off-domain with trailing slash, on-domain) is preserved.
- 3 files touched. Net `+35 / -37` LOC.
- The original `urlparse("http://" + normalized)` and `result.rstrip("/")` semantics are kept verbatim — preserving the existing asymmetry that only the off-domain fallback strips a trailing slash.
- Verified by case-by-case equivalence against the original code paths (see commit message).

## Test plan

- [ ] Existing tests / `__main__` example blocks in `apartments_url_match.py` and `resy_url_match.py` still pass
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3w7XM55DQkhqGK1emGQtk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes shared URL pre-normalization logic; main risk is subtle behavior drift in off-domain/empty URL handling for `ApartmentsUrlMatch` and `ResyUrlMatch`.
> 
> **Overview**
> Extracts the common “lowercase/strip scheme + `urlparse` + off-domain fallback string” preamble into `navi_bench.base.basic_normalize_url`.
> 
> Updates `ApartmentsUrlMatch._normalize_url` and `ResyUrlMatch._normalize_url` to call this helper and early-return the computed fallback for empty or off-domain URLs, removing duplicated logic while keeping domain-specific normalization unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef936b021fcd516c37168e12a489786a2cb8c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->