### PR TITLE
refactor(relative_dates): delegate add_months and in-N-years branch to clamp_day

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -56,8 +56,7 @@ def add_months(d: date, n: int) -> date:
     m += n
     y += (m - 1) // 12
     m = ((m - 1) % 12) + 1
-    day = min(d.day, _days_in_month(y, m))
-    return date(y, m, day)
+    return clamp_day(y, m, d.day)
 
 
 def clamp_day(y: int, m: int, day: int) -> date:
@@ -365,9 +364,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         elif unit.startswith("month"):
             out = add_months(base, n)
         else:
-            y = base.year + n
-            d = min(base.day, _days_in_month(y, base.month))
-            out = date(y, base.month, d)
+            out = clamp_day(base.year + n, base.month, base.day)
         return _maybe_iso(out, return_iso)
 
     # ----------------------------


### PR DESCRIPTION
## What

`add_months()` and the "in N years" branch of `parse_relative_date()` in `navi_bench/relative_dates.py` each reimplemented `clamp_day()`'s exact body inline (`min(day, _days_in_month(y, m))` then build a `date`) instead of calling the already-extracted `clamp_day()` helper that three other call sites (`_resolve_month_day`, `_day_in_shifted_month`, `dates.py::initialize_placeholder_map`) already use.

## Why this is safe

- `clamp_day(y, m, day)` is `date(y, m, min(day, _days_in_month(y, m)))` — byte-for-byte the same computation both call sites already performed inline, just with `day` bound to `d.day`/`base.day`.
- This repo has no test suite, so I verified algebraic equivalence directly: 50,000 randomized `(date, offset)` cases for `add_months` and 50,000 for the "in N years" branch, comparing old vs. new implementations — zero mismatches in either case.
- Contained to one file, one-line/two-line call-site substitutions, no signature changes.
- `ruff check` / `ruff format --check` pass.
- Continues the same de-duplication thread this file has already gone through (`_resolve_month_day`, `_day_in_shifted_month`, `_days_in_month` extractions per prior PRs).

Found and implemented by the hourly automated structural-refactor job.

## Test plan
- [x] `ruff check` / `ruff format --check` pass
- [x] 50,000-case randomized fuzz comparison of old vs. new `add_months` behavior — 0 mismatches
- [x] 50,000-case randomized fuzz comparison of old vs. new "in N years" branch behavior — 0 mismatches


---
_Generated by [Claude Code](https://claude.ai/code/session_019pL81nTEpijvLYc56HYWyX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-neutral refactor in one file with no signature changes; only replaces duplicated clamp logic with an existing helper.
> 
> **Overview**
> **`add_months`** and the **"in N years"** path in **`parse_relative_date`** no longer duplicate day-clamping logic; both now call the existing **`clamp_day`** helper instead of inlining `min(day, _days_in_month(...))` and building a **`date`**.
> 
> This aligns those two spots with **`_resolve_month_day`**, **`_day_in_shifted_month`**, and **`dates.py`** placeholder normalization. No API or parsing behavior changes—same inputs should yield the same dates (including end-of-month cases like Jan 31 → Feb 28/29).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37018051048e05834729d02b839b27619a00a829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->