### PR TITLE
Fix type annotations in resy generate_time_slots/parse_time_to_hour

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -734,7 +734,7 @@ def load_restaurant_metadata() -> dict:
 RESTAURANT_METADATA = load_restaurant_metadata()
 
 
-def parse_time_to_hour(time_str: str) -> float:
+def parse_time_to_hour(time_str: str | None) -> float | None:
     """
     Parse time string like '6:00 AM' or '11:30 PM' to 24-hour format as float.
     Returns hour as float (e.g., 18.0 for 6:00 PM, 18.5 for 6:30 PM).
@@ -765,7 +765,7 @@ def parse_time_to_hour(time_str: str) -> float:
     return hour + (minute / 60.0)
 
 
-def generate_time_slots(open_time: str = None, close_time: str = None) -> list[str]:
+def generate_time_slots(open_time: str | None = None, close_time: str | None = None) -> list[str]:
     """
     Generate 30-minute time slots between open and close times.
     Returns list of times in HHMM format (e.g., '1800' for 6:00 PM).


### PR DESCRIPTION
## Summary

Two functions in `navi_bench/resy/resy_url_match.py` had type annotations that didn't match their actual behavior:

- `parse_time_to_hour(time_str: str) -> float` returns `None` on empty/invalid input and is called with possibly-`None` arguments, so it should be `parse_time_to_hour(time_str: str | None) -> float | None`.
- `generate_time_slots(open_time: str = None, close_time: str = None)` accepts `None` for its defaults (the docstring even says "or None for default"), but the annotations excluded `None`. Should be `str | None = None`.

This is a pure annotation change — no runtime behavior change. The callers already handle `None` (`parse_time_to_hour(...) or 12.0`, and the `if not time_str` guard inside the function), so widening the types only makes the signatures accurate.

This mirrors the identical fix already applied to the downstream copy in the yutori monorepo (PR #9488); the navi-bench repo's copy was missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HythGHveRJo6J9YUPaeYup)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change with no behavioral or runtime impact; improves static type checking accuracy.
> 
> **Overview**
> Updates type hints in `navi_bench/resy/resy_url_match.py` so they match existing behavior—**no runtime logic changes**.
> 
> **`parse_time_to_hour`** is now annotated as `(time_str: str | None) -> float | None`, reflecting empty/invalid input returning `None` and callers (e.g. CSV `open_time` / `close_time`) passing optional values.
> 
> **`generate_time_slots`** parameters are now `open_time: str | None = None` and `close_time: str | None = None`, matching the docstring and how `generate_task_config_random` invokes the helper when hours are missing from metadata.
> 
> This aligns the navi-bench copy with the same annotation fix applied elsewhere in the monorepo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21ca2cb2c41f20b09c235e36b6a01ab7a527f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->