### PR TITLE
refactor: import ABCs from collections.abc in navi_bench/base.py

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -3,10 +3,11 @@ import importlib
 import json
 import random
 import types
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Iterable, TypedDict, TypeVar, Union, get_args, get_origin
+from typing import Any, TypedDict, TypeVar, Union, get_args, get_origin
 from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value


### PR DESCRIPTION
## Summary

Moves `Awaitable`, `Callable`, and `Iterable` from `typing` to `collections.abc` in `navi_bench/base.py`. These abstract base classes have been deprecated as `typing` aliases since Python 3.9 (PEP 585).

`Any`, `TypedDict`, `TypeVar`, `Union`, `get_args`, and `get_origin` remain in `typing` (they have no `collections.abc` equivalent; `Union`/`get_args`/`get_origin` are used for runtime type introspection).

## Why this is safe

- Pure import reorganization — no behavior change. `collections.abc` ABCs support subscription for type annotations since Python 3.9, and this package requires `>=3.10`.
- This exactly matches the source-of-truth copy of `navi_bench/base.py` in the `encord` repo, which already imports these three names from `collections.abc`. This change brings the standalone navi-bench copy back in sync.
- `python -c "import ast; ast.parse(...)"` confirms the file parses cleanly, and no other references to the moved names via `typing.` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRVjxVHBgKvAhKwSjCeFrj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure import reorganization in a single file with no logic or API changes.
> 
> **Overview**
> **Import-only change** in `navi_bench/base.py`: `Awaitable`, `Callable`, and `Iterable` now come from `collections.abc` instead of `typing` (PEP 585 / Python 3.9+ style). Everything else still imports from `typing`.
> 
> No call sites or runtime logic change; annotations on helpers like `parse_filtered_query_params`, `instantiate`, and `async_retry_with_exponential_backoff` behave the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71d5584e98436c56b9b2a4602f4543768f5c655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->