### PR TITLE
refactor(stats): make times_ms the single source of truth in TimingStats

### DIFF
--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from statistics import median
 
 from loguru import logger
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 from tabulate import SEPARATING_LINE, tabulate
 
 from navi_bench.base import DatasetItem
@@ -31,27 +31,43 @@ class Crashed(BaseModel):
 
 
 class TimingStats(BaseModel):
-    call_count: int = 0
-    total_time_ms: float = 0.0
-    min_time_ms: float = float("inf")
-    max_time_ms: float = 0.0
+    """Aggregate timing stats for a sequence of API calls.
+
+    ``times_ms`` is the single source of truth. Aggregate views (``call_count``,
+    ``total_time_ms``, ``min_time_ms``, ``max_time_ms``) are computed from it,
+    so they cannot drift out of sync with the underlying samples and ``add_call``
+    / ``merge`` only need to maintain one field. The aggregates remain part of
+    the serialized schema via ``@computed_field`` so existing ``timing.json``
+    consumers see the same JSON shape.
+    """
+
     times_ms: list[float] = Field(default_factory=list)
 
     def add_call(self, time_ms: float) -> None:
-        self.call_count += 1
-        self.total_time_ms += time_ms
-        self.min_time_ms = min(self.min_time_ms, time_ms)
-        self.max_time_ms = max(self.max_time_ms, time_ms)
         self.times_ms.append(time_ms)
 
     def merge(self, other: "TimingStats") -> "TimingStats":
-        return TimingStats(
-            call_count=self.call_count + other.call_count,
-            total_time_ms=self.total_time_ms + other.total_time_ms,
-            min_time_ms=min(self.min_time_ms, other.min_time_ms),
-            max_time_ms=max(self.max_time_ms, other.max_time_ms),
-            times_ms=self.times_ms + other.times_ms,
-        )
+        return TimingStats(times_ms=self.times_ms + other.times_ms)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def call_count(self) -> int:
+        return len(self.times_ms)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def total_time_ms(self) -> float:
+        return sum(self.times_ms)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def min_time_ms(self) -> float:
+        return min(self.times_ms) if self.times_ms else float("inf")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def max_time_ms(self) -> float:
+        return max(self.times_ms) if self.times_ms else 0.0
 
     @property
     def avg_time_ms(self) -> float:


### PR DESCRIPTION
## Structural issue

`TimingStats` (in `evaluation/stats.py`) tracks five aggregate quantities
that are all derivable from a single underlying list:

```python
class TimingStats(BaseModel):
    call_count: int = 0
    total_time_ms: float = 0.0
    min_time_ms: float = float("inf")
    max_time_ms: float = 0.0
    times_ms: list[float] = Field(default_factory=list)
```

Every mutation has to touch all five fields by hand:

```python
def add_call(self, time_ms: float) -> None:
    self.call_count += 1
    self.total_time_ms += time_ms
    self.min_time_ms = min(self.min_time_ms, time_ms)
    self.max_time_ms = max(self.max_time_ms, time_ms)
    self.times_ms.append(time_ms)

def merge(self, other) -> "TimingStats":
    return TimingStats(
        call_count=self.call_count + other.call_count,
        total_time_ms=self.total_time_ms + other.total_time_ms,
        min_time_ms=min(self.min_time_ms, other.min_time_ms),
        max_time_ms=max(self.max_time_ms, other.max_time_ms),
        times_ms=self.times_ms + other.times_ms,
    )
```

The aggregates are bookkeeping for `times_ms`. Any future code path that
appends to `times_ms` without going through `add_call`/`merge` (e.g.
constructing one from a list literal in tests, or someone adding a new
mutation method) silently produces a `TimingStats` whose aggregates lie
about the underlying data.

## Refactor

Make `times_ms` the only model field; expose `call_count`,
`total_time_ms`, `min_time_ms`, `max_time_ms` as `@computed_field`
properties.

```python
class TimingStats(BaseModel):
    times_ms: list[float] = Field(default_factory=list)

    def add_call(self, time_ms: float) -> None:
        self.times_ms.append(time_ms)

    def merge(self, other: "TimingStats") -> "TimingStats":
        return TimingStats(times_ms=self.times_ms + other.times_ms)

    @computed_field
    @property
    def call_count(self) -> int: ...
    # ... total_time_ms, min_time_ms, max_time_ms similarly
```

`avg_time_ms`, `median_time_ms`, `p95_time_ms` were already plain
`@property`s — left unchanged.

## Why this is safe

- **All five aggregate values produce the same result.** `len`, `sum`,
  `min`, `max` over `times_ms` give exactly what the manually-maintained
  fields gave; the empty-state sentinels (`float("inf")` for min, `0.0`
  for max) are preserved.
- **Public API is unchanged.** `add_call`, `merge`, and every
  attribute access (`call_count`, `total_time_ms`, `min/max/avg/median/p95_time_ms`)
  read identically at every call site. Verified via search:
  - `evaluation/stats.py::show_timing_summary` — uses `call_count`,
    `total_time_ms`, `avg/median/min/max/p95_time_ms`.
  - `evaluation/eval_n1.py` — uses `add_call`, `call_count`,
    `total_time_ms`, `avg/min/max_time_ms`.
  - `evaluation/recorder.py` — round-trips via `model_dump(mode="json")`
    / `model_validate`, no field access.
- **Serialized JSON shape is preserved.** `@computed_field` includes
  `call_count`/`total_time_ms`/`min_time_ms`/`max_time_ms` in
  `model_dump(mode="json")` output, so `timing.json` files written by
  the new code look the same as before.
- **Old `timing.json` files still load.** Pydantic v2's default
  `model_config["extra"] = "ignore"` silently drops input keys that
  match computed fields; only `times_ms` is consumed, and the computed
  fields recompute from it.

## Test plan

- [ ] Run an existing eval (e.g. `python -m evaluation.eval_n1
      --dataset_include_domains craigslist --dataset_max_samples 1`)
      and confirm the timing summary still prints, and the resulting
      `timing.json` contains the same keys (`call_count`,
      `total_time_ms`, `min_time_ms`, `max_time_ms`, `times_ms`).
- [ ] Resume from an existing `results_n1/` to confirm `load_timing`
      still parses pre-refactor `timing.json` files.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LfiCoAMySA7nGRUjb7sRi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to timing aggregation; main risk is any downstream consumer relying on manually-stored aggregate fields behaving differently under edge cases (e.g., empty `times_ms`) or differing Pydantic `computed_field` serialization/validation behavior.
> 
> **Overview**
> Refactors `TimingStats` so `times_ms` is the only persisted field, and `call_count`/`total_time_ms`/`min_time_ms`/`max_time_ms` are now `@computed_field` properties derived from the samples.
> 
> Updates `add_call` and `merge` to only maintain `times_ms`, keeping existing callers and `timing.json` output keys stable while preventing aggregate/sample drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1380fcc8eb9f06d122aa978863eafe62c10cea13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->