### PR TITLE
docs: rebrand "Yutori n1" to "Yutori Navigator" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ eval_result = await evaluator.compute()
 
 ## Evaluation
 
-We provide an evaluation script for the [Yutori n1](https://yutori.com/blog/introducing-navigator) model. You can use it as a reference for evaluating your own agents. The reference evaluator preserves the full saved trajectory for visualization while using the SDK's native n1 payload and coordinate helpers to keep the request history bounded and action execution aligned.
+We provide an evaluation script for the [Yutori Navigator](https://yutori.com/blog/introducing-navigator) model. You can use it as a reference for evaluating your own agents. The reference evaluator preserves the full saved trajectory for visualization while using the SDK's native n1 payload and coordinate helpers to keep the request history bounded and action execution aligned.
 
 ### Setup
 


### PR DESCRIPTION
## Summary\n\n- Fix stale \"Yutori n1\" product name in the Evaluation section of README.md to \"Yutori Navigator\"\n\n## Context\n\nfrontend-visualqa PR #64 completed the product rebrand from \"Yutori n1\" to \"Yutori Navigator\" (updating plugin.json, marketplace.json, SKILL.md, and pyproject.toml), but the navi-bench README was not updated at the same time. The link text `[Yutori n1]` in the Evaluation section still used the old name while linking to the correct `/blog/introducing-navigator` URL.\n\nNote: references to `eval_n1`, `results_n1/`, and `yutori.n1` are code/module identifiers, not product branding, and are intentionally left unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3kwEmXNHEoW6cgTJkikfP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates product branding with no code or behavior impact.
> 
> **Overview**
> Updates the README *Evaluation* section to refer to the model as **Yutori Navigator** instead of **Yutori n1**, keeping the existing link and surrounding guidance unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3710b251df9dbf59cf96ecb66150fbb43d2468a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->