### PR TITLE
refactor(resy): narrow page.evaluate except clauses to PlaywrightError

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -10,7 +10,7 @@ from zoneinfo import ZoneInfo
 
 from beartype import beartype
 from loguru import logger
-from playwright.async_api import Page
+from playwright.async_api import Error as PlaywrightError, Page
 from pydantic import BaseModel
 
 from navi_bench.base import (
@@ -177,7 +177,7 @@ class ResyUrlMatch(BaseMetric):
         try:
             has_no_availability = await page.evaluate(self.js_script)
             logger.info(f"ResyUrlMatch.update: no_availability={has_no_availability} for URL: {url}")
-        except Exception as e:
+        except PlaywrightError as e:
             logger.warning(f"ResyUrlMatch.update: Could not check no_availability: {e}")
             has_no_availability = False
 
@@ -403,7 +403,7 @@ class ResyUrlMatch(BaseMetric):
     async def _extract_availabilities(self, page: PageLike) -> list[AvailabilitySlot]:
         try:
             raw_availabilities = await page.evaluate(self.availability_script)
-        except Exception as exc:  # noqa: BLE001 - log and continue
+        except PlaywrightError as exc:
             logger.debug(f"ResyUrlMatch.update: Could not extract availabilities: {exc}")
             return []
 


### PR DESCRIPTION
## Summary

Both `update()` and `_extract_availabilities()` in `navi_bench/resy/resy_url_match.py` previously caught the bare `Exception` around `page.evaluate(...)`. The `_extract_availabilities` site even carried a `# noqa: BLE001` to suppress the linter complaint.

`page.evaluate()` only raises `playwright.async_api.Error` (and its subclass `TimeoutError`) on browser/script failures. Catching the bare `Exception` also masks unrelated bugs (`AttributeError`, `KeyboardInterrupt`, `MemoryError`, etc.). Narrowing to `PlaywrightError` preserves the existing log-and-continue semantics while letting unrelated failures propagate.

## Why this is safe

- No behavioral change on any expected runtime path — Playwright evaluation errors continue to be logged and swallowed exactly as before.
- Mirrors the recently-landed pattern in this repo (e.g. #61 narrowed `binascii.Error`).
- Touches a single file, two call sites.

## Test plan

- [x] `python -m py_compile navi_bench/resy/resy_url_match.py`
- [ ] CI

https://claude.ai/code/session_01GCBYcKrMB6Ard9JYe4Sux1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCBYcKrMB6Ard9JYe4Sux1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, limited to error-handling around `page.evaluate`; the main change is that non-Playwright exceptions will now surface instead of being silently logged and ignored.
> 
> **Overview**
> Tightens error handling in `ResyUrlMatch.update()` and `_extract_availabilities()` by catching `playwright.async_api.Error` (`PlaywrightError`) instead of a broad `Exception` when running `page.evaluate(...)`.
> 
> This preserves the existing log-and-continue behavior for Playwright/script failures while allowing unrelated runtime errors to propagate, and removes the need for the prior broad-exception suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d16cc3a0699b3a9fb23e66543cb1bf692d01ef8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->