### PR TITLE
refactor(opentable): use shared build_task_config helper

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -13,7 +13,7 @@ from playwright.async_api import Page
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path, read_sidecar
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, build_task_config, read_sidecar
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -846,23 +846,24 @@ def generate_task_config_random(
         f"{date_label} ({date_natural}) for {party_size} {'person' if party_size == 1 else 'people'}."
     )
 
-    # Create evaluator queries
-    eval_target = get_import_path(OpenTableInfoGathering)
-    eval_config = {
-        "_target_": eval_target,
-        "queries": [
-            [
-                {
-                    "restaurant_names": [restaurant_name.lower()],
-                    "dates": date_strs,
-                    "times": meal_time_slots,
-                    "party_sizes": [party_size],
-                }
-            ]
-        ],
-    }
-
-    return BaseTaskConfig(url=url, task=task_description, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=task_description,
+        user_metadata=user_metadata,
+        eval_class=OpenTableInfoGathering,
+        eval_kwargs={
+            "queries": [
+                [
+                    {
+                        "restaurant_names": [restaurant_name.lower()],
+                        "dates": date_strs,
+                        "times": meal_time_slots,
+                        "party_sizes": [party_size],
+                    }
+                ]
+            ],
+        },
+    )
 
 
 def _render_placeholders_in_queries_any(
@@ -950,10 +951,13 @@ def generate_task_config_deterministic(
     else:
         raise ValueError(f"Invalid mode: {mode}")
 
-    eval_target = get_import_path(OpenTableInfoGathering)
-    eval_config = {"_target_": eval_target, "queries": queries}
-
-    return BaseTaskConfig(url=url, task=rendered_task, user_metadata=user_metadata, eval_config=eval_config)
+    return build_task_config(
+        url=url,
+        task=rendered_task,
+        user_metadata=user_metadata,
+        eval_class=OpenTableInfoGathering,
+        eval_kwargs={"queries": queries},
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Migrate `opentable_info_gathering.py`'s `generate_task_config_random` and `generate_task_config_deterministic` to use the shared `build_task_config` helper from `navi_bench/base.py`
- This was the last navi-bench domain matcher still constructing `eval_config` dicts and `BaseTaskConfig` by hand — apartments, craigslist, google_flights, and resy (PR #81) already use the helper
- Removes the now-unused `get_import_path` import from the file

No behavior change: `build_task_config` constructs the same `{"_target_": get_import_path(eval_class), **eval_kwargs}` dict internally.

**Code owner**: @dhruvbatra (authored the `build_task_config` helper and the parallel resy migration in PR #81)

## Test plan

- [ ] `python -m navi_bench.opentable.opentable_info_gathering` demo prints the same eval_config shape as before
- [ ] `ruff check` + `ruff format --check` clean

https://claude.ai/code/session_01GwXXnWiyrFVb96x5RxC5Ax

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwXXnWiyrFVb96x5RxC5Ax)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `BaseTaskConfig.eval_config` is constructed (via shared helper) without altering query/task semantics.
> 
> **Overview**
> Refactors `opentable_info_gathering.py` to construct task configs via the shared `build_task_config` helper.
> 
> `generate_task_config_random` and `generate_task_config_deterministic` no longer manually build `{"_target_": ..., "queries": ...}` / `BaseTaskConfig`; they now pass `eval_class=OpenTableInfoGathering` plus `eval_kwargs` to the helper, and drop the unused `get_import_path` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd197efd5ecc43b90f235b8cce6846886633a527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->