### PR TITLE
refactor(stats): extract log_section_header for repeated banner pattern

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -62,7 +62,7 @@ from evaluation.browser import build_browser, wait_for_page_ready
 from evaluation.cli import cli
 from evaluation.dataset import build_dataset
 from evaluation.recorder import Recorder, log_formatter
-from evaluation.stats import BaseTokenUsage, Crashed, TimingStats, show_results, show_timing_summary
+from evaluation.stats import BaseTokenUsage, Crashed, TimingStats, log_section_header, show_results, show_timing_summary
 from navi_bench.base import BaseMetric, BaseTaskConfig, DatasetItem, instantiate
 from yutori import AsyncYutoriClient
 from yutori.auth import resolve_api_key
@@ -134,10 +134,7 @@ class TokenUsage(BaseTokenUsage):
         total_cost = total_usage.calculate_cost()
         avg_cost = total_cost / len(usages) if usages else 0
 
-        logger.info("")
-        logger.info("=" * 60)
-        logger.info("Token Usage Summary")
-        logger.info("=" * 60)
+        log_section_header("Token Usage Summary")
         logger.info(f"  Input tokens:              {total_usage.input_tokens:>12,}")
         logger.info(f"  Output tokens:             {total_usage.output_tokens:>12,}")
         logger.info("-" * 60)

--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -30,6 +30,14 @@ class Crashed(BaseModel):
     traceback: str | None = None
 
 
+def log_section_header(title: str, width: int = 60) -> None:
+    """Log a banner header surrounded by ``=`` rules at the given width."""
+    logger.info("")
+    logger.info("=" * width)
+    logger.info(title)
+    logger.info("=" * width)
+
+
 class TimingStats(BaseModel):
     """Aggregate timing stats for a sequence of API calls.
 
@@ -94,10 +102,7 @@ def show_timing_summary(timings: list[TimingStats]) -> None:
         total_timing = total_timing.merge(timing)
 
     if total_timing.call_count == 0:
-        logger.info("")
-        logger.info("=" * 60)
-        logger.info("Timing Summary: No API calls recorded")
-        logger.info("=" * 60)
+        log_section_header("Timing Summary: No API calls recorded")
         return
 
     tasks_with_calls = sum(1 for t in timings if t.call_count > 0)
@@ -105,10 +110,7 @@ def show_timing_summary(timings: list[TimingStats]) -> None:
     avg_time_per_task = total_timing.total_time_ms / tasks_with_calls if tasks_with_calls > 0 else 0
     total_time_s = total_timing.total_time_ms / 1000
 
-    logger.info("")
-    logger.info("=" * 60)
-    logger.info("Timing Summary")
-    logger.info("=" * 60)
+    log_section_header("Timing Summary")
     logger.info(f"  Total API calls:           {total_timing.call_count:>12,}")
     logger.info(f"  Total time:                {total_timing.total_time_ms:>12,.0f} ms ({total_time_s:.1f} s)")
     logger.info("-" * 60)
@@ -124,10 +126,7 @@ def show_timing_summary(timings: list[TimingStats]) -> None:
 
 
 def show_results(dataset: list[DatasetItem], results: list[BaseModel | Crashed]) -> None:
-    logger.info("")
-    logger.info("=" * 90)
-    logger.info("Detailed Results")
-    logger.info("=" * 90)
+    log_section_header("Detailed Results", width=90)
 
     per_domain_difficulty: dict[str, dict[str, list[tuple[float, bool]]]] = defaultdict(lambda: defaultdict(list))
 
@@ -161,10 +160,7 @@ def show_results(dataset: list[DatasetItem], results: list[BaseModel | Crashed])
 
         return n_finished, n_crashed, lower_bound, excluding_crashed, upper_bound
 
-    logger.info("")
-    logger.info("=" * 90)
-    logger.info("Summary (Lower Bound: crashed=0.0, Upper Bound: crashed=1.0, Excluding: no crashed)")
-    logger.info("=" * 90)
+    log_section_header("Summary (Lower Bound: crashed=0.0, Upper Bound: crashed=1.0, Excluding: no crashed)", width=90)
 
     table_rows = []
     all_entries: list[tuple[float, bool]] = []


### PR DESCRIPTION
## Summary

`stats.py` and `eval_n1.py` repeat the same four-line banner pattern five times:

```python
logger.info("")
logger.info("=" * N)
logger.info(title)
logger.info("=" * N)
```

Extract a tiny `log_section_header(title, width=60)` helper in `stats.py` and call it from `show_timing_summary` (×2, including the empty-stats fallback), `show_results` (×2), and `TokenUsage.show_summary` in `eval_n1.py` (×1).

## Why this is safe

- Pure mechanical extraction; emits the exact same four lines in the exact same order at the same widths.
- `demo.py` uses a similar but distinct pattern (`print(...)`, with explicit `\n` and a trailing footer line) and is intentionally left alone.
- 2 files changed, 14 insertions, 21 deletions.

https://claude.ai/code/session_0128xZsMZZ7Gro8ArSfAotni

---
_Generated by [Claude Code](https://claude.ai/code/session_0128xZsMZZ7Gro8ArSfAotni)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to logging output formatting; behavior should be unchanged aside from routing banner logs through a shared helper.
> 
> **Overview**
> Refactors repeated “banner” logging into a shared `log_section_header(title, width=60)` helper in `evaluation/stats.py`.
> 
> Updates `show_timing_summary`, `show_results`, and `TokenUsage.show_summary` (in `eval_n1.py`) to call the helper, preserving the existing header widths (60/90) while removing duplicated `logger.info` sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc86eb47652b4098f8b7cef596e7e79788c74940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->