### PR TITLE
refactor(relative_dates): extract _resolve_month_day helper

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -216,6 +216,14 @@ def _maybe_iso(d: date, return_iso: bool) -> str | date:
     return d.isoformat() if return_iso else d
 
 
+def _resolve_month_day(month: int, day: int, base: date, modifier: str, return_iso: bool) -> str | date:
+    """Clamp ``day`` to ``month`` in ``base.year``, pick the occurrence implied by
+    ``modifier`` (this/next/last/empty), and return as ISO string or :class:`date`."""
+    target_this_year = clamp_day(base.year, month, day)
+    chosen = _choose_occurrence(target_this_year, base, modifier)
+    return _maybe_iso(chosen, return_iso)
+
+
 # ----------------------------------
 # Public API
 # ----------------------------------
@@ -246,9 +254,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         modifier = _normalize_modifier(m.group(1))
         month = MONTHS[m.group(2)]
         day = _parse_ordinal_day(m.group(3))
-        try_this = clamp_day(base.year, month, day)
-        chosen = _choose_occurrence(try_this, base, modifier)
-        return _maybe_iso(chosen, return_iso)
+        return _resolve_month_day(month, day, base, modifier, return_iso)
 
     # ----------------------------
     # B1) Day + 'of' + Month with leading modifier:
@@ -262,9 +268,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         modifier = _normalize_modifier(m.group(1))
         day = _parse_ordinal_day(m.group(2))
         month = MONTHS[m.group(3)]
-        try_this = clamp_day(base.year, month, day)
-        chosen = _choose_occurrence(try_this, base, modifier)
-        return _maybe_iso(chosen, return_iso)
+        return _resolve_month_day(month, day, base, modifier, return_iso)
 
     # B2) Day + Month + trailing modifier:
     #     "the 3rd of december next" / "3rd december upcoming"
@@ -276,9 +280,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         day = _parse_ordinal_day(m.group(1))
         month = MONTHS[m.group(2)]
         modifier = _normalize_modifier(m.group(3))
-        try_this = clamp_day(base.year, month, day)
-        chosen = _choose_occurrence(try_this, base, modifier)
-        return _maybe_iso(chosen, return_iso)
+        return _resolve_month_day(month, day, base, modifier, return_iso)
 
     # B3) Day + modifier + Month:
     #     "the 3rd next december" / "3rd next december"
@@ -287,9 +289,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         day = _parse_ordinal_day(m.group(1))
         modifier = _normalize_modifier(m.group(2))
         month = MONTHS[m.group(3)]
-        try_this = clamp_day(base.year, month, day)
-        chosen = _choose_occurrence(try_this, base, modifier)
-        return _maybe_iso(chosen, return_iso)
+        return _resolve_month_day(month, day, base, modifier, return_iso)
 
     # B4) Day + 'of' + Month with NO modifier:
     #     "the 3rd of december" / "3rd of dec." / "3rd december"
@@ -297,10 +297,8 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
     if m and m.group(2) in MONTHS:
         day = _parse_ordinal_day(m.group(1))
         month = MONTHS[m.group(2)]
-        try_this = clamp_day(base.year, month, day)
         # no modifier -> default behavior: upcoming/on-or-after base
-        chosen = _choose_occurrence(try_this, base, modifier="")
-        return _maybe_iso(chosen, return_iso)
+        return _resolve_month_day(month, day, base, modifier="", return_iso=return_iso)
 
     # ----------------------------
     # C) "<D> of the <mod> month" AND loose variants:


### PR DESCRIPTION
## Summary

Patterns A and B1–B4 in `parse_relative_date` all end with the same
three-line tail after the regex match resolves `(month, day, modifier)`:

```python
try_this = clamp_day(base.year, month, day)
chosen = _choose_occurrence(try_this, base, modifier)
return _maybe_iso(chosen, return_iso)
```

This PR extracts that tail into a private helper
`_resolve_month_day(month, day, base, modifier, return_iso)` and points
each of the five blocks at it. Each call site drops from 3 trailing
lines to 1.

## Why it's safe

- **No behavior change.** The helper is a literal extraction of the
  three lines — same `clamp_day` / `_choose_occurrence` / `_maybe_iso`
  composition, same argument order.
- Patterns C, D, E, etc. follow a different tail (`add_months` →
  `clamp_day` → `_maybe_iso`) and are not touched.
- Smoke check against the supported examples in the docstring
  (`next Dec. 3rd`, `this september 1`, `last Jul 4th`, `this the 3rd of
  december`, `next 3rd of december`, `the 3rd of december next`,
  `3rd december upcoming`, `the 3rd next december`, `3rd next
  december`, `the 3rd of december`, `3rd of dec.`, `3rd december`,
  `26th of the next month`, `15th in 3 months`) confirms identical ISO
  output before and after.

## Test plan

- [x] AST parse clean (`python -c "import ast; ast.parse(...)"`).
- [x] Ruff clean (`ruff check`; format diff only contains pre-existing
  unrelated whitespace on `_ORDINAL_WEEK_INDEX`).
- [x] Manual round-trip of all 14 docstring examples produces identical
  ISO output as `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mv3iabnPQT3weNY4eN9kBf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that deduplicates repeated month/day resolution logic; behavior should remain unchanged, with only minor risk of argument/return mismatches in the extracted helper.
> 
> **Overview**
> **Refactors month/day parsing in `parse_relative_date`.** Introduces private helper `/_resolve_month_day()` to centralize the common `clamp_day` → `_choose_occurrence` → `_maybe_iso` flow.
> 
> Updates patterns A and B1–B4 to call the helper instead of inlining the same three-step logic, reducing duplication without touching other parsing branches (e.g., “<day> of next month” logic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea26ff62e03cac558a48324521877fc1408bd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->