### PR TITLE
refactor(base): extract print_dataset_demo helper for matcher __main__ blocks

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -220,7 +220,7 @@ def generate_task_config(
 
 
 if __name__ == "__main__":
-    from navi_bench.base import DatasetItem, instantiate
+    from navi_bench.base import print_dataset_demo
 
     dataset_row = {
         "task_id": "navi_bench/apartments/nyc_multi_region_floor_search/1",
@@ -248,20 +248,4 @@ if __name__ == "__main__":
         "suggested_difficulty": "hard",
     }
 
-    dataset_item = DatasetItem.model_validate(dataset_row)
-    task_config = dataset_item.generate_task_config()
-    evaluator = instantiate(task_config.eval_config)
-
-    print("Loaded dataset item")
-    print("-------------------")
-    print(dataset_item)
-    print()
-
-    print("Generated task config")
-    print("---------------------")
-    print(task_config)
-    print()
-
-    print("Instantiated evaluator")
-    print("----------------------")
-    print(evaluator)
+    print_dataset_demo(dataset_row)

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -309,3 +309,28 @@ class DatasetItem(BaseModel):
     def generate_task_config(self) -> BaseTaskConfig:
         task_config = instantiate(self.task_generation_config)
         return task_config
+
+
+def print_dataset_demo(dataset_row: dict) -> None:
+    """Validate ``dataset_row`` end-to-end and print the loaded item, task config, and evaluator.
+
+    Used by the ``__main__`` demos in each per-domain matcher module so they share a single
+    rendering format.
+    """
+    dataset_item = DatasetItem.model_validate(dataset_row)
+    task_config = dataset_item.generate_task_config()
+    evaluator = instantiate(task_config.eval_config)
+
+    print("Loaded dataset item")
+    print("-------------------")
+    print(dataset_item)
+    print()
+
+    print("Generated task config")
+    print("---------------------")
+    print(task_config)
+    print()
+
+    print("Instantiated evaluator")
+    print("----------------------")
+    print(evaluator)

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -106,7 +106,7 @@ def generate_task_config(
 if __name__ == "__main__":
     import json
 
-    from navi_bench.base import DatasetItem, instantiate
+    from navi_bench.base import print_dataset_demo
 
     dataset_row = {
         "task_id": "navi_bench/craigslist/sf_rental_search/0",
@@ -136,20 +136,4 @@ if __name__ == "__main__":
         "suggested_difficulty": "hard",
     }
 
-    dataset_item = DatasetItem.model_validate(dataset_row)
-    task_config = dataset_item.generate_task_config()
-    evaluator = instantiate(task_config.eval_config)
-
-    print("Loaded dataset item")
-    print("-------------------")
-    print(dataset_item)
-    print()
-
-    print("Generated task config")
-    print("---------------------")
-    print(task_config)
-    print()
-
-    print("Instantiated evaluator")
-    print("----------------------")
-    print(evaluator)
+    print_dataset_demo(dataset_row)

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -242,7 +242,7 @@ def generate_task_config(
 if __name__ == "__main__":
     import json
 
-    from navi_bench.base import DatasetItem, instantiate
+    from navi_bench.base import print_dataset_demo
 
     dataset_row = {
         "task_id": "navi_bench/google_flights/flight_search_budget/0",
@@ -276,20 +276,4 @@ if __name__ == "__main__":
         "suggested_difficulty": None,
     }
 
-    dataset_item = DatasetItem.model_validate(dataset_row)
-    task_config = dataset_item.generate_task_config()
-    evaluator = instantiate(task_config.eval_config)
-
-    print("Loaded dataset item")
-    print("-------------------")
-    print(dataset_item)
-    print()
-
-    print("Generated task config")
-    print("---------------------")
-    print(task_config)
-    print()
-
-    print("Instantiated evaluator")
-    print("----------------------")
-    print(evaluator)
+    print_dataset_demo(dataset_row)

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -952,7 +952,7 @@ def generate_task_config_deterministic(
 if __name__ == "__main__":
     import json
 
-    from navi_bench.base import DatasetItem, instantiate
+    from navi_bench.base import print_dataset_demo
 
     dataset_row = {
         "task_id": "navi_bench/opentable/any_sr_sd_mt_mp/0",
@@ -1046,20 +1046,4 @@ if __name__ == "__main__":
         "l2_category": "random_sr_sd_mt_sp",
     }
 
-    dataset_item = DatasetItem.model_validate(dataset_row)
-    task_config = dataset_item.generate_task_config()
-    evaluator = instantiate(task_config.eval_config)
-
-    print("Loaded dataset item")
-    print("-------------------")
-    print(dataset_item)
-    print()
-
-    print("Generated task config")
-    print("---------------------")
-    print(task_config)
-    print()
-
-    print("Instantiated evaluator")
-    print("----------------------")
-    print(evaluator)
+    print_dataset_demo(dataset_row)

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -1138,7 +1138,7 @@ def generate_task_config_deterministic(
 if __name__ == "__main__":
     import json
 
-    from navi_bench.base import DatasetItem, instantiate
+    from navi_bench.base import print_dataset_demo
 
     dataset_row = {
         "task_id": "navi_bench/resy/any_sr_sd_mt_sp/0",
@@ -1230,20 +1230,4 @@ if __name__ == "__main__":
         "l2_category": "any_sr_dd_st_sp",
     }
 
-    dataset_item = DatasetItem.model_validate(dataset_row)
-    task_config = dataset_item.generate_task_config()
-    evaluator = instantiate(task_config.eval_config)
-
-    print("Loaded dataset item")
-    print("-------------------")
-    print(dataset_item)
-    print()
-
-    print("Generated task config")
-    print("---------------------")
-    print(task_config)
-    print()
-
-    print("Instantiated evaluator")
-    print("----------------------")
-    print(evaluator)
+    print_dataset_demo(dataset_row)


### PR DESCRIPTION
## What

The same 11-line print block was duplicated at the bottom of every per-domain matcher's `if __name__ == "__main__":` demo:

```python
dataset_item = DatasetItem.model_validate(dataset_row)
task_config = dataset_item.generate_task_config()
evaluator = instantiate(task_config.eval_config)

print("Loaded dataset item")
print("-------------------")
print(dataset_item)
print()

print("Generated task config")
print("---------------------")
print(task_config)
print()

print("Instantiated evaluator")
print("----------------------")
print(evaluator)
```

This block appears verbatim in five files:
- `navi_bench/apartments/apartments_url_match.py`
- `navi_bench/craigslist/craigslist_url_match.py`
- `navi_bench/google_flights/google_flights_search_match.py`
- `navi_bench/opentable/opentable_info_gathering.py`
- `navi_bench/resy/resy_url_match.py`

## Why

Whenever someone tweaks the demo output format (e.g., adds a section, switches to `pprint`, etc.), they have to remember to do it in five places. Extracting the shared block into one helper means future tweaks happen once and stay consistent.

## How

Added `print_dataset_demo(dataset_row: dict)` to `navi_bench/base.py` that does the validate / generate / instantiate / print sequence, and replaced the duplicated body in each matcher with a single call to the helper.

## Safety

No behavior change. Each demo still constructs its `dataset_row` dict in place; only the trailing 15 lines were factored out. Verified end-to-end by running each module:

```
python -m navi_bench.apartments.apartments_url_match
python -m navi_bench.craigslist.craigslist_url_match
python -m navi_bench.google_flights.google_flights_search_match
python -m navi_bench.opentable.opentable_info_gathering
python -m navi_bench.resy.resy_url_match
```

All five produce the same three labeled sections in the same order as before.

Net diff: **+35 / -90 lines** across 6 files.


---
_Generated by [Claude Code](https://claude.ai/code/session_017wG44rqZ8XZQJuR8EoAhQL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor limited to `__main__` demo code paths; runtime evaluation logic is unchanged and risk is minimal.
> 
> **Overview**
> Refactors per-domain matcher `__main__` demos to use a shared `print_dataset_demo()` helper instead of duplicating the same validate/generate/instantiate/print sequence.
> 
> Adds `print_dataset_demo(dataset_row: dict)` to `navi_bench/base.py` and updates the Apartments, Craigslist, Google Flights, OpenTable, and Resy matcher modules to import and call it, keeping demo output consistent and centralized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0495a9511c6d37ddabf69b46fee27d9f3dece9c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->