### PR TITLE
refactor(relative_dates): narrow except Exception to ValueError

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -623,12 +623,12 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
             end_base = start
             try:
                 end = parse_relative_date(m.group(3), end_base, return_iso=False)
-            except Exception:
+            except ValueError:
                 # fallback: resolve relative to `base`, and if end < start, bump a year
                 end = parse_relative_date(m.group(3), base, return_iso=False)
                 if end < start:
                     end = date(end.year + 1, end.month, end.day)
-        except Exception:
+        except ValueError:
             # maybe there is no weekday filter; treat the entire thing as "from X through Y"
             wds = set()
             start = parse_relative_date(m.group(1), base, return_iso=False)
@@ -767,7 +767,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
     try:
         d = parse_relative_date(query, base, return_iso=False)
         return [d.isoformat()] if return_iso else [d]
-    except Exception:
+    except ValueError:
         raise ValueError(f"Could not parse date range/multiple description: '{query}'")
 
 


### PR DESCRIPTION
## Summary

The 3 bare `except Exception:` blocks in `parse_relative_dates()` (lines 626, 631, 770) catch failures from `parse_relative_date()` and `_month_ref_to_year_month()`. Both helpers only ever raise `ValueError` (lines 371 and 403). Narrowing to `except ValueError:` lets unexpected exceptions (programming errors like `AttributeError`, system errors like `KeyboardInterrupt`/`MemoryError`) propagate instead of being silently swallowed and falling through to a misleading fallback path.

## Why it's safe

- **No behavior change for ValueError flows.** All `parse_relative_date` / `_month_ref_to_year_month` failures are `ValueError`, so the existing fallback logic still triggers exactly as before.
- **Mirrors recent precedent** — same shape of fix as #56 (`narrow import-failure except in _create_overlay_controller`).
- **Smoke tested**: existing parse cases (`Sat and Sun from next Oct 12 through Nov 25`, `from next Oct 12 through Nov 25`, `next May 11-14 and May 18-21`, `upcoming Friday`) all return identical results, and unparseable strings still raise `ValueError("Could not parse date range/multiple description: ...")`.

## Test plan

- [x] Parsing of weekday + range, plain ranges, weekday-only, multi-month, and pure unparseable input all behave identically to `main`.
- [x] No new dependencies; diff is 3 token swaps in one file.

https://claude.ai/code/session_019BQqFFtXRNbYYH7mb2V4yz

---
_Generated by [Claude Code](https://claude.ai/code/session_019BQqFFtXRNbYYH7mb2V4yz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to exception filtering; behavior should be unchanged for expected parse failures but may surface previously hidden bugs by letting non-`ValueError` exceptions bubble up.
> 
> **Overview**
> Tightens error handling in `parse_relative_dates()` by narrowing three broad `except Exception` blocks to `except ValueError` when falling back from failed `parse_relative_date()` parsing.
> 
> This ensures only expected parse failures trigger the alternative parsing paths, while unexpected errors now propagate instead of being silently swallowed and producing misleading results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51aeb8696c3cec322243d9692f4032a0149b994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->