### PR TITLE
Narrow base64 decode except in google_flights to binascii.Error

### DIFF
--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import urllib.parse
 from collections import defaultdict
 from copy import deepcopy
@@ -98,8 +99,8 @@ class GoogleFlightsSearchMatch(BaseMetric):
         padded = tfs_param + "=" * (-len(tfs_param) % 4)
         try:
             raw_bytes = base64.urlsafe_b64decode(padded)
-        except Exception as e:
-            raise ValueError(f"Base64 decoding failed: {e}")
+        except binascii.Error as e:
+            raise ValueError(f"Base64 decoding failed: {e}") from e
 
         # Note, city locations parse to something like /m/01ly5m but are deterministic and
         # can be used for location matching


### PR DESCRIPTION
## Summary

Replaces the bare `except Exception` around `base64.urlsafe_b64decode` in
`navi_bench/google_flights/google_flights_search_match.py::_decode_google_flights_url`
with the documented `except binascii.Error`, and chains the cause via
`raise ... from e`.

## Why this is a structural improvement

`base64.urlsafe_b64decode` documents `binascii.Error` (a `ValueError`
subclass) as the only failure mode for invalid base64 input. The previous
bare `except Exception` would silently relabel unrelated runtime errors
(e.g. `AttributeError` from a refactor mistake, `RuntimeError` from a
deeper bug) as "Base64 decoding failed", obscuring real bugs and making
trajectories hard to debug. Narrowing to the documented exception type
matches the contract and stops swallowing unrelated bugs.

## Why it's safe

- Single file, ~3 line change; no call sites to update.
- `binascii.Error` is the documented exception for this code path; it
  is also a subclass of `ValueError`, which is the only thing the
  previous exception handler chain would have realistically encountered.
- The surfaced exception type (`ValueError`) is unchanged for both
  valid and invalid base64 input — callers that catch `ValueError`
  continue to work identically.
- `raise ... from e` strictly improves debuggability by preserving the
  cause chain.
- No tests in the repo depend on the broad `except` shape (the file has
  only `__main__` demo code, no `tests/` directory).

## Test plan

- [x] Existing demo (`python -m navi_bench.google_flights.google_flights_search_match`) still imports/runs.
- [ ] CI passes.

https://claude.ai/code/session_01BhcgMyFtQdtq5RbNP2nxXv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhcgMyFtQdtq5RbNP2nxXv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change limited to error handling around base64 decoding, preserving the raised `ValueError` type while avoiding masking unrelated exceptions.
> 
> **Overview**
> Tightens error handling in `GoogleFlightsSearchMatch._decode_google_flights_url` by catching only `binascii.Error` from `base64.urlsafe_b64decode` instead of a broad `Exception`.
> 
> Re-raises as `ValueError` with explicit exception chaining (`raise ... from e`) to preserve the root cause and avoid mislabeling unexpected runtime failures as base64 issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d10eb7c12a45dfc81e1543c87e5f85e6927ed06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->