### PR TITLE
refactor(evaluation/browser): hoist viewport dict to local variable

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -72,6 +72,7 @@ async def build_browser(
     context = None
 
     try:
+        viewport = {"width": config.browser_viewport_width, "height": config.browser_viewport_height}
         need_to_set_location = (
             "apartments.com" in task_config.url or "opentable.com" in task_config.url or "resy.com" in task_config.url
         )
@@ -91,7 +92,7 @@ async def build_browser(
 
         if use_local_browser:
             context_kwargs = {
-                "viewport": {"width": config.browser_viewport_width, "height": config.browser_viewport_height},
+                "viewport": viewport,
                 "timezone_id": task_config.user_metadata.timezone,
             }
             if need_to_set_location:
@@ -105,9 +106,7 @@ async def build_browser(
             if browser.contexts:
                 context = browser.contexts[0]
             else:
-                context = await browser.new_context(
-                    viewport={"width": config.browser_viewport_width, "height": config.browser_viewport_height}
-                )
+                context = await browser.new_context(viewport=viewport)
 
         async def handle_dialog(dialog):
             await dialog.accept()
@@ -126,10 +125,8 @@ async def build_browser(
             page = context.pages[0]
         else:
             page = await context.new_page()
-        if page.viewport_size != {"width": config.browser_viewport_width, "height": config.browser_viewport_height}:
-            await page.set_viewport_size(
-                {"width": config.browser_viewport_width, "height": config.browser_viewport_height}
-            )
+        if page.viewport_size != viewport:
+            await page.set_viewport_size(viewport)
 
         if need_to_set_location and not use_local_browser:
             try:


### PR DESCRIPTION
## Summary

`build_browser()` constructed the same `{"width": ..., "height": ...}` viewport dict from `config.browser_viewport_width` / `config.browser_viewport_height` **four** separate times in the same function:

1. Local-browser context kwargs
2. CDP-fallback `new_context()` call
3. Active-page viewport equality check (`page.viewport_size != {...}`)
4. `set_viewport_size({...})` call when (3) doesn't match

Hoisting it to a single `viewport` local at the top of the try block:

- eliminates the 4-way duplication
- makes the comparison `page.viewport_size != viewport` obviously correct (the comparison and the setter can't drift apart)
- makes `set_viewport_size(viewport)` read more naturally

## Why this is safe
- No behavior change. The four sites all built byte-identical dicts from the same two config values.
- Single-file change.
- Syntax-checked.

## Test plan
- [x] Syntax check
- [ ] Manual review of diff (4 sites collapse to 1 local var)

🤖 Automated refactor — generated by hourly refactor cron.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHhZCdfuqB9ddCxCgRVE9S)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only deduplicates viewport dict construction; behavior should remain identical aside from reducing chances of future drift.
> 
> **Overview**
> Refactors `build_browser()` in `evaluation/browser.py` to compute the Playwright `viewport` dict once and reuse it for context creation (local + CDP fallback) and for page viewport comparison/setting.
> 
> This removes repeated inline `{"width": ..., "height": ...}` literals without changing the browser setup flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aac7746235570a925ed25dfc8dfc0d4cc99d506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->