### PR TITLE
Remove dead async_retry_with_exponential_backoff and now-unused imports

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -1,21 +1,15 @@
-import asyncio
 import importlib
 import json
-import random
 import types
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import Any, TypedDict, TypeVar, Union, get_args, get_origin
+from typing import Any, TypedDict, Union, get_args, get_origin
 from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value
-from loguru import logger
 from pydantic import BaseModel, Field
-
-
-T = TypeVar("T")
 
 
 def get_import_path(obj: Any) -> str:
@@ -188,51 +182,6 @@ def basic_pydantic_to_hf_features(model_class: type[BaseModel]) -> Features:
             raise ValueError(f"Unexpected field type: {field_type}")
 
     return Features(features_dict)
-
-
-def async_retry_with_exponential_backoff(
-    max_retries: int = 3,
-    delay: float = 1,
-    exponential_base: float = 2,
-    jitter: bool = True,
-    allowed_exceptions: tuple[type[Exception], ...] = (Exception,),
-    should_retry_fn: Callable[[Any], bool] | None = None,
-) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
-    """Retry an async function with exponential backoff."""
-
-    def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
-        async def wrapper(*args: Any, **kwargs: Any) -> T:
-            num_retries = 0
-            current_delay = delay
-
-            while True:
-                try:
-                    result = await func(*args, **kwargs)
-
-                    if should_retry_fn is None or not should_retry_fn(result):
-                        return result
-
-                    # should_retry_fn signaled a soft retry; on exhaustion return the
-                    # last result rather than raising.
-                    num_retries += 1
-                    if num_retries > max_retries:
-                        return result
-                    current_delay *= exponential_base * (1 + jitter * random.random())
-                    await asyncio.sleep(current_delay)
-
-                except allowed_exceptions as e:
-                    num_retries += 1
-                    if num_retries > max_retries:
-                        raise Exception(f"Maximum number of retries ({max_retries}) exceeded.") from e
-                    current_delay *= exponential_base * (1 + jitter * random.random())
-                    logger.info(
-                        f"Failed to call {func.__name__}. Retrying in {current_delay} seconds. Error: {repr(e)}"
-                    )
-                    await asyncio.sleep(current_delay)
-
-        return wrapper
-
-    return decorator
 
 
 class UserMetadata(BaseModel):


### PR DESCRIPTION
## Structural issue

`navi_bench/base.py` defined `async_retry_with_exponential_backoff` (a generic async retry-with-backoff decorator factory, ~45 lines including its nested `decorator`/`wrapper`) that has zero callers anywhere in the repo. It predates the recent refactor sweeps (#83-#97) and was never wired up to any call site.

Because it was unused, several imports in the same file (`asyncio`, `random`, `Awaitable`, `Callable` from `collections.abc`, `TypeVar`, and `logger` from `loguru`) were also only used inside this dead function, so removing it makes those imports dead too.

## Why this is an improvement

Dead code and its accompanying unused imports add reading overhead and false discoverability (someone might assume this helper is the repo's retry convention and start using it, when the actual retry logic that's in active use — e.g. `evaluation/eval_n1.py`'s `_sleep_or_reraise` — lives elsewhere with different, purpose-built semantics). Removing it is a pure simplification.

## Why this is safe

- Verified via `grep -rn "async_retry_with_exponential_backoff"` across every `.py`/`.json`/`.yaml`/`.md` file in the repo: the only occurrence was the `def` line itself (no callers, no string-based/dynamic references, no config `_target_` strings pointing at it).
- Confirmed `asyncio.`, `random.`, `Callable`, `Awaitable`, and the `T` TypeVar were used exclusively inside the deleted function body/signature (checked via targeted greps within `base.py`), and `logger.` had no other call sites in the file after the deletion.
- `ruff check` and `ruff format --check` both pass on the modified file.
- `python -m ast.parse` confirms the file is still syntactically valid.

This repo has no test suite, which raises the bar for any change. This PR is a pure deletion of unreachable code plus its now-orphaned imports — there is no behavior change to any live code path, since nothing invoked the removed function. I did not attempt any behavioral consolidation (e.g. of the cross-domain matcher modules, which are correctly *not* unified per `.claude/REFACTOR.md`'s navi-bench notes) — this change is scoped to code-inspection-verifiable dead-code removal only.

## Scope

1 file changed (`navi_bench/base.py`), 2 insertions / 53 deletions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AbUAV225eADxyG994Fqoi4)_