### PR TITLE
refactor(browser): narrow except Exception to PlaywrightError

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -6,7 +6,7 @@ from os import path as osp
 from typing import AsyncIterator
 
 from loguru import logger
-from playwright.async_api import Browser, BrowserContext, Page, Playwright
+from playwright.async_api import Browser, BrowserContext, Error as PlaywrightError, Page, Playwright
 
 from navi_bench.base import BaseTaskConfig
 
@@ -42,7 +42,7 @@ async def wait_for_page_ready(page: Page, step_idx: int = -1, sleep_s: float = 1
             is_ready = await page.evaluate(get_prepare_page_js())
             if is_ready:
                 break
-        except Exception as e:
+        except PlaywrightError as e:
             prefix = f"[{step_idx}] " if step_idx >= 0 else ""
             logger.warning(f"{prefix}Failed to wait for page ready: {e}. Continue waiting")
         await asyncio.sleep(sleep_s)
@@ -139,7 +139,7 @@ async def build_browser(
                         "Proxy.setLocation", {"lat": coords[0], "lon": coords[1], "distance": 100, "strict": False}
                     )
                     logger.info(f"Set location for CDP session: {task_config.user_metadata.location}")
-            except Exception:
+            except PlaywrightError:
                 logger.opt(exception=True).warning(
                     f"Failed to set location for CDP session: {task_config.user_metadata.location}"
                 )


### PR DESCRIPTION
## Summary

- Narrow `except Exception` to `except PlaywrightError` at two Playwright call sites in `evaluation/browser.py`: `page.evaluate()` in `wait_for_page_ready` and CDP session calls in `build_browser`
- Consistent with PR #64 which narrowed the same `page.evaluate()` pattern in `navi_bench/resy/resy_url_match.py`
- `_safe_close` (line 59) intentionally left as `except Exception` since cleanup handlers should catch broadly

No behavior change for any expected runtime path — Playwright evaluation and CDP errors continue to be logged and swallowed exactly as before. Only unrelated bugs (e.g. `AttributeError`, `RuntimeError`) now surface instead of being silently absorbed.

cc @dhruvbatra

## Test plan

- [ ] Verify `evaluation/browser.py` syntax is valid
- [ ] Confirm `PlaywrightError` import resolves correctly
- [ ] Check that `wait_for_page_ready` still logs and retries on Playwright failures
- [ ] Check that CDP location setup still logs a warning on failure and continues

https://claude.ai/code/session_01HZD8H1TTSLaSp8pYqyApkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZD8H1TTSLaSp8pYqyApkg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes which exceptions are swallowed during Playwright operations; unexpected non-Playwright errors will now surface instead of being silently retried/logged.
> 
> **Overview**
> Tightens exception handling in `evaluation/browser.py` by importing `PlaywrightError` and catching it (instead of `Exception`) when retrying `page.evaluate()` in `wait_for_page_ready` and when setting CDP location via `new_cdp_session().send()`.
> 
> Playwright failures are still logged and continue as before, but unrelated runtime errors (e.g., programming/logic issues) will no longer be inadvertently swallowed in these two call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006a414c3dd711e542c7e136eb0c909df46c2aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->