### PR TITLE
refactor(browser): extract _safe_close helper for resource cleanup

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -51,6 +51,15 @@ async def wait_for_page_ready(page: Page, step_idx: int = -1, sleep_s: float = 1
         raise RuntimeError("Page is blank or has navigation error")
 
 
+async def _safe_close(resource, label: str) -> None:
+    if resource is None:
+        return
+    try:
+        await resource.close()
+    except Exception:
+        logger.opt(exception=True).warning(f"Failed to close {label}")
+
+
 @asynccontextmanager
 async def build_browser(
     config, task_config: BaseTaskConfig, playwright: Playwright
@@ -139,14 +148,5 @@ async def build_browser(
         yield browser, context, page
 
     finally:
-        if context is not None:
-            try:
-                await context.close()
-            except Exception:
-                logger.opt(exception=True).warning("Failed to close browser context")
-
-        if browser is not None:
-            try:
-                await browser.close()
-            except Exception:
-                logger.opt(exception=True).warning("Failed to close browser")
+        await _safe_close(context, "browser context")
+        await _safe_close(browser, "browser")


### PR DESCRIPTION
## Summary

`evaluation/browser.py::build_browser`'s `finally` clause had two near-identical 5-line try/except blocks that close the browser context and browser, each logging a warning on failure. Extracted them into a `_safe_close(resource, label)` helper at module scope.

- **What's the structural issue:** Two copies of `if x is not None: try: await x.close() except Exception: log warning` for sibling resources, with the only difference being the resource and the log label.
- **Why it's an improvement:** The helper makes the cleanup intent obvious at the call site (`_safe_close(context, "browser context")`) and eliminates the duplicated null-check + try/except scaffolding.
- **Why it's safe:** Pure refactor of the cleanup path inside a single function. Same exception class caught, same warning log call, same null-guard semantics. No behavior change.

## Test plan
- [x] Syntax check passes (`python -c "import ast; ast.parse(...)"`).
- [x] Diff is mechanical: two 5-line blocks → two helper calls; helper body is the same try/except previously inlined.

https://claude.ai/code/session_012qp4heTDbRaYZMyEqYMwWG

---
_Generated by [Claude Code](https://claude.ai/code/session_012qp4heTDbRaYZMyEqYMwWG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of resource cleanup with no functional changes expected beyond slightly different logging call structure if close fails.
> 
> **Overview**
> Refactors `evaluation/browser.py` to reduce duplicated teardown logic in `build_browser` by introducing a shared async `_safe_close(resource, label)` helper.
> 
> The `finally` block now delegates closing the browser context and browser to `_safe_close`, preserving the same best-effort cleanup behavior while centralizing the warning-on-failure logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9210cf0943a3cd565bd9b2962186520d029eb8ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->