### PR TITLE
Modernize deprecated Optional typing in resy_url_match

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -4,7 +4,7 @@ import random
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Literal, Optional, Protocol, TypedDict, runtime_checkable
+from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
@@ -48,12 +48,12 @@ class ResyQueryState:
     alt_index: int
     gt_url: str
     base_without_time: str
-    gt_time: Optional[str]
+    gt_time: str | None
     seen_visible_times: set[str] = field(default_factory=set)
     last_known_times: list[str] = field(default_factory=list)
 
 
-def _normalize_time_value(raw_time: Any) -> Optional[str]:
+def _normalize_time_value(raw_time: Any) -> str | None:
     if raw_time is None:
         return None
 
@@ -69,9 +69,9 @@ def _normalize_time_value(raw_time: Any) -> Optional[str]:
     if raw.endswith(("Z", "z")):
         raw = raw[:-1]
 
-    hour: Optional[int] = None
-    minute: Optional[int] = None
-    second: Optional[int] = None
+    hour: int | None = None
+    minute: int | None = None
+    second: int | None = None
 
     if raw.isdigit():
         if len(raw) == 4:
@@ -451,7 +451,7 @@ class ResyUrlMatch(BaseMetric):
         self,
         *,
         state: ResyQueryState,
-        url_time: Optional[str],
+        url_time: str | None,
         availabilities: list[AvailabilitySlot],
     ) -> tuple[bool, str]:
         if not state.gt_time:
@@ -526,9 +526,9 @@ class ResyUrlMatch(BaseMetric):
         )
         return False, f"neighbors_not_seen:{','.join(unseen_neighbors)}"
 
-    def _get_neighbor_times(self, gt_time: str, sorted_times: list[str]) -> tuple[Optional[str], Optional[str]]:
-        previous: Optional[str] = None
-        next_time: Optional[str] = None
+    def _get_neighbor_times(self, gt_time: str, sorted_times: list[str]) -> tuple[str | None, str | None]:
+        previous: str | None = None
+        next_time: str | None = None
         gt_seconds = _time_to_seconds(gt_time)
 
         for time_str in sorted_times:
@@ -541,7 +541,7 @@ class ResyUrlMatch(BaseMetric):
 
         return previous, next_time
 
-    def _extract_time_from_url(self, url: str) -> Optional[str]:
+    def _extract_time_from_url(self, url: str) -> str | None:
         if not url:
             return None
         parsed = urlparse(url)
@@ -575,7 +575,7 @@ class ResyUrlMatch(BaseMetric):
         *,
         reason: str,
         state: ResyQueryState,
-        url_time: Optional[str],
+        url_time: str | None,
         has_availabilities: bool,
     ) -> str:
         mapping = {


### PR DESCRIPTION
## What

Replace the remaining `typing.Optional[...]` annotations in `navi_bench/resy/resy_url_match.py` with PEP 604 `X | None` syntax and drop `Optional` from the `typing` import.

## Why

The file already uses modern built-in generics and union syntax (`str | None`, `int | None`, `list[str]`, `dict[str, ...]`, `tuple[int, int] | None`) throughout — the handful of `Optional[...]` annotations were an inconsistent leftover. This makes the typing style uniform across the module.

## Details

- `from typing import ... Optional ...` → drops `Optional`
- `gt_time: Optional[str]` → `gt_time: str | None`
- `_normalize_time_value(...) -> Optional[str]` → `-> str | None`
- `hour/minute/second: Optional[int] = None` → `int | None = None`
- `url_time: Optional[str]` → `url_time: str | None` (two call sites)
- `_get_neighbor_times(...) -> tuple[Optional[str], Optional[str]]` → `tuple[str | None, str | None]` (plus the two local annotations)
- `_extract_time_from_url(...) -> Optional[str]` → `-> str | None`

No behavior change. The package requires Python ≥ 3.10, and `beartype` (used to decorate `ResyUrlMatch`) fully supports PEP 604 unions on 3.10+. `ruff check` and `ruff format --check` both pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6T36TErJGBNZXafkdrhVU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change in a benchmark metric module; no logic, I/O, or evaluation behavior is modified.
> 
> **Overview**
> **Typing-only cleanup** in `navi_bench/resy/resy_url_match.py`: remaining `typing.Optional[...]` annotations are switched to PEP 604 `X | None`, and `Optional` is removed from the `typing` import.
> 
> Affected surfaces include `ResyQueryState.gt_time`, `_normalize_time_value`, local hour/minute/second parsing variables, `_evaluate_condition` / `_describe_conditional_reason` `url_time` parameters, `_get_neighbor_times` return and locals, and `_extract_time_from_url`. **No runtime or benchmark logic changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38512758b43de9709b347f95b81a8305d764c676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->