### PR TITLE
refactor: import log_formatter from yutori SDK

### DIFF
--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -9,32 +9,15 @@ from typing import TypeVar
 import aiofiles
 from loguru import logger
 from pydantic import BaseModel
+from yutori.navigator.replay import log_formatter
 
 from evaluation.stats import TimingStats
 from evaluation.vis import generate_visualization_html
 from navi_bench.base import get_import_path, instantiate
 
+__all__ = ["Recorder", "log_formatter"]
+
 T = TypeVar("T")
-
-
-def log_formatter(record: dict, *, colorize: bool = True) -> str:
-    """Format log messages. Used by both global and task-specific log handlers."""
-
-    def wrap(text: str, color: str) -> str:
-        return f"<{color}>{text}</{color}>" if colorize else text
-
-    extra = record["extra"]
-    parts = [
-        wrap("{time:YYYY-MM-DD HH:mm:ss.SSS}", "green"),
-        wrap("{level: <8}", "level"),
-        f"{wrap('{file}', 'cyan')}:{wrap('{line}', 'cyan')}",
-    ]
-    if "task_id" in extra:
-        parts.append(wrap("{extra[task_id]}", "magenta"))
-    if "attempt" in extra:
-        parts.append(wrap("{extra[attempt]}", "blue"))
-    parts.append(wrap("{message}", "level"))
-    return " | ".join(parts) + "\n{exception}"
 
 
 class Recorder:


### PR DESCRIPTION
## Summary

`evaluation/recorder.py` carries a local copy of `log_formatter` that is byte-for-byte equivalent to `yutori.navigator.replay.log_formatter` (the SDK function it predates). This PR removes the local definition and re-exports the SDK helper so the two implementations cannot drift.

- ~17 lines of duplicated logic removed.
- Re-export preserved via `__all__`, so `from evaluation.recorder import Recorder, log_formatter` in `evaluation/eval_n1.py` keeps working unchanged.
- No behavior change: both versions emit the same loguru format string for the same `record["extra"]` keys (`task_id`, `attempt`).

## Why it's safe

The local function and the SDK function were verified identical (only their docstrings differ). The SDK consolidated the dual-branch colorize pattern in yutori-ai/yutori-sdk-python#94, and any older yutori build that exposes `yutori.navigator` already exposes `yutori.navigator.replay.log_formatter` with the same output contract.

## Test plan

- [ ] `ruff check evaluation/recorder.py` — passes locally.
- [ ] `ruff format --check evaluation/recorder.py` — passes locally.
- [ ] Sanity import (`from evaluation.recorder import Recorder, log_formatter`) succeeds against the published yutori 0.7.4.
- [ ] CI tests on this PR.

https://claude.ai/code/session_01G3xR5tBJV26FQz8GVSdzxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3xR5tBJV26FQz8GVSdzxm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that should preserve log output, but it does introduce a dependency on the presence/behavior of `yutori.navigator.replay.log_formatter` in the installed SDK version.
> 
> **Overview**
> Replaces `evaluation/recorder.py`’s local `log_formatter` implementation with an import from `yutori.navigator.replay`, and re-exports it via `__all__` so existing imports like `from evaluation.recorder import Recorder, log_formatter` keep working.
> 
> This removes duplicated formatting logic while keeping the same call sites (e.g., `functools.partial(log_formatter, colorize=...)`) intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91dedfadeb5c6c215739eb99c74e6a8fcb17756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->