### PR TITLE
refactor(eval_n1): extract _crashed_result helper for terminal failures

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -437,6 +437,19 @@ Today is: {dt.strftime("%A")}"""
     return result, task_usage, task_timing
 
 
+def _crashed_result(e: Exception) -> tuple[Crashed, TokenUsage, TimingStats]:
+    """Build the (Crashed, empty usage, empty timing) tuple returned for terminal task failures.
+
+    Must be called from within an ``except`` block so ``traceback.format_exc()`` captures
+    the current exception's traceback.
+    """
+    return (
+        Crashed(score=0.0, exception=str(e), traceback=traceback.format_exc()),
+        TokenUsage(),
+        TimingStats(),
+    )
+
+
 def _handle_task_failure(
     e: Exception, attempt: int, max_attempts: int
 ) -> tuple[Crashed, TokenUsage, TimingStats] | None:
@@ -444,11 +457,7 @@ def _handle_task_failure(
     retry warning and return None so the caller can continue the retry loop."""
     if attempt == max_attempts:
         logger.opt(exception=True).error(f"Failed to run task: {e}. No more attempts.")
-        return (
-            Crashed(score=0.0, exception=str(e), traceback=traceback.format_exc()),
-            TokenUsage(),
-            TimingStats(),
-        )
+        return _crashed_result(e)
     logger.opt(exception=True).warning(f"Failed to run task: {e}. Will retry.")
     return None
 
@@ -522,11 +531,7 @@ async def main(config: Config) -> None:
                                 f"Unhandled exception escaped run_task: {e}. "
                                 "Marking this task as crashed and continuing."
                             )
-                            return (
-                                Crashed(score=0.0, exception=str(e), traceback=traceback.format_exc()),
-                                TokenUsage(),
-                                TimingStats(),
-                            )
+                            return _crashed_result(e)
 
         eval_tasks = [asyncio.create_task(_eval(item), name=f"eval:{item.task_id}") for item in dataset]
         try:


### PR DESCRIPTION
## Summary

`evaluation/eval_n1.py` had the same 5-line `(Crashed, TokenUsage(), TimingStats())` tuple construction repeated in two places, both inside `except` blocks that wanted to mark a task as terminally crashed:

- `_handle_task_failure()` (lines 447–451) — final-attempt path of the retry loop in `run_task`.
- The unhandled-exception fallback inside `main()._eval()` (lines 525–529).

Both call `traceback.format_exc()` and construct the same shape. This PR extracts the construction into a single `_crashed_result(e)` helper:

```python
def _crashed_result(e: Exception) -> tuple[Crashed, TokenUsage, TimingStats]:
    return (
        Crashed(score=0.0, exception=str(e), traceback=traceback.format_exc()),
        TokenUsage(),
        TimingStats(),
    )
```

Each call site collapses to a single `return _crashed_result(e)`.

## Why this is a clean refactor

- Removes a real 5-line × 2-site duplication; the helper has a clear single responsibility ("build the terminal-failure result tuple").
- Documents the implicit precondition that `traceback.format_exc()` requires the helper to be called from inside an `except` block.
- Both existing call sites already satisfy that precondition, so behavior is unchanged.
- Diff is fully contained to one file.

## Behavior

No behavioral change. Each call site already invoked from inside an `except` block; `traceback.format_exc()` captures the same active-exception traceback it did before, and the surrounding control flow is unchanged (`_handle_task_failure` still returns `None` on retry, the helper is reached only on terminal failure).

## Test plan
- [x] `python -c "import ast; ast.parse(open('evaluation/eval_n1.py').read())"` — passes
- [x] `grep -n 'Crashed(score=0.0' evaluation/eval_n1.py` — only the helper definition matches; both call sites now go through it

https://claude.ai/code/session_01TYEcuSxggDsf1mwheRWG4m

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYEcuSxggDsf1mwheRWG4m)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to evaluation error handling; behavior should be unchanged aside from centralizing the crashed-result tuple construction (including traceback capture) behind a helper.
> 
> **Overview**
> Refactors `evaluation/eval_n1.py` to centralize terminal task-failure output into a new `_crashed_result(e)` helper that returns `(Crashed, TokenUsage(), TimingStats())` with `traceback.format_exc()`.
> 
> Updates both final-attempt failure handling in `_handle_task_failure` and the unhandled-exception fallback in `main()._eval()` to `return _crashed_result(e)`, removing duplicated tuple construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56714208b7196154add1f48a8164408b460d505c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->