### PR TITLE
refactor: simplify 12-hour clock conversion using modulo arithmetic

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -569,30 +569,16 @@ def time_to_natural_language(time_str: str) -> str:
     Returns:
         Natural language time string
     """
-    # Parse the time
     parts = time_str.split(":")
     hour = int(parts[0])
     minute = int(parts[1]) if len(parts) > 1 else 0
 
-    # Convert to 12-hour format
-    if hour == 0:
-        hour_12 = 12
-        period = "am"
-    elif hour < 12:
-        hour_12 = hour
-        period = "am"
-    elif hour == 12:
-        hour_12 = 12
-        period = "pm"
-    else:
-        hour_12 = hour - 12
-        period = "pm"
+    hour_12 = hour % 12 or 12
+    period = "pm" if hour >= 12 else "am"
 
-    # Format the output
     if minute == 0:
         return f"{hour_12}{period}"
-    else:
-        return f"{hour_12}:{minute:02d}{period}"
+    return f"{hour_12}:{minute:02d}{period}"
 
 
 def is_time_string(s: str) -> bool:

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -802,15 +802,8 @@ def format_time_display(time_hhmm: str) -> str:
     hour = int(time_hhmm[:2])
     minute = int(time_hhmm[2:])
 
-    period = "AM"
-    display_hour = hour
-
-    if hour >= 12:
-        period = "PM"
-        if hour > 12:
-            display_hour = hour - 12
-    if hour == 0:
-        display_hour = 12
+    display_hour = hour % 12 or 12
+    period = "PM" if hour >= 12 else "AM"
 
     return f"{display_hour}:{minute:02d} {period}"
 


### PR DESCRIPTION
## Summary

Replace branching `if/elif` chains for 12-hour clock formatting with the idiomatic `hour % 12 or 12` pattern in two near-duplicate helpers:

- `time_to_natural_language` in `navi_bench/opentable/opentable_info_gathering.py` (was 12 lines of branching → 2 lines)
- `format_time_display` in `navi_bench/resy/resy_url_match.py` (was 8 lines of nested branching → 2 lines)

Both functions now compute the display hour and AM/PM period in two lines:

```python
hour_12 = hour % 12 or 12
period = "pm" if hour >= 12 else "am"
```

## Why this is an improvement

- **Readability**: Eliminates four-branch `if/elif/else` chains that handle 0, 1–11, 12, and 13–23 separately. The intent ("convert 0–23 to 1–12 with AM/PM") is now expressed directly.
- **Consistency**: The same pattern across the two files makes the conversion immediately recognizable.
- **Fewer lines to audit**: 26 lines deleted, 5 added.

## Why this is safe

- No public API changes — same function signatures, same return types, same return values.
- Verified equivalent against the original implementations across all 24 hours × 5 minute samples (240 cases) — every output matches exactly.
- The `hour % 12 or 12` idiom maps `{0,12}→12` and `{1..11,13..23}→{1..11}`, which is exactly what the original branches encoded.

## Test plan

- [x] Mechanical equivalence test against the original implementations for all hours 0–23 and minutes {0, 15, 30, 45, 59}: 240/240 cases match.
- [x] Spot-check sample outputs: `18:00→6pm`, `00:00→12am`, `12:30→12:30pm`, `1800→6:00 PM`, `0000→12:00 AM`, `1230→12:30 PM`.

https://claude.ai/code/session_012Xvmj2RhXhBn5WTGG7RADp

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xvmj2RhXhBn5WTGG7RADp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to time string display/formatting helpers with no API or behavior changes expected beyond potential edge-case regressions around 00:xx/12:xx formatting.
> 
> **Overview**
> Refactors `time_to_natural_language` (OpenTable) and `format_time_display` (Resy) to replace multi-branch AM/PM and 12-hour conversion logic with the idiomatic `hour % 12 or 12` calculation plus a single period check.
> 
> Also slightly simplifies the return logic in `time_to_natural_language` by removing the redundant `else` branch while keeping the same output format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a09b7797419fb32e8197da3af9e45508701919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->