### PR TITLE
refactor: name site-specific browser-config domain sets in evaluation/browser.py

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -26,6 +26,16 @@ BLOCKED_URL_KEYWORDS = (
     "google-analytics.com",
 )
 
+# Domains where the geolocation override must be applied to the browser context.
+GEOLOCATION_REQUIRED_DOMAINS = ("apartments.com", "opentable.com", "resy.com")
+
+# Domains that require a CDP-attached browser (cannot use the local browser fallback).
+CDP_REQUIRED_DOMAINS = ("apartments.com", "resy.com")
+
+
+def _url_matches_domain(url: str, domains: tuple[str, ...]) -> bool:
+    return any(domain in url for domain in domains)
+
 
 @functools.cache
 def get_prepare_page_js() -> str:
@@ -73,12 +83,10 @@ async def build_browser(
 
     try:
         viewport = {"width": config.browser_viewport_width, "height": config.browser_viewport_height}
-        need_to_set_location = (
-            "apartments.com" in task_config.url or "opentable.com" in task_config.url or "resy.com" in task_config.url
-        )
+        need_to_set_location = _url_matches_domain(task_config.url, GEOLOCATION_REQUIRED_DOMAINS)
 
         force_cdp = getattr(task_config, "use_cdp", False)
-        use_local_browser = not force_cdp and "apartments.com" not in task_config.url and "resy.com" not in task_config.url
+        use_local_browser = not force_cdp and not _url_matches_domain(task_config.url, CDP_REQUIRED_DOMAINS)
         if not use_local_browser and not os.getenv("BROWSER_CDP_URL"):
             if force_cdp:
                 raise ValueError("BROWSER_CDP_URL must be set when the task config enables use_cdp")


### PR DESCRIPTION
## What

`build_browser` in `evaluation/browser.py` had two inline `"apartments.com" in url or ...` checks that encoded two distinct site-policy sets:
- sites where the geolocation override must be applied (`apartments`, `opentable`, `resy`)
- sites that require a CDP-attached browser (`apartments`, `resy`)

The two sets are intentionally different — `opentable` needs location but works on the local browser. The inline conditionals obscured that fact and made it look like a typo when reviewing.

## Changes

Extracted two module-level tuples (`GEOLOCATION_REQUIRED_DOMAINS`, `CDP_REQUIRED_DOMAINS`) alongside the existing `LOCATION_COORDS` / `BLOCKED_URL_KEYWORDS` constants, plus a tiny `_url_matches_domain(url, domains)` helper:

```python
GEOLOCATION_REQUIRED_DOMAINS = ("apartments.com", "opentable.com", "resy.com")
CDP_REQUIRED_DOMAINS = ("apartments.com", "resy.com")

def _url_matches_domain(url: str, domains: tuple[str, ...]) -> bool:
    return any(domain in url for domain in domains)
```

Call sites:
```python
need_to_set_location = _url_matches_domain(task_config.url, GEOLOCATION_REQUIRED_DOMAINS)
force_cdp = getattr(task_config, "use_cdp", False)
use_local_browser = not force_cdp and not _url_matches_domain(task_config.url, CDP_REQUIRED_DOMAINS)
```

## Safety

No behavior change — the substring-match logic is identical (`"x" in url`); only the tuple/helper structure changes. Verified that the only references to these domain strings in conditional logic live in `evaluation/browser.py`.

https://claude.ai/code/session_01D6dxqjNeS81KQ1McDzKuGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6dxqjNeS81KQ1McDzKuGD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only reorganizes URL substring checks into named constants/helpers; behavior should be unchanged aside from potential misclassification if the domain lists are edited incorrectly.
> 
> **Overview**
> Refactors `build_browser` URL policy checks by extracting two explicit domain sets—`GEOLOCATION_REQUIRED_DOMAINS` and `CDP_REQUIRED_DOMAINS`—and a small `_url_matches_domain` helper.
> 
> This replaces inline `"..." in url` conditionals for when to apply geolocation overrides vs when to require a CDP-attached browser, making the intentionally different site policies clearer without changing the underlying matching logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ed625c63a2bc9418212700765b52044273e8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->