### PR TITLE
docs: complete Navigator rebrand and fix deprecated SDK imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ eval_result = await evaluator.compute()
 
 ## Evaluation
 
-We provide an evaluation script for the [Yutori Navigator](https://yutori.com/blog/introducing-navigator) model. You can use it as a reference for evaluating your own agents. The reference evaluator preserves the full saved trajectory for visualization while using the SDK's native n1 payload and coordinate helpers to keep the request history bounded and action execution aligned.
+We provide an evaluation script for the [Yutori Navigator](https://yutori.com/blog/introducing-navigator) model. You can use it as a reference for evaluating your own agents. The reference evaluator preserves the full saved trajectory for visualization while using the SDK's native Navigator payload and coordinate helpers to keep the request history bounded and action execution aligned.
 
 ### Setup
 

--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Evaluate the Yutori n1 model on the Navi-Bench dataset (https://yutori.com/blog/introducing-navigator).
+Evaluate the Yutori Navigator model on the Navi-Bench dataset (https://yutori.com/blog/introducing-navigator).
 
 Authentication: either run `yutori auth login` (credentials are saved to ~/.yutori/config.json)
 or set the YUTORI_API_KEY environment variable. If both are present, the env var takes precedence.
@@ -66,7 +66,7 @@ from evaluation.stats import BaseTokenUsage, Crashed, TimingStats, log_section_h
 from navi_bench.base import BaseMetric, BaseTaskConfig, DatasetItem, instantiate
 from yutori import AsyncYutoriClient
 from yutori.auth import resolve_api_key
-from yutori.n1 import denormalize_coordinates, estimate_messages_size_bytes, trimmed_messages_to_fit
+from yutori.navigator import denormalize_coordinates, estimate_messages_size_bytes, trimmed_messages_to_fit
 
 RETRYABLE_API_ERRORS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -81,7 +81,7 @@ _CLICK_KWARGS: dict[str, dict[str, object]] = {
 
 
 class Config(BaseModel):
-    # Yutori n1 model API config
+    # Yutori Navigator model API config
     model_name: str = "n1-experimental"
     # Yutori Navi-Bench dataset config
     dataset_name: str = "yutori-ai/navi-bench"

--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -1,7 +1,7 @@
 import json
 from html import escape as _escape_html
 
-from yutori.n1 import N1_COORDINATE_SCALE
+from yutori.navigator import NAVIGATOR_COORDINATE_SCALE
 
 
 def _escape_json_for_script_tag(json_str: str) -> str:
@@ -74,8 +74,8 @@ def _anthropic_image_to_data_url(block: dict) -> str | None:
 
 def _get_action_marker_style(
     action: dict,
-    coord_space_width: int = N1_COORDINATE_SCALE,
-    coord_space_height: int = N1_COORDINATE_SCALE,
+    coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
+    coord_space_height: int = NAVIGATOR_COORDINATE_SCALE,
 ) -> dict:
     """Generate CSS positioning for action markers.
 
@@ -120,8 +120,8 @@ def generate_visualization_html(
     task_id: str,
     messages: list[dict],
     result: object | None,
-    coord_space_width: int = N1_COORDINATE_SCALE,
-    coord_space_height: int = N1_COORDINATE_SCALE,
+    coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
+    coord_space_height: int = NAVIGATOR_COORDINATE_SCALE,
 ) -> str:
     """Generate a static HTML file for visualizing the evaluation messages and result."""
 


### PR DESCRIPTION
## Summary
- **eval_n1.py**: Update "Yutori n1" branding to "Yutori Navigator" in docstring and comment; migrate deprecated `from yutori.n1 import ...` to `from yutori.navigator import ...`
- **vis.py**: Migrate `from yutori.n1 import N1_COORDINATE_SCALE` to `from yutori.navigator import NAVIGATOR_COORDINATE_SCALE` and update all 4 usage sites
- **README.md**: Fix remaining "SDK's native n1 payload" to "SDK's native Navigator payload"

PR #70 rebranded the README but these source files and import paths were missed.

## Test plan
- [ ] Verify `yutori.navigator` exports `denormalize_coordinates`, `estimate_messages_size_bytes`, `trimmed_messages_to_fit`, `NAVIGATOR_COORDINATE_SCALE`
- [ ] Grep for remaining "Yutori n1" references in non-historical files

https://claude.ai/code/session_014ReNVABatUmD6NqLFR8UF9

---
_Generated by [Claude Code](https://claude.ai/code/session_014ReNVABatUmD6NqLFR8UF9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: these are documentation text updates and import/constant renames to the new `yutori.navigator` module, with no behavioral changes expected beyond fixing breakage from deprecated paths.
> 
> **Overview**
> Updates remaining references from *n1* to **Navigator** across docs and evaluation tooling.
> 
> The eval script and visualization now import coordinate/payload helpers from `yutori.navigator` (including switching `N1_COORDINATE_SCALE` to `NAVIGATOR_COORDINATE_SCALE`), aligning the code with the rebranded SDK and removing deprecated `yutori.n1` imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b694bbdac5bdb6774a551d11a1e1ca22722bbf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->