### PR TITLE
refactor(recorder): consolidate log_formatter colorize branches

### DIFF
--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -19,26 +19,22 @@ T = TypeVar("T")
 
 def log_formatter(record: dict, *, colorize: bool = True) -> str:
     """Format log messages. Used by both global and task-specific log handlers."""
+
+    def wrap(text: str, color: str) -> str:
+        return f"<{color}>{text}</{color}>" if colorize else text
+
     extra = record["extra"]
-    if colorize:
-        result = (
-            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-            "<level>{level: <8}</level> | "
-            "<cyan>{file}</cyan>:<cyan>{line}</cyan> | "
-        )
-        if "task_id" in extra:
-            result += "<magenta>{extra[task_id]}</magenta> | "
-        if "attempt" in extra:
-            result += "<blue>{extra[attempt]}</blue> | "
-        result += "<level>{message}</level>\n{exception}"
-    else:
-        result = "{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {file}:{line} | "
-        if "task_id" in extra:
-            result += "{extra[task_id]} | "
-        if "attempt" in extra:
-            result += "{extra[attempt]} | "
-        result += "{message}\n{exception}"
-    return result
+    parts = [
+        wrap("{time:YYYY-MM-DD HH:mm:ss.SSS}", "green"),
+        wrap("{level: <8}", "level"),
+        f"{wrap('{file}', 'cyan')}:{wrap('{line}', 'cyan')}",
+    ]
+    if "task_id" in extra:
+        parts.append(wrap("{extra[task_id]}", "magenta"))
+    if "attempt" in extra:
+        parts.append(wrap("{extra[attempt]}", "blue"))
+    parts.append(wrap("{message}", "level"))
+    return " | ".join(parts) + "\n{exception}"
 
 
 class Recorder:


### PR DESCRIPTION
## Summary

`log_formatter` in `evaluation/recorder.py` carried two near-identical branches that built the same field structure (`time | level | file:line | task_id? | attempt? | message`), differing only in whether to wrap each field with loguru color tags. Adding a new `extra` field meant duplicating the entry in both branches and risked them silently drifting.

Replace the two branches with a single field list plus a small `wrap()` helper that conditionally adds the color tags, keeping the colorize toggle without restating the layout (~22 lines → ~15 lines, single source of truth for the field order).

## Why this is safe

- Output is byte-for-byte identical across all 2×4 combinations of `colorize` × `{no extras, task_id, attempt, both}` — verified locally with a small parity script.
- Function is private to `evaluation/recorder.py`; only call sites are `eval_n1.py:488/490` and `recorder.py:57`, all of which only forward the result to `loguru.logger.add(..., format=...)`.

## Test plan

- [x] Parity check: 8/8 combinations of (`colorize`, extras) produce identical output between old and new implementations
- [x] `ruff check evaluation/recorder.py` — clean
- [x] `ruff format --check evaluation/recorder.py` — already formatted

https://claude.ai/code/session_013qp7yuixSCXn4biAJLFxac

---
_Generated by [Claude Code](https://claude.ai/code/session_013qp7yuixSCXn4biAJLFxac)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `log_formatter`; it restructures string building while preserving the same log output format and call sites.
> 
> **Overview**
> Refactors `evaluation/recorder.py` `log_formatter` to remove duplicated `colorize` branches by introducing a small `wrap()` helper and building the log format from a single ordered `parts` list.
> 
> This keeps the same field layout (`time | level | file:line | task_id? | attempt? | message`) while making it easier to add or reorder fields without updating two separate format-string paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e79024292cc5c1824bd6e357c78fd3bf51ebfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->