### PR TITLE
refactor(relative_dates): extract _shift_for_modifier helper

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -197,6 +197,21 @@ def _choose_occurrence(target_this_year: date, base: date, modifier: str) -> dat
     return target_this_year.replace(year=target_this_year.year + shift)
 
 
+def _shift_for_modifier(mod: str) -> int:
+    """Return calendar shift (-1, 0, +1) for a normalized modifier.
+
+    Used by patterns that consume the ``(this|next|coming|upcoming|last|previous)``
+    ``_MOD_GROUP`` regex after ``_normalize_modifier()`` aliases ``upcoming`` -> ``next``.
+    Returns ``0`` for ``this``, ``+1`` for ``next``/``coming``, and ``-1`` for everything
+    else (``last``/``previous`` in practice).
+    """
+    if mod == "this":
+        return 0
+    if mod in ("next", "coming"):
+        return 1
+    return -1
+
+
 # ----------------------------------
 # Public API
 # ----------------------------------
@@ -294,8 +309,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
     if m:
         day = _parse_ordinal_day(m.group(1))
         mod = _normalize_modifier(m.group(2))
-        shift = 0 if mod == "this" else (1 if mod in ("next", "coming") else (-1 if mod in ("last", "previous") else 1))
-        target = add_months(base, shift)
+        target = add_months(base, _shift_for_modifier(mod))
         out = clamp_day(target.year, target.month, day)
         return out.isoformat() if return_iso else out
 
@@ -304,8 +318,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
     if m:
         day = _parse_ordinal_day(m.group(1))
         mod = _normalize_modifier(m.group(2))
-        shift = 0 if mod == "this" else (1 if mod in ("next", "coming") else -1)
-        target = add_months(base, shift)
+        target = add_months(base, _shift_for_modifier(mod))
         out = clamp_day(target.year, target.month, day)
         return out.isoformat() if return_iso else out
 
@@ -400,9 +413,8 @@ def _month_ref_to_year_month(text: str, base: date) -> tuple[int, int]:
     m = re.fullmatch(rf"{_MOD_GROUP}\s+month", s)
     if m:
         mod = _normalize_modifier(m.group(1))
-        shift = 0 if mod == "this" else (1 if mod in ("next", "coming") else -1)
         dt = date(base.year, base.month, 15)
-        dt2 = add_months(dt, shift)
+        dt2 = add_months(dt, _shift_for_modifier(mod))
         return dt2.year, dt2.month
 
     # explicit month (with optional modifier)
@@ -544,8 +556,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
         mod = _normalize_modifier(m.group(2))
 
         # Get target month
-        shift = 0 if mod == "this" else (1 if mod in ("next", "coming") else -1)
-        target = add_months(base, shift)
+        target = add_months(base, _shift_for_modifier(mod))
 
         start_date, end_date = _ordinal_week_boundaries(target.year, target.month, ordinal_str)
         out = _expand_span(start_date, end_date, None)


### PR DESCRIPTION
## Summary

Three identical inline expressions and one near-identical variant scattered across `parse_relative_date`, `_month_ref_to_year_month`, and `parse_relative_dates` were computing the same `(this/next/coming/last/previous) -> (0/+1/-1)` mapping. Extract `_shift_for_modifier(mod)` so the four call sites read as a one-liner and the mapping lives in one place.

The duplication was at lines 297, 307, 403, 547 in `relative_dates.py` (pre-refactor). Three were identical (`shift = 0 if mod == "this" else (1 if mod in ("next", "coming") else -1)`), and the fourth had a slightly different `else 1` default that was dead code in practice — `_MOD_GROUP` only matches the six tokens above and `_normalize_modifier` aliases `upcoming -> next`, so the unknown branch is never reached.

## Why it's safe

- All four call sites consume `_MOD_GROUP` matches that have been through `_normalize_modifier`, so `mod` is always one of `this`/`next`/`coming`/`last`/`previous`.
- For those inputs, the helper produces exactly the same mapping the inline expressions produced. The dead-code branch differences disappear with no observable effect.
- The `__main__` demo in `relative_dates.py` produces identical output before and after the refactor (smoke-tested locally, including `26th next month`, `next Jan` ordinal-week paths, and `the first/second week of …`).

## Test plan

- [x] `python navi_bench/relative_dates.py` — demo output unchanged
- [x] Spot-checked `_shift_for_modifier` directly: `this -> 0`, `next -> 1`, `coming -> 1`, `last -> -1`, `previous -> -1`

https://claude.ai/code/session_01E534qqE9ShTNuXaUZQLMMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01E534qqE9ShTNuXaUZQLMMF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes month-shift modifier mapping; behavior should remain unchanged but could affect parsing of month-relative phrases if the mapping is wrong.
> 
> **Overview**
> Refactors relative-date parsing to centralize the `(this|next|coming|last|previous)` → `(-1|0|+1)` month shift mapping into a new helper, `_shift_for_modifier()`.
> 
> Updates the month-relative parsing paths (e.g., `"<day> ... <mod> month"`, `"<mod> month"`, and `"<ordinal> week of <mod> month"`) to use the helper, removing duplicated inline logic and a previously inconsistent fallback branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b0c8c56a61de08aa2621f5cc9e0a727db03035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->