### PR TITLE
refactor(resy): route task config construction through build_task_config

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -18,7 +18,7 @@ from navi_bench.base import (
     BaseTaskConfig,
     UserMetadata,
     basic_normalize_url,
-    get_import_path,
+    build_task_config,
     read_sidecar,
 )
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
@@ -1013,11 +1013,13 @@ def generate_task_config_random(
         f"https://resy.com/cities/{city_slug}/venues/{venue_slug}?date={date_str}&seats={party_size}&time={time_hhmm}"
     )
 
-    # Create evaluator config
-    eval_target = get_import_path(ResyUrlMatch)
-    eval_config = {"_target_": eval_target, "queries": [[resy_url]]}
-
-    return BaseTaskConfig(url=url, task=task_description, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=task_description,
+        user_metadata=user_metadata,
+        eval_class=ResyUrlMatch,
+        eval_kwargs={"queries": [[resy_url]]},
+    )
 
 
 def _render_placeholders_in_queries_any(
@@ -1122,10 +1124,13 @@ def generate_task_config_deterministic(
     else:
         raise ValueError(f"Invalid mode: {mode}")
 
-    eval_target = get_import_path(ResyUrlMatch)
-    eval_config = {"_target_": eval_target, "queries": queries}
-
-    return BaseTaskConfig(url=url, task=rendered_task, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=rendered_task,
+        user_metadata=user_metadata,
+        eval_class=ResyUrlMatch,
+        eval_kwargs={"queries": queries},
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Structural issue

`navi_bench/base.py::build_task_config(...)` already centralizes the pattern

```python
eval_config = {"_target_": get_import_path(eval_class), **eval_kwargs}
return BaseTaskConfig(url=..., task=..., user_metadata=..., eval_config=eval_config)
```

…and every other navi-bench domain matcher routes through it:

- `apartments/apartments_url_match.py::generate_task_config`
- `craigslist/craigslist_url_match.py::generate_task_config`
- `google_flights/google_flights_search_match.py` (similar pattern)
- `opentable/opentable_info_gathering.py` (similar pattern)

The two builders in `resy/resy_url_match.py` (`generate_task_config_random` and `generate_task_config_deterministic`) were the only holdouts — both hand-rolled the eval_config dict and `BaseTaskConfig` construction inline.

## Change

- Replace the two inline `eval_target = get_import_path(ResyUrlMatch); eval_config = {"_target_": eval_target, ...}; return BaseTaskConfig(...)` blocks with one `build_task_config(...)` call each.
- Imports: swap `get_import_path` → `build_task_config` (same line count, no other usage of `get_import_path` remained in the file).

## Why it's safe

- Pure no-behavior-change refactor. `build_task_config`'s body is exactly the two lines the inline code was inlining — verified by reading `navi_bench/base.py`.
- Verified by exercising both demo paths:
  - `python -m navi_bench.resy.resy_url_match` (random generator) emits the same `eval_config = {'_target_': 'navi_bench.resy.resy_url_match.ResyUrlMatch', 'queries': [[...]]}` shape as before.
  - `generate_task_config_deterministic(mode="any", values={"date": "{now() + timedelta(1)}"}, ...)` returns a `BaseTaskConfig` with the same eval_config shape.
- Sibling demos (`apartments`, `opentable`) confirmed unchanged.
- `ruff check` and `ruff format --check` pass.
- 1 file, +15/-10 lines.

## Test plan

- [x] `python -m py_compile navi_bench/resy/resy_url_match.py`
- [x] `python -m navi_bench.resy.resy_url_match` — demo emits unchanged config
- [x] `generate_task_config_deterministic(...)` with dynamic offset returns expected `BaseTaskConfig`
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI runs the existing test suite

🤖 Generated by automated hourly refactor cron.

---
_Generated by [Claude Code](https://claude.ai/code/session_015gcPY44TiXjUf1uBWcUwy8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `eval_config`/`BaseTaskConfig` are constructed for Resy tasks; behavior should remain identical aside from potential config-shape regressions.
> 
> **Overview**
> Routes Resy task config generation through the shared `build_task_config(...)` helper instead of hand-building `eval_config` with `get_import_path` in `generate_task_config_random` and `generate_task_config_deterministic`.
> 
> This removes the direct `get_import_path` import/usage in `resy_url_match.py` and centralizes construction of the evaluator `_target_` and kwargs in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6fb39a360242b83327548514c511caa0906477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->