### PR TITLE
refactor(opentable): hoist shared iteration in evidence handlers

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -2,8 +2,9 @@ import functools
 import itertools
 import random
 import re
+from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Literal
+from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
 from beartype import beartype
@@ -134,6 +135,38 @@ class OpenTableInfoGathering(BaseMetric):
             return False
         return target_restaurant in (name.lower() for name in query_names)
 
+    def _mark_uncovered_queries_with_unconditional_evidence(
+        self,
+        *,
+        restaurant: str,
+        condition_key: str,
+        all_satisfy: Callable[[Any], bool],
+        on_covered: Callable[[int, MultiCandidateQuery], None],
+    ) -> None:
+        """Mark uncovered queries as covered when an evidence item rules them out unconditionally.
+
+        For each uncovered query, look for an alternative condition that
+        (a) names ``restaurant`` explicitly and (b) has every value under
+        ``condition_key`` satisfying ``all_satisfy``. The first match marks
+        the query covered and invokes ``on_covered(i, alternative_condition)``
+        so callers can emit their domain-specific log line.
+
+        Used by ``_handle_too_far_in_advance`` (``condition_key="dates"``) and
+        ``_handle_party_too_small_or_too_large`` (``condition_key="party_sizes"``)
+        which share this iteration shape and only differ in the value predicate
+        and the log line.
+        """
+        for i, alternative_conditions in enumerate(self.queries):
+            if self._is_query_covered[i]:
+                continue
+            for alternative_condition in alternative_conditions:
+                if not self._condition_matches_restaurant(alternative_condition, restaurant):
+                    continue
+                if (values := alternative_condition.get(condition_key)) and all(all_satisfy(v) for v in values):
+                    on_covered(i, alternative_condition)
+                    self._is_query_covered[i] = True
+                    break
+
     def _handle_too_far_in_advance(self, info: InfoDict) -> None:
         """Handle cases where dates are too far in advance to book.
 
@@ -145,24 +178,18 @@ class OpenTableInfoGathering(BaseMetric):
 
         logger.info(f"OpenTableInfoGathering found 'too far in advance' for {too_far_restaurant} on {too_far_date}")
 
-        for i, alternative_conditions in enumerate(self.queries):
-            if self._is_query_covered[i]:
-                continue
+        def _on_covered(i: int, alternative_condition: MultiCandidateQuery) -> None:
+            logger.info(
+                f"OpenTableInfoGathering marking query {i} as covered due to too far in advance: "
+                f"{alternative_condition=}, all dates >= {too_far_date}"
+            )
 
-            # Check if ANY alternative condition can be satisfied by this "too far in advance" evidence
-            for alternative_condition in alternative_conditions:
-                if not self._condition_matches_restaurant(alternative_condition, too_far_restaurant):
-                    continue
-
-                # Check if ALL dates in this alternative condition are >= too_far_date
-                if query_dates := alternative_condition.get("dates"):
-                    if all(date >= too_far_date for date in query_dates):
-                        logger.info(
-                            f"OpenTableInfoGathering marking query {i} as covered due to too far in advance: "
-                            f"{alternative_condition=}, all dates >= {too_far_date}"
-                        )
-                        self._is_query_covered[i] = True
-                        break
+        self._mark_uncovered_queries_with_unconditional_evidence(
+            restaurant=too_far_restaurant,
+            condition_key="dates",
+            all_satisfy=lambda d: d >= too_far_date,
+            on_covered=_on_covered,
+        )
 
     def _handle_party_too_small_or_too_large(self, info: InfoDict, issue: str = "too small") -> None:
         """Handle cases where the party is too small or too large to book.
@@ -178,28 +205,22 @@ class OpenTableInfoGathering(BaseMetric):
             f"{party_issue_restaurant} with party size {party_issue_size}"
         )
 
-        for i, alternative_conditions in enumerate(self.queries):
-            if self._is_query_covered[i]:
-                continue
-            # Check if ANY alternative condition can be satisfied by this party too small/large evidence
-            for alternative_condition in alternative_conditions:
-                if not self._condition_matches_restaurant(alternative_condition, party_issue_restaurant):
-                    continue
+        op = "<=" if issue == "too small" else ">="
+        all_satisfy = (lambda s: s <= party_issue_size) if issue == "too small" else (lambda s: s >= party_issue_size)
 
-                # Check if ALL party sizes in this alternative condition are
-                # <= party_issue_size (if too small) or >= party_issue_size (if too large)
-                if query_party_sizes := alternative_condition.get("party_sizes"):
-                    if all(
-                        party_size <= party_issue_size if issue == "too small" else party_size >= party_issue_size
-                        for party_size in query_party_sizes
-                    ):
-                        logger.info(
-                            f"OpenTableInfoGathering marking query {i} as covered due to party {issue}: "
-                            f"{alternative_condition=}, "
-                            f"all party sizes {'<=' if issue == 'too small' else '>='} {party_issue_size}"
-                        )
-                        self._is_query_covered[i] = True
-                        break
+        def _on_covered(i: int, alternative_condition: MultiCandidateQuery) -> None:
+            logger.info(
+                f"OpenTableInfoGathering marking query {i} as covered due to party {issue}: "
+                f"{alternative_condition=}, "
+                f"all party sizes {op} {party_issue_size}"
+            )
+
+        self._mark_uncovered_queries_with_unconditional_evidence(
+            restaurant=party_issue_restaurant,
+            condition_key="party_sizes",
+            all_satisfy=all_satisfy,
+            on_covered=_on_covered,
+        )
 
     async def compute(self) -> FinalResult:
         # At the end, for each uncovered query, check if we have exhausted searching for all the alternative conditions


### PR DESCRIPTION
## What

`_handle_too_far_in_advance` and `_handle_party_too_small_or_too_large` in `OpenTableInfoGathering` had identical iteration shapes:

- enumerate `self.queries`, skip already-covered queries
- inner-loop over alternative conditions, gate on `_condition_matches_restaurant`
- pull a list under a fixed key (`"dates"` / `"party_sizes"`)
- if every value satisfies the predicate, log + mark covered + break out of the inner loop

The two methods only differed in the value predicate, the condition key, and the log line. Extracted the shared loop into `_mark_uncovered_queries_with_unconditional_evidence(...)` and parameterized the three variations via `condition_key`, `all_satisfy`, and `on_covered`.

## Why

These two handlers will keep growing in lockstep — any future "evidence rules out a query unconditionally" pattern (e.g. a restaurant closed on a holiday, a minimum-spend gate) will want the same iteration shape. Centralizing the loop:

- removes the drift risk between the two existing handlers (today they already share a subtle invariant: `break` only exits the inner loop, the outer loop must keep checking other queries — easy to mis-edit on either side without the other),
- makes the per-handler bodies expose only what's actually different (predicate + condition key + log).

## Why it's safe

Pure structural refactor — no behavior change:

- Inner control flow is identical: same `_is_query_covered[i]` skip, same `_condition_matches_restaurant` gate, same walrus on `alternative_condition.get(condition_key)`, same `all(...)` on the values, same break-on-first-match.
- Predicate semantics preserved:
  - too-far: `lambda d: d >= too_far_date` ≡ inline `date >= too_far_date`.
  - party: `(lambda s: s <= party_issue_size) if issue == "too small" else (lambda s: s >= party_issue_size)` ≡ inline `party_size <= party_issue_size if issue == "too small" else party_size >= party_issue_size`.
- Log messages are byte-identical. Verified end-to-end with a smoke test (run locally) covering: all-match coverage, partial-match (one date earlier than `too_far_date` ⇒ not covered), missing condition key (`dates` absent ⇒ not covered), missing `restaurant_names` (no restaurant gate ⇒ not covered), party `too small`/`too large` op flip.
- Re-imports were limited to `collections.abc.Callable` and `typing.Any` for the new helper signature; the only existing typing import (`Literal`) is still used.

## Test plan

- [x] Module imports cleanly (`python3 -c 'import navi_bench.opentable.opentable_info_gathering'`)
- [x] `python3 -m navi_bench.opentable.opentable_info_gathering` demo still loads/instantiates the evaluator unchanged
- [x] Smoke test: 6 assertions across the cases above, all pass with byte-identical log output
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated by automated refactor cron.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NATtJmHK6whNznT2ba4NqP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes duplicated query-coverage iteration; main risk is any subtle behavior drift in coverage marking or logging for edge cases.
> 
> **Overview**
> Refactors `OpenTableInfoGathering` to centralize the shared “unconditional evidence marks a query covered” iteration into `_mark_uncovered_queries_with_unconditional_evidence()`.
> 
> `_handle_too_far_in_advance` and `_handle_party_too_small_or_too_large` now call this helper with a condition key (`dates`/`party_sizes`), a predicate, and a logging callback, and the module adds `Callable`/`Any` typing imports to support the helper signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb34341cfb8857bf278b1a795339a328904da01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->