### PR TITLE
refactor(eval_n1): split retry except chain to drop isinstance dispatch

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -355,10 +355,12 @@ Today is: {dt.strftime("%A")}"""
 
             except OpenAIAuthError:
                 raise
-            except Exception as e:
+            except RETRYABLE_API_ERRORS:
+                await _sleep_or_reraise(attempt, content)
+            except APIStatusError:
                 # Non-retryable APIStatusError subclasses (e.g. BadRequestError) should propagate.
-                if isinstance(e, APIStatusError) and not isinstance(e, RETRYABLE_API_ERRORS):
-                    raise
+                raise
+            except Exception:
                 await _sleep_or_reraise(attempt, content)
 
     while step_idx < config.eval_max_steps:


### PR DESCRIPTION
## Summary

The retry except block in `_predict` (`evaluation/eval_n1.py` lines 356–362) caught broad `Exception` and then used `isinstance(e, APIStatusError)` / `isinstance(e, RETRYABLE_API_ERRORS)` to decide whether to re-raise or back off. Two sibling except chains in the same file (lines 404–411 in `run_agent` and 480–488 in `run_task`) already split the same logic into separate except clauses without `isinstance` dispatch.

This PR rewrites the `_predict` block to match the sibling style:

```python
except OpenAIAuthError:
    raise
except RETRYABLE_API_ERRORS:
    await _sleep_or_reraise(attempt, content)
except APIStatusError:
    raise
except Exception:
    await _sleep_or_reraise(attempt, content)
```

## Why it's safe

Behavior is preserved because:

- `OpenAIAuthError` (a subclass of `APIStatusError`) is still matched first → re-raise.
- `RETRYABLE_API_ERRORS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)` is matched next → backoff. Two of these (`RateLimitError`, `InternalServerError`) are subclasses of `APIStatusError`, but ordering means the retryable tuple wins over the bare `APIStatusError` clause.
- Other `APIStatusError` subclasses (e.g. `BadRequestError`, `NotFoundError`) → re-raise (matches the old `isinstance(e, APIStatusError) and not isinstance(e, RETRYABLE_API_ERRORS)` branch).
- Any other `Exception` (e.g. `asyncio.TimeoutError`) → backoff (matches the old fallthrough).

Net diff: +5/-3 in one file.

## Test plan

- [ ] CI green

https://claude.ai/code/session_01GpRd9nGPhcBe3Ncj9gzCee

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpRd9nGPhcBe3Ncj9gzCee)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to retry/propagation branching; main concern is subtle changes in which OpenAI exceptions are retried vs re-raised due to `except` ordering.
> 
> **Overview**
> Updates `_predict`’s retry loop in `evaluation/eval_n1.py` to split the broad `except Exception` + `isinstance` checks into explicit `except RETRYABLE_API_ERRORS`, `except APIStatusError`, and fallback `except Exception` clauses.
> 
> This keeps auth errors and non-retryable `APIStatusError`s propagating immediately while routing retryable API failures and other exceptions through the existing backoff helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e257249c2151d2f813c332c33c3b1a8722ccd082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->