### PR TITLE
Extract duplicated truncate-to-150-chars logic in vis.py

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -4,6 +4,11 @@ from html import escape as _escape_html
 from yutori.navigator import NAVIGATOR_COORDINATE_SCALE
 
 
+def _truncate_preview(text: str, limit: int = 150) -> str:
+    """Truncate ``text`` to ``limit`` characters, appending an ellipsis if shortened."""
+    return text[:limit] + "..." if len(text) > limit else text
+
+
 def _escape_json_for_script_tag(json_str: str) -> str:
     """Escape JSON string for safe embedding in HTML script tags.
 
@@ -1237,9 +1242,7 @@ def generate_visualization_html(
 
         # Handle final answer case (no tool calls = implicit stop)
         if is_final_answer and final_answer_content:
-            answer_preview = (
-                final_answer_content[:150] + "..." if len(final_answer_content) > 150 else final_answer_content
-            )
+            answer_preview = _truncate_preview(final_answer_content)
             step["stop_answer"] = final_answer_content
             actions_html = f"""
             <div class="action-item stop-action" onclick="openAnswerModal({step_num})">
@@ -1256,7 +1259,7 @@ def generate_visualization_html(
             if stop_actions:
                 stop_text = stop_actions[0].get("text", "")
                 if stop_text:
-                    answer_preview = stop_text[:150] + "..." if len(stop_text) > 150 else stop_text
+                    answer_preview = _truncate_preview(stop_text)
                     step["stop_answer"] = stop_text
                     stop_label = stop_actions[0].get("action_type", "Finished")
                     actions_html = f"""


### PR DESCRIPTION
## Issue

`evaluation/vis.py::generate_visualization_html` computes the same "truncate a string to 150 chars, appending `...` if truncated" expression twice, in two separate branches of the same function:

- `final_answer_content[:150] + "..." if len(final_answer_content) > 150 else final_answer_content` (final-answer branch)
- `stop_text[:150] + "..." if len(stop_text) > 150 else stop_text` (stop-action branch)

Both are byte-for-byte the same idiom applied to a different local variable — same magic number (150), same comparison, same slicing/concatenation.

## Improvement

Extracted a tiny helper:

```python
def _truncate_preview(text: str, limit: int = 150) -> str:
    """Truncate ``text`` to ``limit`` characters, appending an ellipsis if shortened."""
    return text[:limit] + "..." if len(text) > limit else text
```

and replaced both call sites with `_truncate_preview(final_answer_content)` / `_truncate_preview(stop_text)`. No other logic in either branch was touched (the surrounding HTML-building code differs slightly between the two branches — e.g. the badge label — so only the narrow, identical truncation expression was pulled out).

## Safety

This repo has **no test suite**, so I verified correctness by hand and with an independent fuzz check rather than relying on CI:

- Read both call sites side-by-side and confirmed the expressions are identical modulo the variable name.
- Ran a 5,000-iteration equivalence fuzz test comparing the original inline expression against the extracted function across random strings of varying lengths (0–400 chars, mixed printable characters, spanning the `> 150` boundary in both directions) — all outputs matched exactly.
- `python3 -m py_compile evaluation/vis.py` passes.
- `git diff` is minimal: one new 3-line pure function plus two one-line call-site substitutions; no other code paths touched.

This is a pure extraction with no behavior change — same inputs produce byte-for-byte identical outputs.

🤖 Generated as part of an automated structural-refactor pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KT3ayfuPEBg4LxMGAwEAap)_