### PR TITLE
refactor(vis): extract duplicated stop-action-type tuple into a constant

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -4,6 +4,11 @@ from html import escape as _escape_html
 from yutori.navigator import NAVIGATOR_COORDINATE_SCALE
 
 
+# Action-type labels (in both PascalCase and snake_case, as seen from different message
+# sources) that represent an implicit "stop" action rather than a browser interaction.
+_STOP_ACTION_TYPES = ("Finished", "CallUser", "finished", "call_user")
+
+
 def _truncate_preview(text: str, limit: int = 150) -> str:
     """Truncate ``text`` to ``limit`` characters, appending an ellipsis if shortened."""
     return text[:limit] + "..." if len(text) > limit else text
@@ -1253,9 +1258,7 @@ def generate_visualization_html(
 """
         else:
             # Check if any action is a stop action (Finished/CallUser)
-            stop_actions = [
-                a for a in actions if a.get("action_type") in ("Finished", "CallUser", "finished", "call_user")
-            ]
+            stop_actions = [a for a in actions if a.get("action_type") in _STOP_ACTION_TYPES]
             if stop_actions:
                 stop_text = stop_actions[0].get("text", "")
                 if stop_text:
@@ -1273,7 +1276,7 @@ def generate_visualization_html(
             for i, action in enumerate(actions):
                 action_type = action.get("action_type", "unknown")
                 # Skip stop actions already rendered above
-                if action_type in ("Finished", "CallUser", "finished", "call_user"):
+                if action_type in _STOP_ACTION_TYPES:
                     continue
                 details = []
 


### PR DESCRIPTION
## What

In `evaluation/vis.py`'s `generate_visualization_html()`, the literal tuple
`("Finished", "CallUser", "finished", "call_user")` — the set of action-type
labels that represent an implicit "stop" action rather than a real browser
interaction — was written out verbatim in two separate places:

1. The `stop_actions` filter that looks for a stop action among a step's actions.
2. The per-action loop that skips re-rendering any action already covered by (1).

This PR extracts it into a single module-level constant, `_STOP_ACTION_TYPES`,
and updates both call sites to reference it.

## Why this is safe

- Purely mechanical, behavior-preserving extraction: both call sites now
  reference the exact same tuple contents that were previously inlined
  (confirmed via `grep` that these were the only two occurrences in the file,
  and the only occurrences of `"Finished"`/`"CallUser"` in the repo).
- No control flow, ordering, or interface changes — `in <tuple>` membership
  checks behave identically against a module-level constant.
- `evaluation/vis.py` has no test suite; verification here relies on the diff
  being a literal-for-literal substitution, plus `python -m py_compile` and
  `ruff check`/`ruff format --check`, both of which pass cleanly.

## Why this matters

Without a shared constant, the two lists could silently drift apart (e.g. if
a new label like `"stop"` were added to only one of the two spots), causing
inconsistent behavior between what counts as a "stop" for summarizing vs.
what gets skipped in the detailed action list.

## Files changed

- `evaluation/vis.py`


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9rz68T1EuT66RbQXYKihc)_