### PR TITLE
refactor: import AsyncIterator from collections.abc in evaluation/browser.py

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -1,9 +1,9 @@
 import asyncio
 import functools
 import os
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from os import path as osp
-from typing import AsyncIterator
 
 from loguru import logger
 from playwright.async_api import Browser, BrowserContext, Error as PlaywrightError, Page, Playwright


### PR DESCRIPTION
## Summary

`evaluation/browser.py` imported `AsyncIterator` from `typing`, which has been deprecated since Python 3.9 in favor of `collections.abc`. This moves the import accordingly and reorders it into the correct isort position.

The only use is the `build_browser` async context manager return annotation (`AsyncIterator[tuple[Browser, BrowserContext, Page]]`), which is unaffected.

## Why

`collections.abc.AsyncIterator` is the non-deprecated home for this ABC, and the repo already uses modern annotation syntax (`str | None`, `dict[str, str]`, `tuple[...]`), so it targets Python 3.10+. This keeps the runner code consistent with that style.

## Risk

None — pure import-source change with no runtime behavior difference. Scoped to the `evaluation/` runner code (not the Encord-synced `navi_bench/` verifier package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtjxNGaiXFHmZCULTTdtMa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file import change with no runtime or logic impact on browser evaluation.
> 
> **Overview**
> In **`evaluation/browser.py`**, **`AsyncIterator`** is now imported from **`collections.abc`** instead of the deprecated **`typing`** path, with import order adjusted for isort.
> 
> The **`build_browser`** return type **`AsyncIterator[tuple[Browser, BrowserContext, Page]]`** is unchanged; this is an import-source-only update for the evaluation runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9aa5bae528f05fbe0ff6bc616b529a84c20e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->