### PR TITLE
refactor(base): replace deprecated typing.Type with built-in type

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -5,7 +5,7 @@ import random
 import types
 from datetime import datetime
 from functools import cached_property
-from typing import Any, Awaitable, Callable, Iterable, Type, TypeVar, Union, get_args, get_origin
+from typing import Any, Awaitable, Callable, Iterable, TypeVar, Union, get_args, get_origin
 from urllib.parse import ParseResult, urlparse
 
 from datasets import Features, Value
@@ -138,7 +138,7 @@ def instantiate(
         return config
 
 
-def basic_pydantic_to_hf_features(model_class: Type[BaseModel]) -> Features:
+def basic_pydantic_to_hf_features(model_class: type[BaseModel]) -> Features:
     """
     Basic function to convert a pydantic model to a HuggingFace Features dictionary.
     It only supports fields of basic types or nested pydantic models with basic types, not list, dict, etc.


### PR DESCRIPTION
## Summary

- Replace `typing.Type` with built-in `type` in `navi_bench/base.py` (single occurrence in `basic_pydantic_to_hf_features`)
- Project requires Python >=3.10 (pyproject.toml), so the built-in `type[...]` form is preferred

No behavior change. Ruff clean.

cc @dhruvbatra

## Test plan

- [x] File parses correctly
- [x] `ruff check` and `ruff format` pass
- [ ] CI tests pass

https://claude.ai/code/session_01TzQZNCmFdcF8TGNqSUpLDU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzQZNCmFdcF8TGNqSUpLDU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3df69b4ac5bc661c519255b5c3aff98862615d79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->