### PR TITLE
refactor(eval_n1): consolidate click-action branches into a dispatch table

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -70,6 +70,15 @@ from yutori.n1 import denormalize_coordinates, estimate_messages_size_bytes, tri
 
 RETRYABLE_API_ERRORS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
+# Per-action overrides forwarded to ``page.mouse.click`` for the click family.
+# Membership in this dict is also how ``_execute`` decides a tool call is a click.
+_CLICK_KWARGS: dict[str, dict[str, object]] = {
+    "left_click": {},
+    "double_click": {"click_count": 2},
+    "triple_click": {"click_count": 3},
+    "right_click": {"button": "right"},
+}
+
 
 class Config(BaseModel):
     # Yutori n1 model API config
@@ -188,17 +197,8 @@ Today is: {dt.strftime("%A")}"""
             arguments = json.loads(tool_call.function.arguments or "{}")
             tool_call_id_to_observations.setdefault(tool_call.id, [])
 
-            if name == "left_click":
-                await page.mouse.click(*_denorm(arguments["coordinates"]))
-
-            elif name == "double_click":
-                await page.mouse.click(*_denorm(arguments["coordinates"]), click_count=2)
-
-            elif name == "triple_click":
-                await page.mouse.click(*_denorm(arguments["coordinates"]), click_count=3)
-
-            elif name == "right_click":
-                await page.mouse.click(*_denorm(arguments["coordinates"]), button="right")
+            if name in _CLICK_KWARGS:
+                await page.mouse.click(*_denorm(arguments["coordinates"]), **_CLICK_KWARGS[name])
 
             elif name == "scroll":
                 await page.mouse.move(*_denorm(arguments["coordinates"]))


### PR DESCRIPTION
## What

Replace the four `left_click` / `double_click` / `triple_click` / `right_click` arms inside `_execute()` with a module-level `_CLICK_KWARGS` table + a single membership-test branch.

```python
_CLICK_KWARGS: dict[str, dict[str, object]] = {
    "left_click": {},
    "double_click": {"click_count": 2},
    "triple_click": {"click_count": 3},
    "right_click": {"button": "right"},
}
...
if name in _CLICK_KWARGS:
    await page.mouse.click(*_denorm(arguments["coordinates"]), **_CLICK_KWARGS[name])
```

## Why

The four branches were structurally identical — same `_denorm(arguments["coordinates"])` invocation, same `page.mouse.click` target — and differed only in the per-action kwargs (`click_count` for double/triple, `button` for right). Lifting those kwargs into a table makes the actual variation easy to scan in one place and removes the 11 lines of near-duplicate code from the long action-dispatch chain.

## Safety

- Each known click name still produces the same `page.mouse.click(*coords, **kwargs)` call it produced before — the dispatch table is just a literal of the kwargs that were inline previously.
- The surrounding elif chain (`scroll`, `type`, `key_press`, …) is untouched, and the trailing `else: raise RuntimeError(f"Unknown action type: {name}")` still catches unknown names.
- No tests in this repo to update; static syntax check passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NcVKNSa515kxiKRhJCzRBo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to the tool-call execution dispatch; behavior should be identical but a bad mapping key/kwargs could change click semantics at runtime.
> 
> **Overview**
> Refactors `evaluation/eval_n1.py` click tool handling by replacing four separate `left_click`/`double_click`/`triple_click`/`right_click` branches with a module-level `_CLICK_KWARGS` dispatch table and a single `if name in _CLICK_KWARGS` path that forwards the mapped kwargs into `page.mouse.click`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70fca40d238d21b9c41671bf609838aebe1648a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->