### PR TITLE
fix: use datetime.now(timezone.utc) for UserMetadata timestamps

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -4,7 +4,7 @@ import json
 import random
 import types
 from collections.abc import Awaitable, Callable, Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
 from typing import Any, TypedDict, TypeVar, Union, get_args, get_origin
@@ -48,7 +48,7 @@ def basic_normalize_url(url: str, target_domain: str) -> tuple[ParseResult | Non
     is a basic-normalized "netloc + path[?query]" string with any trailing slash stripped —
     this is the form domain matchers return as-is for off-domain URLs.
 
-    Empty input returns ``(None, "")``.
+    Empty input returns ``(None, ""``.
     """
     if not url:
         return None, ""
@@ -238,7 +238,7 @@ def async_retry_with_exponential_backoff(
 class UserMetadata(BaseModel):
     location: str = Field(description="Location of the user", default="San Francisco, CA, United States")
     timezone: str = Field(description="Timezone of the user", default="America/Los_Angeles")
-    timestamp: int = Field(default_factory=lambda: int(datetime.now().timestamp()))
+    timestamp: int = Field(default_factory=lambda: int(datetime.now(timezone.utc).timestamp()))
 
 
 class BaseTaskConfig(BaseModel):

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -48,7 +48,7 @@ def basic_normalize_url(url: str, target_domain: str) -> tuple[ParseResult | Non
     is a basic-normalized "netloc + path[?query]" string with any trailing slash stripped —
     this is the form domain matchers return as-is for off-domain URLs.
 
-    Empty input returns ``(None, ""``.
+    Empty input returns ``(None, "")``.
     """
     if not url:
         return None, ""

--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -1,7 +1,7 @@
 """Unified utilities for parsing and evaluating dynamic date expressions."""
 
 import re
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from navi_bench.base import UserMetadata
@@ -12,6 +12,9 @@ _MONTH_STYLE_OPTIONS = {"short", "long"}
 _PREFIX_OPTIONS = {"next", "none", "auto"}
 _RANGE_OPTIONS = {"endpoints", "all"}
 _YEAR_OPTIONS = {"set", "none"}
+# Cached at module level so the `timezone: str` parameter in
+# initialize_user_metadata() does not shadow the stdlib timezone object.
+_UTC = timezone.utc
 
 _DYNAMIC_OFFSET_PATTERN = re.compile(
     r"""
@@ -192,7 +195,7 @@ def initialize_user_metadata(
     timestamp: int | None = None,
 ) -> UserMetadata:
     """Initialize the user metadata with the current date and time."""
-    timestamp = int(datetime.now().timestamp()) if timestamp is None else timestamp
+    timestamp = int(datetime.now(_UTC).timestamp()) if timestamp is None else timestamp
     user_metadata = UserMetadata(timestamp=timestamp, location=location, timezone=timezone)
     return user_metadata
 


### PR DESCRIPTION
## What

Fix two `datetime.now()` calls that were missing an explicit timezone, in violation of the project's CLAUDE.md requirement:

> **IMPORTANT**: Always use `datetime.now(timezone.utc)` instead of `datetime.now()`. The latter uses local timezone and can cause timezone-related bugs.

### Changes

**`navi_bench/base.py`**
- Add `timezone` to the `datetime` import
- `UserMetadata.timestamp` default_factory: `datetime.now()` → `datetime.now(timezone.utc)`

**`navi_bench/dates.py`**
- Add `timezone` to the `datetime` import
- Add `_UTC = timezone.utc` at module level — necessary because `initialize_user_metadata()` has a parameter also named `timezone: str`, which would shadow the stdlib `timezone` object inside the function body
- `initialize_user_metadata()` fallback timestamp: `datetime.now()` → `datetime.now(_UTC)`

## Why

`datetime.now()` uses the local system timezone. On CI or production servers that run in a non-local timezone, the resulting Unix timestamp is still correct (`.timestamp()` always returns UTC epoch seconds), **but** any intermediate datetime arithmetic done before `.timestamp()` would produce wrong results if the naive datetime were compared or formatted. Using `timezone.utc` makes the intent explicit and eliminates the entire class of local-timezone bugs.

## Risk

Low — mechanical one-liner change at two call sites. The Unix epoch value produced by `int(datetime.now(timezone.utc).timestamp())` is identical to `int(datetime.now().timestamp())` on any correctly-configured machine; the only difference is correctness on misconfigured hosts and clarity of intent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cn8cNp6HEPgb4SgKxbSxeG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical two-call-site change; epoch seconds from `.timestamp()` should match on correctly configured hosts, with clearer intent and fewer timezone footguns.
> 
> **Overview**
> Replaces naive **`datetime.now()`** with explicit UTC when defaulting **`UserMetadata.timestamp`** and when **`initialize_user_metadata()`** fills in a missing timestamp, aligning with the project rule to always use **`datetime.now(timezone.utc)`**.
> 
> In **`dates.py`**, a module-level **`_UTC = timezone.utc`** avoids shadowing from the **`timezone: str`** parameter on **`initialize_user_metadata()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6213f5d9355a2791ea50af75f89422f2373e380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->