### PR TITLE
refactor(base): extract fractional_coverage_score helper

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -58,6 +58,17 @@ def basic_normalize_url(url: str, target_domain: str) -> tuple[ParseResult | Non
     return parsed, ""
 
 
+def fractional_coverage_score(n_covered: int, n_total: int) -> float:
+    """Fraction of required items covered, i.e. ``n_covered / n_total``.
+
+    Guards the zero-required edge case (treated as fully covered rather than raising
+    ``ZeroDivisionError``) the same way domain matchers with "cover N required items"
+    scoring do, e.g. craigslist's AND-of-OR URL matching and opentable's multi-query
+    coverage checks.
+    """
+    return n_covered / max(n_total, 1)
+
+
 def parse_filtered_query_params(query: str, ignored: Iterable[str]) -> dict[str, list[str]]:
     """Parse a URL query string and drop keys in ``ignored``.
 

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -9,6 +9,7 @@ from navi_bench.base import (
     FinalResult,
     UrlMetricInput,
     build_task_config,
+    fractional_coverage_score,
     parse_filtered_query_params,
 )
 from navi_bench.dates import initialize_user_metadata
@@ -69,7 +70,7 @@ class CraigslistUrlMatch(BaseMetric):
                     break
 
         n_required = len(self._gt_states)
-        score = n_covered / max(n_required, 1)
+        score = fractional_coverage_score(n_covered, n_required)
         reasoning = f"Covered {n_covered} out of {n_required} required URLs"
         return FinalResult(score=score, reasoning=reasoning)
 

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -13,7 +13,14 @@ from playwright.async_api import Page
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, build_task_config, read_sidecar
+from navi_bench.base import (
+    BaseMetric,
+    BaseTaskConfig,
+    UserMetadata,
+    build_task_config,
+    fractional_coverage_score,
+    read_sidecar,
+)
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 
 
@@ -237,7 +244,7 @@ class OpenTableInfoGathering(BaseMetric):
         n_queries = len(self.queries)
         n_covered = sum(self._is_query_covered)
         final_result = FinalResult(
-            score=n_covered / max(n_queries, 1),
+            score=fractional_coverage_score(n_covered, n_queries),
             n_queries=n_queries,
             n_covered=n_covered,
             queries=self.queries,


### PR DESCRIPTION
## Issue

`CraigslistUrlMatch.compute()` and `OpenTableInfoGathering.compute()` both independently computed their coverage score as `n_covered / max(n_total, 1)` — the same "fraction of required items covered" formula, including the same zero-required guard to avoid `ZeroDivisionError`.

## Improvement

Extracted the shared formula into a new `fractional_coverage_score(n_covered, n_total)` helper in `navi_bench/base.py`, alongside the other small shared scoring/normalization helpers already there (`parse_filtered_query_params`, `basic_normalize_url`). Both matchers now call the shared helper instead of duplicating the formula.

## Safety

This is a pure structural refactor with **no behavior change**:
- The helper is a direct extraction of the existing expression (`n_covered / max(n_total, 1)`), used identically in both call sites.
- Verified interactively that both matchers produce identical scores before/after the change, including the zero-required edge case (`fractional_coverage_score(0, 0) == 0.0`).
- Ran the `__main__` demo for `craigslist_url_match.py` end-to-end (dataset item → task config → evaluator) to confirm nothing broke on import/instantiation.
- `ruff check` and `ruff format --check` both pass on the touched files.
- No test suite exists in this repo to run, so verification was done via targeted manual exercising of both `compute()` methods.

Touches 3 files: `navi_bench/base.py`, `navi_bench/craigslist/craigslist_url_match.py`, `navi_bench/opentable/opentable_info_gathering.py`.

🤖 Generated as part of an automated hourly refactor job.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R1ygBa82MRNzyeRcNXk9XY)_