### PR TITLE
Consolidate duplicated FinalResult into base.py

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -4,21 +4,17 @@ from urllib.parse import urlencode
 
 from beartype import beartype
 from loguru import logger
-from pydantic import BaseModel
 
 from navi_bench.base import (
     BaseMetric,
     BaseTaskConfig,
+    FinalResult,
     UrlMetricInput,
     basic_normalize_url,
     build_task_config,
     parse_filtered_query_params,
 )
 from navi_bench.dates import initialize_user_metadata
-
-
-class FinalResult(BaseModel):
-    score: float  # 1.0 if match, 0.0 if no match
 
 
 @beartype

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -278,6 +278,12 @@ class BaseMetric:
     async def reset(self) -> None: ...
 
 
+class FinalResult(BaseModel):
+    """Standard result returned by URL-based domain matchers."""
+
+    score: float  # 1.0 if match, 0.0 if no match
+
+
 class DatasetItem(BaseModel):
     # task required fields
     task_id: str = Field(

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -7,9 +7,8 @@ from typing import Any
 
 from beartype import beartype
 from loguru import logger
-from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UrlMetricInput, build_task_config
+from navi_bench.base import BaseMetric, BaseTaskConfig, FinalResult, UrlMetricInput, build_task_config
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 from navi_bench.google_flights.google_flights_pb2 import Info
 
@@ -20,10 +19,6 @@ Ensure that google_flights_pb2 is compiled from google_flights.proto.
 cd navi_bench/google_flights
 protoc --python_out=. google_flights.proto
 """
-
-
-class FinalResult(BaseModel):
-    score: float  # 1.0 if match, 0.0 if no match
 
 
 @beartype

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -11,11 +11,11 @@ from zoneinfo import ZoneInfo
 from beartype import beartype
 from loguru import logger
 from playwright.async_api import Error as PlaywrightError, Page
-from pydantic import BaseModel
 
 from navi_bench.base import (
     BaseMetric,
     BaseTaskConfig,
+    FinalResult,
     UserMetadata,
     basic_normalize_url,
     build_task_config,
@@ -34,10 +34,6 @@ class PageLike(Protocol):
 class InputDict(TypedDict):
     url: str
     page: Page
-
-
-class FinalResult(BaseModel):
-    score: float  # 1.0 if match, 0.0 if no match
 
 
 @dataclass


### PR DESCRIPTION
## What structural issue does this fix?

Three domain matchers each defined an identical Pydantic model:

```python
class FinalResult(BaseModel):
    score: float  # 1.0 if match, 0.0 if no match
```

This was duplicated verbatim in:
- `navi_bench/apartments/apartments_url_match.py`
- `navi_bench/google_flights/google_flights_search_match.py`
- `navi_bench/resy/resy_url_match.py`

## What this PR does

Moves `FinalResult` to `navi_bench/base.py` (alongside `BaseMetric`, `UrlMetricInput`, and other shared types) and replaces the three local definitions with an import.

`navi_bench/craigslist/craigslist_url_match.py` is intentionally left unchanged — its `FinalResult` includes an additional `reasoning: str` field, making it a different type.

## Why it's safe

- Pure structural change: no logic is modified, only where the class is defined
- `FinalResult` is only used locally within each matcher's `compute()` method (return type annotation + object construction)
- The class is identical across all three files; consolidating it doesn't change any behavior
- Craigslist remains independent since its variant differs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1dYDAkvJXK67V5YtNPZbz

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1dYDAkvJXK67V5YtNPZbz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural deduplication only; no matcher logic or schema changes for the three updated modules.
> 
> **Overview**
> Introduces a shared **`FinalResult`** Pydantic model in `navi_bench/base.py` (single `score` field, documented as the standard URL-matcher result) next to **`BaseMetric`** and related shared types.
> 
> **Apartments**, **Google Flights**, and **Resy** URL matchers drop their duplicate local definitions and import **`FinalResult`** from **`base`** instead; unused **`BaseModel`** imports are removed where they only served that class.
> 
> **Craigslist** is unchanged—it keeps its own **`FinalResult`** with an extra **`reasoning`** field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09570d39c70bbc497760d1b644b20c0cd2fb77a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->