### PR TITLE
refactor(demo): extract _safe_evaluator_update helper

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -34,16 +34,20 @@ def load_task(task_id: str) -> dict[str, Any]:
     raise ValueError(f"Task {task_id} not found in {HF_DATASET}/{HF_SPLIT}")
 
 
+async def _safe_evaluator_update(evaluator, page: Page, *, label: str = "") -> None:
+    try:
+        await evaluator.update(url=page.url, page=page)
+    except Exception as e:
+        print(f"[WARN] {label}evaluator.update(url={page.url!r}, page={page}) failed: {e}")
+
+
 async def attach_human_agent_loop(page: Page, evaluator) -> None:
     """
     This is the human-agent-loop. Execute the task by navigating the website.
     """
 
     async def on_navigation():
-        try:
-            await evaluator.update(url=page.url, page=page)
-        except Exception as e:
-            print(f"[WARN] evaluator.update(url={page.url!r}, page={page}) failed: {e}")
+        await _safe_evaluator_update(evaluator, page)
 
     page.on("framenavigated", lambda frame: asyncio.create_task(on_navigation()))
 
@@ -92,10 +96,7 @@ async def run_human_session(task_id: str) -> None:
         await asyncio.to_thread(input, "\nPress Enter when you've completed the task... ")
 
         # Final update before computing result
-        try:
-            await evaluator.update(url=page.url, page=page)
-        except Exception as e:
-            print(f"[WARN] Final evaluator.update(url={page.url!r}, page={page}) failed: {e}")
+        await _safe_evaluator_update(evaluator, page, label="Final ")
 
         # Compute the evaluation result
         print("\nComputing evaluation result...\n")


### PR DESCRIPTION
## What

`demo.py` had two `evaluator.update(url=page.url, page=page)` call sites — one inside the `framenavigated` handler and one before computing the final result — each wrapped in an identical `try/except Exception, log [WARN] ...` block that differed only by a `"Final "` prefix in the warning message. Extract the wrapper into a single `_safe_evaluator_update(evaluator, page, *, label="")` helper.

## Why

Single source of truth for "best-effort evaluator update with logged failure," matching the pattern used elsewhere in this repo for `_safe_close`, `_safe_evaluate`, etc. If the error message format ever changes (e.g. structured logging instead of `print`), there's now one place to update.

## Safety

No behavior change. Both warning messages remain byte-for-byte equivalent — the `"Final "` discriminator is preserved via the `label` kwarg. The except clause still catches `Exception` (broad, but consistent with the demo-script intent).

---
_Generated by [Claude Code](https://claude.ai/code/session_019iqPEbVDTWxXbZwHkdFwbh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in a demo script: consolidates duplicate `try/except` logging around `evaluator.update` without changing control flow or error handling semantics.
> 
> **Overview**
> Extracts a shared `_safe_evaluator_update(...)` helper in `demo.py` and uses it for both navigation-triggered updates and the final pre-`compute()` update, keeping the same warning log format (with an optional `"Final "` label).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0545a3ba59a4fa58839ce27afae78b31217d0aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->