### PR TITLE
refactor(relative_dates): extract _maybe_iso helper

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -212,6 +212,10 @@ def _shift_for_modifier(mod: str) -> int:
     return -1
 
 
+def _maybe_iso(d: date, return_iso: bool) -> str | date:
+    return d.isoformat() if return_iso else d
+
+
 # ----------------------------------
 # Public API
 # ----------------------------------
@@ -244,7 +248,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         day = _parse_ordinal_day(m.group(3))
         try_this = clamp_day(base.year, month, day)
         chosen = _choose_occurrence(try_this, base, modifier)
-        return chosen.isoformat() if return_iso else chosen
+        return _maybe_iso(chosen, return_iso)
 
     # ----------------------------
     # B1) Day + 'of' + Month with leading modifier:
@@ -260,7 +264,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         month = MONTHS[m.group(3)]
         try_this = clamp_day(base.year, month, day)
         chosen = _choose_occurrence(try_this, base, modifier)
-        return chosen.isoformat() if return_iso else chosen
+        return _maybe_iso(chosen, return_iso)
 
     # B2) Day + Month + trailing modifier:
     #     "the 3rd of december next" / "3rd december upcoming"
@@ -274,7 +278,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         modifier = _normalize_modifier(m.group(3))
         try_this = clamp_day(base.year, month, day)
         chosen = _choose_occurrence(try_this, base, modifier)
-        return chosen.isoformat() if return_iso else chosen
+        return _maybe_iso(chosen, return_iso)
 
     # B3) Day + modifier + Month:
     #     "the 3rd next december" / "3rd next december"
@@ -285,7 +289,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         month = MONTHS[m.group(3)]
         try_this = clamp_day(base.year, month, day)
         chosen = _choose_occurrence(try_this, base, modifier)
-        return chosen.isoformat() if return_iso else chosen
+        return _maybe_iso(chosen, return_iso)
 
     # B4) Day + 'of' + Month with NO modifier:
     #     "the 3rd of december" / "3rd of dec." / "3rd december"
@@ -296,7 +300,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         try_this = clamp_day(base.year, month, day)
         # no modifier -> default behavior: upcoming/on-or-after base
         chosen = _choose_occurrence(try_this, base, modifier="")
-        return chosen.isoformat() if return_iso else chosen
+        return _maybe_iso(chosen, return_iso)
 
     # ----------------------------
     # C) "<D> of the <mod> month" AND loose variants:
@@ -311,7 +315,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         mod = _normalize_modifier(m.group(2))
         target = add_months(base, _shift_for_modifier(mod))
         out = clamp_day(target.year, target.month, day)
-        return out.isoformat() if return_iso else out
+        return _maybe_iso(out, return_iso)
 
     # Keep the original strict "of the <mod> month" for safety
     m = re.fullmatch(rf"{_ORDINAL_DAY}\s+of\s+the\s+{_MOD_GROUP}\s+month", s)
@@ -320,7 +324,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         mod = _normalize_modifier(m.group(2))
         target = add_months(base, _shift_for_modifier(mod))
         out = clamp_day(target.year, target.month, day)
-        return out.isoformat() if return_iso else out
+        return _maybe_iso(out, return_iso)
 
     # ----------------------------
     # D) "<D> in N months"
@@ -331,7 +335,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         n = int(m.group(2))
         target = add_months(base, n)
         out = clamp_day(target.year, target.month, day)
-        return out.isoformat() if return_iso else out
+        return _maybe_iso(out, return_iso)
 
     # ----------------------------
     # E) "in N units" (days/weeks/months/years)
@@ -350,7 +354,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
             y = base.year + n
             d = min(base.day, calendar.monthrange(y, base.month)[1])
             out = date(y, base.month, d)
-        return out.isoformat() if return_iso else out
+        return _maybe_iso(out, return_iso)
 
     # ----------------------------
     # F) Weekdays: "(this|next|upcoming|last) <weekday>"
@@ -371,7 +375,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
             delta = (base_wd - target_wd) % 7
             delta = 7 if delta == 0 else delta
             out = base - timedelta(days=delta)
-        return out.isoformat() if return_iso else out
+        return _maybe_iso(out, return_iso)
 
     # ----------------------------
     # G) Holidays: "(this|next|upcoming|last) <holiday>"
@@ -393,7 +397,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
                 d_this = resolver(y)
                 shift = _year_shift_for_modifier(d_this, base, modifier)
                 out = d_this if shift == 0 else resolver(y + shift)
-                return out.isoformat() if return_iso else out
+                return _maybe_iso(out, return_iso)
     raise ValueError(f"Could not parse relative date description: '{text}'")
 
 


### PR DESCRIPTION
## Summary

`parse_relative_date()` in `navi_bench/relative_dates.py` returned `X.isoformat() if return_iso else X` in 11 different branches. This repeated the same conditional expression after every successful parse path. Extract a `_maybe_iso(d, return_iso)` helper so each return site becomes one line of intent rather than a 7-token expression.

## Why this is a win

- 11 sites collapse from `return chosen.isoformat() if return_iso else chosen` / `return out.isoformat() if return_iso else out` to `return _maybe_iso(chosen, return_iso)` / `return _maybe_iso(out, return_iso)`.
- Easier to grep for "early-return path in parse_relative_date" — every site looks the same now.
- Future return-type tweaks (e.g. adding another output format) live in one place.

## Why this is safe

- Pure mechanical substitution — `_maybe_iso(d, return_iso)` is identical to the inline conditional it replaces.
- Scope: 1 file, 11 lines changed, 1 new 2-line helper.
- Verified manually with `parse_relative_date()` across weekday ("next monday"), day-of-month ("next 5th of december", "5th of december"), relative-month ("3rd of next month"), "in N units" ("in 5 days"), and holiday ("thanksgiving", "next christmas") paths in both `return_iso=True` and `return_iso=False` modes — all produced the expected ISO string and `date` object.

## Test plan
- [x] Manual smoke test of parse paths in both `return_iso` modes
- [ ] CI passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01J8CSQcHi8NdZXYbzvuzH2E)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical refactor that centralizes `return_iso` formatting logic; behavior should remain identical but touches multiple early-return branches in `parse_relative_date()`.
> 
> **Overview**
> Refactors `parse_relative_date()` to centralize the repeated `return_iso` conditional into a new helper, `*_maybe_iso()*`, and updates all successful parse branches to return via that helper.
> 
> This reduces duplicated `d.isoformat() if return_iso else d` expressions across month/day, relative month, duration, weekday, and holiday parsing paths without changing parsing logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08291328dd92f89a1e915ad5443478eb268c3243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->