### PR TITLE
refactor: move reasoning field to base FinalResult, remove craigslist local redef

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -283,6 +283,7 @@ class FinalResult(BaseModel):
     """Standard result returned by URL-based domain matchers."""
 
     score: float  # 1.0 if match, 0.0 if no match
+    reasoning: str | None = None
 
 
 class DatasetItem(BaseModel):

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -2,11 +2,11 @@ from urllib.parse import urlparse
 
 from beartype import beartype
 from loguru import logger
-from pydantic import BaseModel
 
 from navi_bench.base import (
     BaseMetric,
     BaseTaskConfig,
+    FinalResult,
     UrlMetricInput,
     build_task_config,
     parse_filtered_query_params,
@@ -15,11 +15,6 @@ from navi_bench.dates import initialize_user_metadata
 
 
 IGNORE_URL_PARAMS = ("isTrusted",)
-
-
-class FinalResult(BaseModel):
-    score: float
-    reasoning: str
 
 
 @beartype


### PR DESCRIPTION
## Summary

`craigslist_url_match.py` defined a local `FinalResult(BaseModel)` with `score` and `reasoning` fields that partially duplicated `base.FinalResult`. This local class shadowed what could have been a shared import, and required a `from pydantic import BaseModel` import used nowhere else in the file.

**Changes:**
- Add `reasoning: str | None = None` to `base.FinalResult` — backward-compatible since existing callers that return `FinalResult(score=...)` continue to work unchanged
- Remove the local `FinalResult` class from `craigslist_url_match.py` and import it from `navi_bench.base` instead
- Drop the now-unused `from pydantic import BaseModel` import from craigslist

No behavior change — `CraigslistUrlMatch.compute()` still returns `FinalResult(score=score, reasoning=reasoning)`, just using the shared base class now.

---
_Generated by [Claude Code](https://claude.ai/code/session_0155U8ebBB5qGAv45KKwu6DL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small schema consolidation with a backward-compatible optional field; no scoring or URL-matching logic changes.
> 
> **Overview**
> **Shared `FinalResult` now carries optional `reasoning`.** The base URL-matcher result type gains `reasoning: str | None = None`, so callers that only set `score` (e.g. apartments) stay unchanged.
> 
> **Craigslist stops defining its own model.** `craigslist_url_match.py` drops the local `FinalResult` and unused `BaseModel` import, and imports `FinalResult` from `navi_bench.base`. `CraigslistUrlMatch.compute()` still returns the same `score` and `reasoning` payload—just via the shared type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c3570b65279ff5e603bac1ad87d6aaa59995fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->