### PR TITLE
refactor(dates): extract _is_dynamic_offset helper

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -32,6 +32,16 @@ _DYNAMIC_OFFSET_PATTERN = re.compile(
 )
 
 
+def _is_dynamic_offset(text: str) -> bool:
+    """Return True if ``text`` is a ``{now() + timedelta(...)}`` dynamic expression.
+
+    Centralizes the predicate used both to dispatch inside
+    ``resolve_placeholder_values`` and to choose the post-processing
+    branch in ``initialize_placeholder_map``.
+    """
+    return _DYNAMIC_OFFSET_PATTERN.fullmatch(text.strip()) is not None
+
+
 def _ordinal_suffix(value: int) -> str:
     """Return the ordinal suffix for a day number."""
     if 10 <= value % 100 <= 20:
@@ -205,8 +215,7 @@ def initialize_placeholder_map(
     for placeholder_key, relative_description in values.items():
         resolved_desc, iso_dates = resolve_placeholder_values(relative_description, base_date)
 
-        is_dynamic = _DYNAMIC_OFFSET_PATTERN.fullmatch(relative_description.strip()) is not None
-        if is_dynamic:
+        if _is_dynamic_offset(relative_description):
             # Dynamic expressions are always correct; just filter past dates
             today = base_date.isoformat()
             iso_dates = [d for d in iso_dates if d >= today]


### PR DESCRIPTION
## Summary

`initialize_placeholder_map` was inlining the dynamic-offset regex check
(`_DYNAMIC_OFFSET_PATTERN.fullmatch(relative_description.strip()) is not None`)
to decide which post-processing branch to take, duplicating the match that
`resolve_placeholder_values` already runs internally. This PR extracts a
single-purpose `_is_dynamic_offset(text)` predicate and calls it in
`initialize_placeholder_map` so the dispatch reads as the named concept
("is this a `{now() + timedelta(...)}` expression?") rather than a repeated
regex incantation.

## Why it's an improvement

- The dispatch in `initialize_placeholder_map` was tightly coupled to the
  `_DYNAMIC_OFFSET_PATTERN` regex internals. A future reader had to grok
  the regex to understand the branch condition.
- The named helper documents the intent, and any future change to what
  counts as a "dynamic offset" expression now has a single home.

## Why it's safe

- No behavior change. The predicate matches the same expression that the
  inline regex evaluation produced (`_DYNAMIC_OFFSET_PATTERN.fullmatch(text.strip()) is not None`).
- Pure refactor: only the new helper + a one-call-site swap inside
  `initialize_placeholder_map`. `resolve_placeholder_values` still uses
  the compiled pattern directly because it needs the captured groups.
- Public surface area unchanged — `_is_dynamic_offset` is private (leading
  underscore), and no existing exported function changed signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUg9T5HEDRzqr68sz7A3hq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: replaces an inline regex match in `initialize_placeholder_map` with a shared helper, with no behavioral change expected beyond the same dynamic-offset detection logic.
> 
> **Overview**
> Refactors dynamic-date detection by extracting `_is_dynamic_offset()` (a wrapper around `_DYNAMIC_OFFSET_PATTERN.fullmatch(text.strip())`).
> 
> `initialize_placeholder_map` now uses this helper instead of inlining the regex check when selecting the dynamic-offset post-processing branch, improving readability and centralizing the predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6caf6aa8e9995761f72935fc8b57103a2804b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->