### PR TITLE
refactor(dates): collapse duplicate dynamic-offset regex match

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -32,16 +32,6 @@ _DYNAMIC_OFFSET_PATTERN = re.compile(
 )
 
 
-def _is_dynamic_offset(text: str) -> bool:
-    """Return True if ``text`` is a ``{now() + timedelta(...)}`` dynamic expression.
-
-    Centralizes the predicate used both to dispatch inside
-    ``resolve_placeholder_values`` and to choose the post-processing
-    branch in ``initialize_placeholder_map``.
-    """
-    return _DYNAMIC_OFFSET_PATTERN.fullmatch(text.strip()) is not None
-
-
 def _ordinal_suffix(value: int) -> str:
     """Return the ordinal suffix for a day number."""
     if 10 <= value % 100 <= 20:
@@ -117,9 +107,10 @@ def _get_validated_option(
 def resolve_placeholder_values(
     text: str,
     base_date: date,
-) -> tuple[str, list[str]]:
+) -> tuple[str, list[str], bool]:
     """
-    Resolve a placeholder description into the user-facing text and ISO dates.
+    Resolve a placeholder description into the user-facing text, ISO dates, and a
+    flag indicating whether the input was a dynamic offset expression.
 
     Supports literal descriptions understood by parse_relative_dates as well as the
     dynamic syntax {now() + timedelta(start, end)} where start/end are inclusive offsets and optional options.
@@ -130,6 +121,8 @@ def resolve_placeholder_values(
         - range: "endpoints" or "all"
         - year: "set" or "none"
 
+    The third tuple element (``is_dynamic``) tells callers which branch produced
+    the result so they don't need to re-run the regex to dispatch on it.
     """
     stripped = text.strip()
 
@@ -169,11 +162,11 @@ def resolve_placeholder_values(
         description = (
             prefix + _format_placeholder_span(start_date, end_date, month_style=month_style, year_style=year_style)
         ).strip()
-        return description, iso_dates
+        return description, iso_dates, True
 
     # Fallback to string parsing
     dates = parse_relative_dates(text, base=base_date, return_iso=True)
-    return text, dates
+    return text, dates, False
 
 
 def render_task_statement(task: str, resolved_placeholders: dict[str, tuple[str, list[str]]]) -> str:
@@ -213,9 +206,9 @@ def initialize_placeholder_map(
 
     placeholder_map = {}
     for placeholder_key, relative_description in values.items():
-        resolved_desc, iso_dates = resolve_placeholder_values(relative_description, base_date)
+        resolved_desc, iso_dates, is_dynamic = resolve_placeholder_values(relative_description, base_date)
 
-        if _is_dynamic_offset(relative_description):
+        if is_dynamic:
             # Dynamic expressions are always correct; just filter past dates
             today = base_date.isoformat()
             iso_dates = [d for d in iso_dates if d >= today]


### PR DESCRIPTION
## Summary

`navi_bench/dates.py` had two call sites running `_DYNAMIC_OFFSET_PATTERN.fullmatch` against the same input:

1. `resolve_placeholder_values()` matches the regex to dispatch between the dynamic-offset branch and the `parse_relative_dates` fallback.
2. `initialize_placeholder_map()` then calls `_is_dynamic_offset()` (a thin wrapper around the same regex match) on the same string to pick its post-processing branch.

That duplicates the dispatch predicate across two call sites. If anyone updates the dispatch logic in one place — say, to recognise an additional dynamic syntax — the other place silently drifts.

This PR has `resolve_placeholder_values` return the dispatch flag alongside its result, removes the now-unused `_is_dynamic_offset` helper, and consumes the flag in `initialize_placeholder_map`.

## Why it's safe

- No behavior change. The branches in `initialize_placeholder_map` still gate on whether the input matched `_DYNAMIC_OFFSET_PATTERN.fullmatch(text.strip())`; they just read the flag from the return value instead of re-running the same regex.
- `resolve_placeholder_values` is at module level, but a code search found it called only from `dates.py` itself (`initialize_placeholder_map`), and `_is_dynamic_offset` was only called from the same function. The 2-tuple → 3-tuple signature change touches a single call site.
- `_is_dynamic_offset` deletion is safe: no other reference in the repo.

## Test plan

- [ ] CI passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01AjBZL9sr9v4UKvbvPRjp9o)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `navi_bench/dates.py`, but it changes the `resolve_placeholder_values` return signature, so any external callers would break if they exist.
> 
> **Overview**
> **Eliminates duplicated dynamic-offset detection** by removing `_is_dynamic_offset` and having `resolve_placeholder_values` return a third value (`is_dynamic`) alongside the description and ISO dates.
> 
> `initialize_placeholder_map` now uses this returned flag to decide whether to filter past dates (dynamic expressions) vs. run the existing normalization/bump logic (string-parsed dates), avoiding a second `_DYNAMIC_OFFSET_PATTERN.fullmatch` call on the same input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f483f08736c0e22bb8ace7f607e706951ae4f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->