### PR TITLE
Consolidate duplicated InputDict TypedDict into base.UrlMetricInput

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -1,6 +1,5 @@
 import json
 import re
-from typing import TypedDict
 from urllib.parse import urlencode
 
 from beartype import beartype
@@ -10,15 +9,12 @@ from pydantic import BaseModel
 from navi_bench.base import (
     BaseMetric,
     BaseTaskConfig,
+    UrlMetricInput,
     basic_normalize_url,
     build_task_config,
     parse_filtered_query_params,
 )
 from navi_bench.dates import initialize_user_metadata
-
-
-class InputDict(TypedDict, total=False):
-    url: str
 
 
 class FinalResult(BaseModel):
@@ -45,7 +41,7 @@ class ApartmentsUrlMatch(BaseMetric):
         self._found_match = False
 
     async def update(self, **kwargs) -> None:
-        inputs: InputDict = kwargs
+        inputs: UrlMetricInput = kwargs
         url = inputs["url"]
 
         # Normalize the state URL

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -6,7 +6,7 @@ import types
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Iterable, TypeVar, Union, get_args, get_origin
+from typing import Any, Awaitable, Callable, Iterable, TypedDict, TypeVar, Union, get_args, get_origin
 from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value
@@ -257,6 +257,17 @@ def build_task_config(
 ) -> BaseTaskConfig:
     eval_config = {"_target_": get_import_path(eval_class), **eval_kwargs}
     return BaseTaskConfig(url=url, task=task, user_metadata=user_metadata, eval_config=eval_config)
+
+
+class UrlMetricInput(TypedDict, total=False):
+    """Shared `update(**kwargs)` payload for URL-based metrics.
+
+    Domain matchers that branch on the visited browser URL alone (e.g. apartments,
+    craigslist, google_flights) declare their `update` kwargs as this type so the
+    contract is captured in one place.
+    """
+
+    url: str
 
 
 class BaseMetric:

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -1,19 +1,20 @@
-from typing import TypedDict
 from urllib.parse import urlparse
 
 from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, build_task_config, parse_filtered_query_params
+from navi_bench.base import (
+    BaseMetric,
+    BaseTaskConfig,
+    UrlMetricInput,
+    build_task_config,
+    parse_filtered_query_params,
+)
 from navi_bench.dates import initialize_user_metadata
 
 
 IGNORE_URL_PARAMS = ("isTrusted",)
-
-
-class InputDict(TypedDict, total=False):
-    url: str
 
 
 class FinalResult(BaseModel):
@@ -44,7 +45,7 @@ class CraigslistUrlMatch(BaseMetric):
         self._intermediate_url_to_state = {}
 
     async def update(self, **kwargs) -> None:
-        inputs: InputDict = kwargs
+        inputs: UrlMetricInput = kwargs
         url = inputs["url"]
         if url not in self._intermediate_url_to_state:
             state = self._parse_state(url)

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -3,13 +3,13 @@ import binascii
 import urllib.parse
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, TypedDict
+from typing import Any
 
 from beartype import beartype
 from loguru import logger
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, build_task_config
+from navi_bench.base import BaseMetric, BaseTaskConfig, UrlMetricInput, build_task_config
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 from navi_bench.google_flights.google_flights_pb2 import Info
 
@@ -20,10 +20,6 @@ Ensure that google_flights_pb2 is compiled from google_flights.proto.
 cd navi_bench/google_flights
 protoc --python_out=. google_flights.proto
 """
-
-
-class InputDict(TypedDict, total=False):
-    url: str
 
 
 class FinalResult(BaseModel):
@@ -135,7 +131,7 @@ class GoogleFlightsSearchMatch(BaseMetric):
         self._url_to_flight_info = defaultdict(Info)
 
     async def update(self, **kwargs) -> None:
-        inputs: InputDict = kwargs
+        inputs: UrlMetricInput = kwargs
         url = inputs.get("url")
         if url and url not in self._url_to_flight_info:
             flight_info = self._decode_google_flights_url(url)
@@ -274,7 +270,7 @@ if __name__ == "__main__":
         "l1_category": "travel",
         "l2_category": "flight_search_budget",
         "suggested_split": "validation",
-        "suggested_difficulty": None,
+        "suggested_difficulty": null,
     }
 
     print_dataset_demo(dataset_row)

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -270,7 +270,7 @@ if __name__ == "__main__":
         "l1_category": "travel",
         "l2_category": "flight_search_budget",
         "suggested_split": "validation",
-        "suggested_difficulty": null,
+        "suggested_difficulty": None,
     }
 
     print_dataset_demo(dataset_row)


### PR DESCRIPTION
## Summary

Three URL-based domain matchers (`apartments`, `craigslist`, `google_flights`) each defined an identical `class InputDict(TypedDict, total=False): url: str` locally, used only to type-hint the `**kwargs` parameter of their `update()` method.

This PR moves the shared shape into `navi_bench/base.py` as `UrlMetricInput` so the input contract for URL-only metrics lives in one place.

## Why this is a structural improvement

- Removes copy/paste duplication across three modules.
- Makes the URL-input contract discoverable from `base.py` alongside `BaseMetric`, so anyone adding a new URL-only matcher has one canonical type to reuse.
- Drops the per-module `from typing import TypedDict` import in two of the three files.

## Why it's safe

- `TypedDict` is purely a type alias used at static-check time; renaming it has no runtime effect.
- `InputDict` was never imported across module boundaries (each file declared its own private copy), so there are no external call sites to update.
- Three modules are intentionally **not** touched:
  - `resy/resy_url_match.py` and `opentable/opentable_info_gathering.py` accept a playwright `Page` in addition to (or instead of) a URL — their input shapes are genuinely different.
  - `craigslist`'s `FinalResult` has an extra `reasoning` field, so only its `InputDict` is consolidated; its `FinalResult` stays as-is.
- Verified by re-running the existing `__main__` demos in all three modules and exercising `update()`/`compute()` paths in a small async harness.

## Files

- `navi_bench/base.py` — add `UrlMetricInput`
- `navi_bench/apartments/apartments_url_match.py` — drop local `InputDict`, import shared
- `navi_bench/craigslist/craigslist_url_match.py` — drop local `InputDict`, import shared
- `navi_bench/google_flights/google_flights_search_match.py` — drop local `InputDict`, import shared

## Test plan

- [x] `python -c "import ast; [ast.parse(open(p).read()) for p in [...]]"` — all four files parse.
- [x] `python -m navi_bench.apartments.apartments_url_match` — demo runs.
- [x] `python -m navi_bench.craigslist.craigslist_url_match` — demo runs.
- [x] `python -m navi_bench.google_flights.google_flights_search_match` — demo runs.
- [x] Async harness instantiates each matcher, calls `update(url=...)` and `compute()`, asserts expected scores (1.0 for matching URL, 0.0 for non-matching).

https://claude.ai/code/session_01GYsPJ7zzgh9dz6WprFVtsD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYsPJ7zzgh9dz6WprFVtsD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes type hints/imports for URL-based metrics and should not affect runtime behavior. Risk is limited to potential typing/linters or minor import issues.
> 
> **Overview**
> Consolidates the duplicated per-metric `InputDict` `TypedDict` into a single shared `UrlMetricInput` in `navi_bench/base.py` to standardize the `update(**kwargs)` payload for URL-only matchers.
> 
> Updates the `apartments`, `craigslist`, and `google_flights` URL match metrics to import and use `UrlMetricInput`, removing their local `TypedDict` definitions and related imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4136b9481923c33897353b5742a824e18e5308b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->