### PR TITLE
refactor(vis): extract _block_type / _block_field helpers for content-block duality

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -72,6 +72,28 @@ def _anthropic_image_to_data_url(block: dict) -> str | None:
     return f"data:{media_type};base64,{data}"
 
 
+def _block_type(block: object) -> str | None:
+    """Read ``"type"`` from an Anthropic content block.
+
+    Blocks arrive either as plain dicts (JSON-serialized history) or as
+    pydantic objects (Anthropic SDK response), so callers need to branch on
+    ``isinstance(block, dict)`` before reaching for ``.get`` or ``getattr``.
+    """
+    if isinstance(block, dict):
+        return block.get("type")
+    return getattr(block, "type", None)
+
+
+def _block_field(block: object, field: str, default: object = None) -> object:
+    """Read an arbitrary attribute from an Anthropic content block.
+
+    Mirrors :func:`_block_type` but for fields other than ``type``.
+    """
+    if isinstance(block, dict):
+        return block.get(field, default)
+    return getattr(block, field, default)
+
+
 def _get_action_marker_style(
     action: dict,
     coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
@@ -210,10 +232,8 @@ def generate_visualization_html(
             text_parts = []
             if isinstance(assistant_content, list):
                 for block in assistant_content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text_parts.append(block.get("text", ""))
-                    elif hasattr(block, "type") and block.type == "text":
-                        text_parts.append(getattr(block, "text", ""))
+                    if _block_type(block) == "text":
+                        text_parts.append(_block_field(block, "text", ""))
                 assistant_text = "\n\n".join(text_parts) if text_parts else ""
             elif isinstance(assistant_content, str):
                 assistant_text = assistant_content
@@ -234,11 +254,7 @@ def generate_visualization_html(
                 display_parts = []
                 if assistant_text:
                     display_parts.append(assistant_text)
-                tool_uses = [
-                    b
-                    for b in assistant_content
-                    if (isinstance(b, dict) and b.get("type") == "tool_use") or getattr(b, "type", None) == "tool_use"
-                ]
+                tool_uses = [b for b in assistant_content if _block_type(b) == "tool_use"]
                 if tool_uses:
                     tool_summary = []
                     for tu in tool_uses:


### PR DESCRIPTION
## Summary

Anthropic content blocks arrive either as plain dicts (JSON-serialized history) or as pydantic objects (Anthropic SDK), so `vis.py` had to branch on `isinstance(block, dict)` three times to read the same two attributes (`type` and `text`).

Adds `_block_type(block) -> str | None` and `_block_field(block, field, default)` next to `_anthropic_image_to_data_url`, and migrates two of the three branched sites.

## Before / after

**Text extraction (lines 213–216):**

```python
# Before
if isinstance(block, dict) and block.get("type") == "text":
    text_parts.append(block.get("text", ""))
elif hasattr(block, "type") and block.type == "text":
    text_parts.append(getattr(block, "text", ""))

# After
if _block_type(block) == "text":
    text_parts.append(_block_field(block, "text", ""))
```

**`tool_use` filter (lines 237–241):**

```python
# Before
tool_uses = [
    b
    for b in assistant_content
    if (isinstance(b, dict) and b.get("type") == "tool_use") or getattr(b, "type", None) == "tool_use"
]

# After
tool_uses = [b for b in assistant_content if _block_type(b) == "tool_use"]
```

## Why safe

- `_block_type({"type": X})` returns the same string as `block.get("type")`, and on objects it returns `getattr(block, "type", None)` — matches both original branches.
- `_block_field` accepts a per-call default so each migrated site keeps the exact default it had (`""` for text).
- Smoke-tested the helpers against dict / object / missing-attribute inputs.

## Out of scope

The `name`/`input` extraction inside the tool-summary loop (lines 245–246) used different defaults for the dict and object branches (`None` for `tu.get("name")` vs `"unknown"` for `getattr(tu, "name", "unknown")`). Unifying those would be a behavior change in display output, so it's left for a separate cleanup.

## Test plan

- [x] `python -c "import ast; ast.parse(open('evaluation/vis.py').read())"`
- [x] Smoke test of `_block_type` / `_block_field` against dict, object-with-attr, and missing-attr inputs.
- [ ] CI: existing pre-commit + lint (no test suite in this repo).


---
_Generated by [Claude Code](https://claude.ai/code/session_0162aeyaFUdN1JoHvaRyV1xk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how Anthropic content blocks are read (dict vs SDK object) when extracting assistant text and filtering `tool_use` blocks; output should be equivalent but could affect display if edge-case block shapes differ.
> 
> **Overview**
> Adds `_block_type` and `_block_field` helpers in `evaluation/vis.py` to abstract over Anthropic content blocks arriving as either dicts or SDK objects.
> 
> Updates assistant text extraction and the `tool_use` block filter to use these helpers instead of repeated `isinstance(..., dict)` / `getattr` branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0515af3f8865401f88b55db9f8c01ad806904084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->