### PR TITLE
refactor(base): extract parse_filtered_query_params helper

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -1,13 +1,19 @@
 import json
 import re
 from typing import TypedDict
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import urlencode
 
 from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, basic_normalize_url, build_task_config
+from navi_bench.base import (
+    BaseMetric,
+    BaseTaskConfig,
+    basic_normalize_url,
+    build_task_config,
+    parse_filtered_query_params,
+)
 from navi_bench.dates import initialize_user_metadata
 
 
@@ -167,8 +173,7 @@ class ApartmentsUrlMatch(BaseMetric):
         path_parts = [part for part in parsed.path.split("/") if part]
         path_locations, non_location_path_parts = self._extract_locations_from_path(path_parts)
 
-        query_params = parse_qs(parsed.query)
-        query_params = {k: v for k, v in query_params.items() if k not in self.IGNORED_PARAMS}
+        query_params = parse_filtered_query_params(parsed.query, self.IGNORED_PARAMS)
         query_locations, normalized_params = self._extract_locations_from_query(query_params)
 
         # Combine all locations and sort for canonical representation

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable, TypeVar, Union, get_args, get_origin
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value
 from loguru import logger
@@ -61,6 +61,17 @@ def basic_normalize_url(url: str, target_domain: str) -> tuple[ParseResult | Non
             result += "?" + parsed.query
         return None, result.rstrip("/")
     return parsed, ""
+
+
+def parse_filtered_query_params(query: str, ignored: Iterable[str]) -> dict[str, list[str]]:
+    """Parse a URL query string and drop keys in ``ignored``.
+
+    Centralizes the ``parse_qs(...) -> dict-comp filter`` pattern that
+    domain matchers use to canonicalize URL state by stripping noise
+    parameters (e.g. tracking flags, trusted-source markers) before
+    comparison.
+    """
+    return {k: v for k, v in parse_qs(query).items() if k not in ignored}
 
 
 def omni_import(path: str):

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -1,11 +1,11 @@
 from typing import TypedDict
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, build_task_config
+from navi_bench.base import BaseMetric, BaseTaskConfig, build_task_config, parse_filtered_query_params
 from navi_bench.dates import initialize_user_metadata
 
 
@@ -79,10 +79,7 @@ class CraigslistUrlMatch(BaseMetric):
 
     @staticmethod
     def _parse_state(url: str) -> dict:
-        parsed_url = urlparse(url)
-        query_params = parse_qs(parsed_url.query)
-        query_params = {k: v for k, v in query_params.items() if k not in IGNORE_URL_PARAMS}
-        return query_params
+        return parse_filtered_query_params(urlparse(url).query, IGNORE_URL_PARAMS)
 
 
 def generate_task_config(


### PR DESCRIPTION
## Summary

Both `ApartmentsUrlMatch._normalize_url` and `CraigslistUrlMatch._parse_state` canonicalize URLs by parsing the query string and dropping a tuple of ignored keys (apartments: `io`/`ss`; craigslist: `isTrusted`). Each used the same two-line `parse_qs(...) + dict-comp filter` idiom.

Move that idiom into `navi_bench/base.parse_filtered_query_params` alongside `basic_normalize_url` so future domain matchers can reach for the helper instead of re-implementing it. Each call site now reads as a single line:

```python
parse_filtered_query_params(parsed.query, IGNORED_PARAMS)
```

## Why this is safe

- `parse_qs` is invoked with the same default arguments at the new site.
- The same key-membership filter (`if k not in ignored`) is applied.
- The Craigslist file no longer needs a direct `parse_qs` import — `urlparse` is still imported for the `urlparse(url).query` usage.

## Test plan

- [ ] No tests exist in this repo, but the refactor is purely a textual extraction with identical semantics; `parse_qs` and dict comprehension behavior are unchanged.

https://claude.ai/code/session_019nWZEaJmmzuiCsrU7JK1j8

---
_Generated by [Claude Code](https://claude.ai/code/session_019nWZEaJmmzuiCsrU7JK1j8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes URL query parsing/filtering without changing comparison logic; main risk is subtle behavioral drift if call sites relied on local `parse_qs` usage, but semantics appear identical.
> 
> **Overview**
> **Refactors URL canonicalization** by adding `parse_filtered_query_params` to `navi_bench/base.py` to encapsulate the common `parse_qs` + ignored-key filtering pattern.
> 
> Updates the Apartments and Craigslist URL matchers to call this helper instead of inlining query parsing/filtering, and cleans up related imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83548ea536b8744bbb107197c23b852b11afce01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->