### PR TITLE
refactor(base): extract read_sidecar helper for module-relative file reads

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -5,6 +5,7 @@ import random
 import types
 from datetime import datetime
 from functools import cached_property
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable, TypeVar, Union, get_args, get_origin
 from urllib.parse import ParseResult, urlparse
 
@@ -19,6 +20,11 @@ T = TypeVar("T")
 def get_import_path(obj: Any) -> str:
     """Get the import path of an object."""
     return f"{obj.__module__}.{obj.__qualname__}"
+
+
+def read_sidecar(module_file: str, filename: str) -> str:
+    """Read a sidecar file located next to ``module_file`` (typically ``__file__``)."""
+    return (Path(module_file).parent / filename).read_text()
 
 
 def strip_url_scheme(url: str) -> str:

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -3,7 +3,6 @@ import itertools
 import random
 import re
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Literal
 from zoneinfo import ZoneInfo
 
@@ -13,7 +12,7 @@ from playwright.async_api import Page
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path, read_sidecar
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -82,8 +81,7 @@ class OpenTableInfoGathering(BaseMetric):
 
     @functools.cached_property
     def js_script(self) -> str:
-        with open(Path(__file__).parent / "opentable_info_gathering.js", "r") as f:
-            return f.read()
+        return read_sidecar(__file__, "opentable_info_gathering.js")
 
     async def reset(self) -> None:
         self._all_infos = []

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -13,7 +13,14 @@ from loguru import logger
 from playwright.async_api import Page
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, basic_normalize_url, get_import_path
+from navi_bench.base import (
+    BaseMetric,
+    BaseTaskConfig,
+    UserMetadata,
+    basic_normalize_url,
+    get_import_path,
+    read_sidecar,
+)
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -149,14 +156,12 @@ class ResyUrlMatch(BaseMetric):
     @functools.cached_property
     def js_script(self) -> str:
         """Load the JavaScript for checking 'no availability' message"""
-        with open(Path(__file__).parent / "resy_no_availability_check.js", "r") as f:
-            return f.read()
+        return read_sidecar(__file__, "resy_no_availability_check.js")
 
     @functools.cached_property
     def availability_script(self) -> str:
         """Load the JavaScript for extracting availability metadata."""
-        with open(Path(__file__).parent / "resy_availability_extractor.js", "r") as f:
-            return f.read()
+        return read_sidecar(__file__, "resy_availability_extractor.js")
 
     async def reset(self) -> None:
         self._is_query_covered = [False] * len(self.queries)


### PR DESCRIPTION
## Summary

Three call sites duplicated the same `with open(Path(__file__).parent / "<filename>", "r") as f: return f.read()` pattern for loading sidecar JS files:

- `navi_bench/resy/resy_url_match.py::ResyUrlMatch.js_script` — `resy_no_availability_check.js`
- `navi_bench/resy/resy_url_match.py::ResyUrlMatch.availability_script` — `resy_availability_extractor.js`
- `navi_bench/opentable/opentable_info_gathering.py::OpenTableInfoGathering.js_script` — `opentable_info_gathering.js`

Extract a tiny `read_sidecar(module_file, filename)` helper in `navi_bench/base.py` so each call site collapses to a single line and the helper can be reused for any future sidecar files (CSS, additional JS, etc.).

## Why it's safe

- **No behavioral change.** `Path.read_text()` uses the same default text encoding as `open(path, "r")`; both close the handle deterministically. The cached `@functools.cached_property` wrappers are preserved.
- **CSV path left untouched.** `load_restaurant_metadata()` in `resy_url_match.py` continues to use `with open(csv_path, "r") as f: csv.DictReader(f)` — switching that to `read_sidecar` would change reading semantics (whole-file-into-memory + StringIO wrap), so it stays as is.
- **Verifiable from diff alone.** Each call site replaces 2 lines with 1; the helper is 2 lines.
- **`pathlib.Path` import removed from `opentable_info_gathering.py`** since it's no longer used there. `resy_url_match.py` keeps its `Path` import — still used by the CSV loader.

## Test plan

- [x] `ruff check` passes on all touched files
- [x] `ruff format --check` clean
- [x] `python -c "import ast; ..."` parses all three files
- [ ] CI green

https://claude.ai/code/session_018gLV3Ci8X91AohypxPt4Vb

---
_Generated by [Claude Code](https://claude.ai/code/session_018gLV3Ci8X91AohypxPt4Vb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to how module-adjacent text files are read; behavior should remain the same aside from potential encoding/default differences in `Path.read_text()` vs `open()`.
> 
> **Overview**
> Refactors sidecar JavaScript loading to use a shared `read_sidecar(__file__, filename)` helper in `navi_bench/base.py` instead of repeating `open(Path(__file__).parent / ...)` at each call site.
> 
> Updates the OpenTable and Resy metrics to use the helper (and drops the now-unused `Path` import from `opentable_info_gathering.py`), without changing caching behavior or URL-matching logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15edab2eb27295e54dcd976a968b3ea178bd8175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->