### PR TITLE
refactor(eval_n1): consolidate scroll-direction branches into dispatch table

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -79,6 +79,15 @@ _CLICK_KWARGS: dict[str, dict[str, object]] = {
     "right_click": {"button": "right"},
 }
 
+# Unit (dx, dy) vectors for the four scroll directions, scaled by ``abs(amount)``
+# at the call site. Mirrors the dispatch-table style used by ``_CLICK_KWARGS``.
+_SCROLL_VECTORS: dict[str, tuple[int, int]] = {
+    "up": (0, -1),
+    "down": (0, 1),
+    "left": (-1, 0),
+    "right": (1, 0),
+}
+
 
 class Config(BaseModel):
     # Yutori Navigator model API config
@@ -202,16 +211,11 @@ Today is: {dt.strftime("%A")}"""
 
             elif name == "scroll":
                 await page.mouse.move(*_denorm(arguments["coordinates"]))
-                scroll_amount = arguments["amount"] * 84
-                direction = arguments["direction"]
-                if direction == "up":
-                    await page.mouse.wheel(0, -abs(scroll_amount))
-                elif direction == "down":
-                    await page.mouse.wheel(0, abs(scroll_amount))
-                elif direction == "left":
-                    await page.mouse.wheel(-abs(scroll_amount), 0)
-                elif direction == "right":
-                    await page.mouse.wheel(abs(scroll_amount), 0)
+                vector = _SCROLL_VECTORS.get(arguments["direction"])
+                if vector is not None:
+                    magnitude = abs(arguments["amount"] * 84)
+                    dx, dy = vector
+                    await page.mouse.wheel(dx * magnitude, dy * magnitude)
 
             elif name == "type":
                 if arguments.get("clear_before_typing", True):


### PR DESCRIPTION
## What

`_execute()` in `evaluation/eval_n1.py` dispatched the `scroll` action via a 4-branch `if/elif` on `direction`, with each branch repeating the `abs(scroll_amount)` × axis-vector pattern verbatim:

```python
elif name == "scroll":
    await page.mouse.move(*_denorm(arguments["coordinates"]))
    scroll_amount = arguments["amount"] * 84
    direction = arguments["direction"]
    if direction == "up":
        await page.mouse.wheel(0, -abs(scroll_amount))
    elif direction == "down":
        await page.mouse.wheel(0, abs(scroll_amount))
    elif direction == "left":
        await page.mouse.wheel(-abs(scroll_amount), 0)
    elif direction == "right":
        await page.mouse.wheel(abs(scroll_amount), 0)
```

This PR replaces the if/elif with a module-level dispatch table:

```python
_SCROLL_VECTORS: dict[str, tuple[int, int]] = {
    "up": (0, -1), "down": (0, 1), "left": (-1, 0), "right": (1, 0),
}
...
elif name == "scroll":
    await page.mouse.move(*_denorm(arguments["coordinates"]))
    vector = _SCROLL_VECTORS.get(arguments["direction"])
    if vector is not None:
        magnitude = abs(arguments["amount"] * 84)
        dx, dy = vector
        await page.mouse.wheel(dx * magnitude, dy * magnitude)
```

## Why this is an improvement

- Mirrors the dispatch-table pattern already used by `_CLICK_KWARGS` directly above (and noted explicitly in PR #57). Membership-driven dispatch is the established style for this `_execute()` body.
- Collapses 4 redundant `abs(...)` calls and 4 separate `mouse.wheel` calls into one. Adding diagonal scroll directions later is a one-line table edit.
- Surfaces the (dx, dy) unit-vector structure as data instead of repeated branches.

## Why it's safe

- 1 file. 1 deletion + 1 addition net.
- Verified equivalent behavior for all four documented directions: same `abs(...)` magnitude, same axis sign.
- Unknown direction handling is preserved exactly. The original if/elif silently skipped unknown directions; the new code uses `dict.get(...)` + `is not None` guard, also a silent no-op. (Using `_SCROLL_VECTORS[direction]` directly would have raised `KeyError` — that would be a behavior change, so I deliberately did not.)
- `magnitude` is computed only when the direction is known, mirroring the original (the `mouse.move(...)` that runs unconditionally is unchanged).

## Test plan

- [x] `python -m py_compile evaluation/eval_n1.py` passes
- [ ] CI runs the existing test suite

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018pmZogAT3nBVaRE3sEPFjf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `evaluation/eval_n1.py` that rewrites scroll dispatch logic without changing supported directions or error handling semantics.
> 
> **Overview**
> Simplifies `eval_n1._execute()` scroll handling by replacing the `direction` `if/elif` chain with a module-level `_SCROLL_VECTORS` dispatch table and a single `page.mouse.wheel()` call computed from a direction vector and magnitude.
> 
> Behavior for the four supported directions remains equivalent, while unknown directions continue to no-op via a `dict.get()` guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a5ecabd5b0f43bf5890bcd417d6809778dd408a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->