### PR TITLE
refactor(relative_dates): extract _day_in_shifted_month helper

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -224,6 +224,18 @@ def _resolve_month_day(month: int, day: int, base: date, modifier: str, return_i
     return _maybe_iso(chosen, return_iso)
 
 
+def _day_in_shifted_month(base: date, day: int, months_offset: int, return_iso: bool) -> str | date:
+    """Clamp ``day`` to the calendar month ``months_offset`` away from ``base``.
+
+    Sibling of :func:`_resolve_month_day` for parser branches that already know
+    the month offset (e.g. ``"<D> of the next month"``, ``"<D> in N months"``)
+    rather than picking a year-occurrence of a named month. Performs the
+    ``add_months → clamp_day → _maybe_iso`` chain in one place.
+    """
+    target = add_months(base, months_offset)
+    return _maybe_iso(clamp_day(target.year, target.month, day), return_iso)
+
+
 # ----------------------------------
 # Public API
 # ----------------------------------
@@ -311,18 +323,14 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
     if m:
         day = _parse_ordinal_day(m.group(1))
         mod = _normalize_modifier(m.group(2))
-        target = add_months(base, _shift_for_modifier(mod))
-        out = clamp_day(target.year, target.month, day)
-        return _maybe_iso(out, return_iso)
+        return _day_in_shifted_month(base, day, _shift_for_modifier(mod), return_iso)
 
     # Keep the original strict "of the <mod> month" for safety
     m = re.fullmatch(rf"{_ORDINAL_DAY}\s+of\s+the\s+{_MOD_GROUP}\s+month", s)
     if m:
         day = _parse_ordinal_day(m.group(1))
         mod = _normalize_modifier(m.group(2))
-        target = add_months(base, _shift_for_modifier(mod))
-        out = clamp_day(target.year, target.month, day)
-        return _maybe_iso(out, return_iso)
+        return _day_in_shifted_month(base, day, _shift_for_modifier(mod), return_iso)
 
     # ----------------------------
     # D) "<D> in N months"
@@ -331,9 +339,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
     if m:
         day = _parse_ordinal_day(m.group(1))
         n = int(m.group(2))
-        target = add_months(base, n)
-        out = clamp_day(target.year, target.month, day)
-        return _maybe_iso(out, return_iso)
+        return _day_in_shifted_month(base, day, n, return_iso)
 
     # ----------------------------
     # E) "in N units" (days/weeks/months/years)
@@ -457,7 +463,7 @@ _ORDINAL_WEEK_INDEX = {
     "second": 2, "2nd": 2,
     "third": 3, "3rd": 3,
     "fourth": 4, "4th": 4,
-}
+}  # fmt: skip
 
 
 def _ordinal_week_boundaries(year: int, month: int, ordinal: str) -> tuple[date, date]:


### PR DESCRIPTION
## Summary

Three parser branches in `parse_relative_date` repeat the same 3-line `add_months → clamp_day → _maybe_iso` chain — the only thing that varies across them is how the month offset is computed:

- the two `"<D> of the <mod> month"` variants (modifier-derived offset via `_shift_for_modifier`),
- the `"<D> in N months"` branch (explicit integer `n`).

This PR extracts `_day_in_shifted_month(base, day, months_offset, return_iso)` next to the existing `_resolve_month_day` sibling so the chain lives in one place. The three call sites collapse to a single helper call each.

Sibling-naming intent: `_resolve_month_day` picks a year-occurrence of a *named* month using a `this/next/last` modifier; `_day_in_shifted_month` works in calendar-month offset space (no occurrence logic). Keeping them adjacent with parallel signatures makes the distinction explicit instead of leaving it implicit in the inline code.

## Why this is safe

- No behavior change. The helper performs exactly the same `add_months` + `clamp_day` + `_maybe_iso` composition as the inline code it replaces.
- Scoped to one file, three call sites; reviewer can verify correctness from the diff alone.

## Test plan

- [x] `ruff format` and `ruff check` pass on the changed file.
- [x] Helper is exercised through the three existing `parse_relative_date` branches it replaces — no new public surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBVStR8FXni3aJS1KecseV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `navi_bench/relative_dates.py`, replacing duplicated date-calculation logic with a helper; behavior should remain unchanged aside from potential edge-case differences if the helper is incorrect.
> 
> **Overview**
> Refactors `parse_relative_date` to remove repeated `add_months → clamp_day → _maybe_iso` logic by introducing `_day_in_shifted_month()` and using it for the `"<D> of the <mod> month"` and `"<D> in N months"` parsing branches.
> 
> Also adds a `# fmt: skip` annotation to keep the `_ORDINAL_WEEK_INDEX` dict formatting stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2f2348dfe0bfb4d0e89879b7970f4b0e39ee8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->