### PR TITLE
refactor(vis): use _block_field for remaining tool-use field accesses

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -258,8 +258,8 @@ def generate_visualization_html(
                 if tool_uses:
                     tool_summary = []
                     for tu in tool_uses:
-                        name = tu.get("name") if isinstance(tu, dict) else getattr(tu, "name", "unknown")
-                        inp = tu.get("input", {}) if isinstance(tu, dict) else getattr(tu, "input", {})
+                        name = _block_field(tu, "name", "unknown")
+                        inp = _block_field(tu, "input", {})
                         # Unwrap browser/computer tool for display
                         if name in ("browser", "computer") and isinstance(inp, dict) and "action" in inp:
                             action_name = inp["action"]


### PR DESCRIPTION
## Summary

- #84 extracted `_block_field` to unify dict-vs-pydantic branching but missed two instances at lines 261-262 in `evaluation/vis.py`
- Replace the remaining `isinstance(tu, dict)` / `getattr` branches with `_block_field(tu, "name", "unknown")` and `_block_field(tu, "input", {})`

## Test plan

- [ ] CI passes (no behavioral change — pure consistency fix)

https://claude.ai/code/session_01ALanMWwYg8Hzhp8KHUsfnk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALanMWwYg8Hzhp8KHUsfnk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to visualization display formatting; should be behavior-preserving aside from marginally more consistent handling of dict vs pydantic tool-use blocks.
> 
> **Overview**
> **Refactors Anthropic tool-use display parsing** in `evaluation/vis.py` by replacing the remaining `isinstance(..., dict)`/`getattr` accesses for tool-use `name` and `input` with `_block_field`.
> 
> This makes tool-use field extraction consistent across dict and pydantic block representations without changing the visualization’s intended output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 833014553bf540361847f0b86e9e1a0b898dece5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->