### PR TITLE
refactor(vis): extract _anthropic_image_to_data_url helper

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -14,8 +14,8 @@ def _escape_json_for_script_tag(json_str: str) -> str:
     # Escape HTML comment patterns
     result = result.replace("<!--", "<\\!--")
     # Escape Unicode line/paragraph separators (valid in JSON but can cause issues in JS)
-    result = result.replace("\u2028", "\\u2028")
-    result = result.replace("\u2029", "\\u2029")
+    result = result.replace(" ", "\\u2028")
+    result = result.replace(" ", "\\u2029")
     return result
 
 
@@ -55,6 +55,21 @@ def _parse_tool_calls(msg: dict) -> list[dict]:
     if "tool_calls" in msg and msg["tool_calls"]:
         return _parse_tool_calls_from_openai_format(msg["tool_calls"])
     return []
+
+
+def _anthropic_image_to_data_url(block: dict) -> str | None:
+    """Convert an Anthropic base64 image block to a ``data:`` URL.
+
+    Returns ``None`` when ``block`` is not a base64-encoded image so callers
+    can keep their nested-content traversal explicit instead of branching on
+    ``source["type"]`` themselves.
+    """
+    source = block.get("source", {})
+    if source.get("type") != "base64":
+        return None
+    data = source.get("data", "")
+    media_type = source.get("media_type", "image/png")
+    return f"data:{media_type};base64,{data}"
 
 
 def _get_action_marker_style(
@@ -140,21 +155,16 @@ def generate_visualization_html(
                             for tc in tool_content:
                                 if isinstance(tc, dict):
                                     if tc.get("type") == "image":
-                                        # Anthropic base64 image
-                                        source = tc.get("source", {})
-                                        if source.get("type") == "base64":
-                                            data = source.get("data", "")
-                                            media_type = source.get("media_type", "image/png")
-                                            observation_images.append(f"data:{media_type};base64,{data}")
+                                        data_url = _anthropic_image_to_data_url(tc)
+                                        if data_url is not None:
+                                            observation_images.append(data_url)
                                     elif tc.get("type") == "text":
                                         observation_texts.append(tc.get("text", ""))
                     elif c_type == "image":
                         # Standalone Anthropic image block
-                        source = c.get("source", {})
-                        if source.get("type") == "base64":
-                            data = source.get("data", "")
-                            media_type = source.get("media_type", "image/png")
-                            observation_images.append(f"data:{media_type};base64,{data}")
+                        data_url = _anthropic_image_to_data_url(c)
+                        if data_url is not None:
+                            observation_images.append(data_url)
                     elif c_type == "image_url":
                         # OpenAI format
                         observation_images.append(c.get("image_url", {}).get("url", ""))

--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -14,8 +14,8 @@ def _escape_json_for_script_tag(json_str: str) -> str:
     # Escape HTML comment patterns
     result = result.replace("<!--", "<\\!--")
     # Escape Unicode line/paragraph separators (valid in JSON but can cause issues in JS)
-    result = result.replace(" ", "\\u2028")
-    result = result.replace(" ", "\\u2029")
+    result = result.replace(chr(0x2028), "\\u2028")
+    result = result.replace(chr(0x2029), "\\u2029")
     return result
 
 

--- a/tmp/test_encoding.txt
+++ b/tmp/test_encoding.txt
@@ -1,3 +1,0 @@
-test1: \\u2028
-test2:  
-end

--- a/tmp/test_encoding.txt
+++ b/tmp/test_encoding.txt
@@ -1,0 +1,3 @@
+test1: \\u2028
+test2:  
+end


### PR DESCRIPTION
## Summary

The 4-line "Anthropic base64 image block → `data:` URL" conversion was duplicated verbatim across the two image branches inside `generate_visualization_html` in `evaluation/vis.py`:

- once for image blocks nested under a `tool_result` (line 142)
- once for standalone top-level `image` blocks (line 151)

Both copies read `block["source"]`, checked `source["type"] == "base64"`, extracted `source["data"]` and `source["media_type"]`, and built the same `f"data:{media_type};base64,{data}"` URL.

## Change

Pull the conversion into a small `_anthropic_image_to_data_url(block)` helper that returns `None` for non-base64 blocks, mirroring the existing `_parse_tool_calls` / `_get_action_marker_style` style of small named helpers in this file. The two call sites collapse to a single None-guard each.

## Why this is safe

No behavior change — the helper produces the byte-identical `data:` URL for any block that previously appended one, and returns `None` (skipping the append) for any block where the previous code's inner `if source.get("type") == "base64":` was false. Verified by:

- `python -c "import ast; ast.parse(open('evaluation/vis.py').read())"` ✓
- Reading through both branches confirms 1:1 mapping between old branches and new helper-based code.

## Note for reviewers

The diff also touches lines 17-18 inside `_escape_json_for_script_tag`. The Python source `" "` literal compiles to the same single U+2028 character as the literal U+2028 byte sequence; both forms produce identical runtime behavior. The cron's MCP push round-tripped the source through JSON which silently rewrote `" "` → `"<U+2028>"`. Functionally a no-op, but flagging since it's outside the scoped refactor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjEavpgf5cLFQnGDYuLCjm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to visualization HTML generation; behavior should be unchanged aside from a safe literal-to-`chr()` swap when escaping U+2028/U+2029.
> 
> **Overview**
> **Refactors `evaluation/vis.py` to deduplicate Anthropic image handling.** A new `_anthropic_image_to_data_url()` helper centralizes converting Anthropic base64 image blocks into `data:` URLs, and both the `tool_result`-nested and top-level `image` branches now call this helper with a `None` guard.
> 
> Also replaces the U+2028/U+2029 escape replacements in `_escape_json_for_script_tag` with `chr(0x2028)`/`chr(0x2029)` to avoid relying on embedded unicode literals while keeping the same escaping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a79dafce016c747319fd4ea72fca9c63dc350b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->