### PR TITLE
refactor(vis): replace hand-rolled _escape_html with stdlib html.escape

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -1,10 +1,7 @@
 import json
+from html import escape as _escape_html
 
 from yutori.n1 import N1_COORDINATE_SCALE
-
-
-def _escape_html(text: str) -> str:
-    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
 
 
 def _escape_json_for_script_tag(json_str: str) -> str:


### PR DESCRIPTION
## Summary

`evaluation/vis.py` defined a 1-line `_escape_html()` that reimplements stdlib's `html.escape()`. Drop the local definition and import the stdlib function under the same name so all 11 existing call sites stay untouched.

## Why this is safe

- All call sites are inside `evaluation/vis.py` (private helper, leading underscore, only used in `generate_visualization_html`).
- `_escape_html` is not imported by any other module (`grep` confirms `evaluation/recorder.py` only imports `generate_visualization_html`).
- Output is HTML embedded in a visualization page; there are no snapshot tests in the repo.

## Behavioral note

`html.escape()` defaults to `quote=True`, which additionally escapes `'` to `&#x27;` (the previous implementation only escaped `&`, `<`, `>`, `"`). Browsers render `&#x27;` identically to `'`, so the visualization looks the same; the additional escape is strictly safer in attribute contexts.

## Test plan

- [x] `python -c "import ast; ast.parse(open('evaluation/vis.py').read())"`
- [x] No external `_escape_html` imports (`grep -rn '_escape_html' --include='*.py'`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MSmM8qFNWWhxPsDrLzgq3T)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9bffbbae3b32e01acb42687e7699dcef876d8637. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->