### PR TITLE
docs: fix load_dataset split param, add navi_bench to known-first-party

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ from datasets import load_dataset
 from navi_bench.base import DatasetItem, instantiate
 
 # Load dataset from HF
-dataset = load_dataset("yutori-ai/navi-bench")
+dataset = load_dataset("yutori-ai/navi-bench", split="validation")
 
 # Load a task from the dataset
 task_item = DatasetItem.model_validate(dataset[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,5 +74,5 @@ line-ending = "auto"
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
-known-first-party = ["evaluation"]
+known-first-party = ["evaluation", "navi_bench"]
 lines-after-imports = 2


### PR DESCRIPTION
## Summary

- **README.md**: Add `split="validation"` to `load_dataset` call — without it, `load_dataset` returns a `DatasetDict` and `dataset[0]` raises `KeyError`
- **pyproject.toml**: Add `navi_bench` to Ruff isort `known-first-party` — was only listing `evaluation`, causing `navi_bench` imports to sort as third-party

## Test plan

- [ ] Verify `demo.py` and `evaluation/dataset.py` both pass `split=...` to `load_dataset`
- [ ] Verify `navi_bench` is a declared package in `pyproject.toml` `[tool.hatch.build.targets.wheel]`

https://claude.ai/code/session_017tT6zLgHsBWT8er2aBf4Bz

---
_Generated by [Claude Code](https://claude.ai/code/session_017tT6zLgHsBWT8er2aBf4Bz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and lint configuration only; no runtime or security impact.
> 
> **Overview**
> Fixes the README **Usage** snippet so `load_dataset("yutori-ai/navi-bench", split="validation")` returns a single split instead of a `DatasetDict`, avoiding a `KeyError` on `dataset[0]`.
> 
> Updates Ruff isort **known-first-party** in `pyproject.toml` to include `navi_bench` alongside `evaluation`, so first-party imports sort correctly instead of as third-party.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9144603b204211c713bc349b7550873452c9ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->