### PR TITLE
refactor(vis): extract to_pct closure for action marker percentages

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -77,25 +77,22 @@ def _get_action_marker_style(
     if "ref" in action:
         result["ref"] = action["ref"]
 
+    def to_pct(xy: tuple[float, float]) -> tuple[float, float]:
+        x, y = xy
+        return x / coord_space_width * 100, y / coord_space_height * 100
+
     # Handle coordinate-based actions
     # Check drag first since drags have both start_coordinates and coordinates
     if "start_coordinates" in action and action_type.lower() in ("drag", "left_click_drag"):
-        sx, sy = action["start_coordinates"]
-        ex, ey = action.get("coordinates", action.get("center_coordinates", action.get("end_coordinates", [0, 0])))
-        result["start_x"] = sx / coord_space_width * 100
-        result["start_y"] = sy / coord_space_height * 100
-        result["end_x"] = ex / coord_space_width * 100
-        result["end_y"] = ey / coord_space_height * 100
+        end_xy = action.get("coordinates", action.get("center_coordinates", action.get("end_coordinates", [0, 0])))
+        result["start_x"], result["start_y"] = to_pct(action["start_coordinates"])
+        result["end_x"], result["end_y"] = to_pct(end_xy)
         result["has_drag"] = True
     elif "coordinates" in action:
-        x, y = action["coordinates"]
-        result["x"] = x / coord_space_width * 100  # percentage
-        result["y"] = y / coord_space_height * 100
+        result["x"], result["y"] = to_pct(action["coordinates"])
         result["has_point"] = True
     elif "center_coordinates" in action:
-        x, y = action["center_coordinates"]
-        result["x"] = x / coord_space_width * 100
-        result["y"] = y / coord_space_height * 100
+        result["x"], result["y"] = to_pct(action["center_coordinates"])
         result["has_point"] = True
     else:
         result["has_point"] = False


### PR DESCRIPTION
## Summary

Eliminates 8 repetitions of the `coord / coord_space_X * 100` pattern inside `_get_action_marker_style` in `evaluation/vis.py` (drag start/end + 2 click branches × 2 axes). Adds a small `to_pct((x, y))` closure inside the function that captures the width/height parameters so each branch becomes a single line of tuple-unpacked assignment.

## What changed

```python
# Before — repeated per axis, per branch
sx, sy = action["start_coordinates"]
result["start_x"] = sx / coord_space_width * 100
result["start_y"] = sy / coord_space_height * 100

# After — captured once, applied per branch
result["start_x"], result["start_y"] = to_pct(action["start_coordinates"])
```

Net: -3 LOC, but the real win is that the percentage formula now lives in exactly one place inside the function.

## Why it's safe

- Pure refactor inside a single function. The arithmetic is byte-for-byte identical: same `coord / coord_space * 100` per axis, just hoisted into a closure.
- No callers outside this file (verified: `_get_action_marker_style` is only used at line 181 of the same file, passing the same parameters).
- No existing unit tests for this helper, so no test churn.

## Test plan

- [x] Manually verified semantics for all three branches (drag, coordinates, center_coordinates) — same output as before.
- [x] `python -c "import ast; ast.parse(open('evaluation/vis.py').read())"` — parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6yw744ZuRgvQLPZ1sH1nF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure, localized refactor of UI marker positioning math with no changes to inputs/outputs expected.
> 
> **Overview**
> Refactors `evaluation/vis.py`’s `_get_action_marker_style` by extracting the repeated `coord / coord_space_* * 100` math into a local `to_pct()` helper and using tuple-unpacked assignments for drag start/end and point actions.
> 
> Behavior should be unchanged; this is a small maintainability improvement that reduces duplicated arithmetic across the coordinate-handling branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d798eb5f4c1b905d52a416b6fd2650fb415445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->