### PR TITLE
Extract resolve_city_now helper for duplicated city-timezone-now block

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -211,6 +211,19 @@ def initialize_user_metadata(
     return user_metadata
 
 
+def resolve_city_now(city_meta: dict) -> tuple[datetime, UserMetadata]:
+    """Resolve the current tz-aware time and UserMetadata for a CITY_METADATA entry."""
+    tz_info = ZoneInfo(city_meta["timezone"])
+    today = datetime.now(tz_info)
+    timestamp = int(today.timestamp())
+    user_metadata = UserMetadata(
+        location=city_meta["location"],
+        timezone=city_meta["timezone"],
+        timestamp=timestamp,
+    )
+    return today, user_metadata
+
+
 def initialize_placeholder_map(
     user_metadata: UserMetadata,
     values: dict[str, str],

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -5,7 +5,6 @@ import re
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any, Literal
-from zoneinfo import ZoneInfo
 
 from beartype import beartype
 from loguru import logger
@@ -16,7 +15,6 @@ from typing_extensions import TypedDict
 from navi_bench.base import (
     BaseMetric,
     BaseTaskConfig,
-    UserMetadata,
     build_task_config,
     fractional_coverage_score,
     hour_to_12h_period,
@@ -27,6 +25,7 @@ from navi_bench.dates import (
     initialize_placeholder_map,
     initialize_user_metadata,
     render_task_statement,
+    resolve_city_now,
 )
 
 
@@ -790,14 +789,7 @@ def generate_task_config_random(
     city_meta = CITY_METADATA.get(city, CITY_METADATA["SF"])  # Default to SF if city not found
     city_display = CITY_METADATA.get(city, {}).get("location", city)
 
-    tz_info = ZoneInfo(city_meta["timezone"])
-    today = datetime.now(tz_info)
-    timestamp = int(today.timestamp())
-    user_metadata = UserMetadata(
-        location=city_meta["location"],
-        timezone=city_meta["timezone"],
-        timestamp=timestamp,
-    )
+    today, user_metadata = resolve_city_now(city_meta)
 
     # Determine party size range
     if party_size_range is None:

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -6,7 +6,6 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
 from urllib.parse import parse_qs, urlparse
-from zoneinfo import ZoneInfo
 
 from beartype import beartype
 from loguru import logger
@@ -16,7 +15,6 @@ from navi_bench.base import (
     BaseMetric,
     BaseTaskConfig,
     FinalResult,
-    UserMetadata,
     basic_normalize_url,
     build_task_config,
     hour_to_12h_period,
@@ -27,6 +25,7 @@ from navi_bench.dates import (
     initialize_placeholder_map,
     initialize_user_metadata,
     render_task_statement,
+    resolve_city_now,
 )
 
 
@@ -961,14 +960,7 @@ def generate_task_config_random(
     city_display = city_meta["location"]
     city_slug = city_meta["city_slug"]
 
-    tz_info = ZoneInfo(city_meta["timezone"])
-    today = datetime.now(tz_info)
-    timestamp = int(today.timestamp())
-    user_metadata = UserMetadata(
-        location=city_meta["location"],
-        timezone=city_meta["timezone"],
-        timestamp=timestamp,
-    )
+    today, user_metadata = resolve_city_now(city_meta)
 
     # Determine party size
     if party_size is None:


### PR DESCRIPTION
## Summary
- `resy_url_match.py` and `opentable_info_gathering.py`'s `generate_task_config_random` each had the identical 8-line block resolving a city's current tz-aware timestamp and building the corresponding `UserMetadata` from `CITY_METADATA`.
- Extracted `resolve_city_now(city_meta) -> tuple[datetime, UserMetadata]` into `dates.py` (already imported by both files); both call sites now delegate to it.

## Why this is safe
- The extracted code is a byte-for-byte copy of the duplicated block (verified via `diff` before extracting) — pure code motion, no logic change.
- `tz_info`/`timestamp` were local-only in both original call sites; `today` continues to be used downstream exactly as before.
- This repo has no test suite. Verified correctness by importing both modules and calling `resolve_city_now()` directly to confirm it produces the same `(datetime, UserMetadata)` shape the inlined code did.

## Test plan
- [x] `python -c "import navi_bench.resy.resy_url_match, navi_bench.opentable.opentable_info_gathering"` — imports cleanly
- [x] `resolve_city_now({...})` manually exercised, produces expected tz-aware datetime + UserMetadata
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QP5hSv5J2v2noroqRJzPGA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure code motion with no logic change; only affects benchmark task config generation helpers, not runtime auth or data paths.
> 
> **Overview**
> Adds **`resolve_city_now(city_meta)`** in `dates.py` to centralize the repeated pattern of getting a city’s tz-aware “now” and building matching **`UserMetadata`**.
> 
> **OpenTable** and **Resy** `generate_task_config_random` now call that helper instead of inlining the same **`ZoneInfo` / `datetime.now` / timestamp** block. Each file drops the local **`ZoneInfo`** import and no longer imports **`UserMetadata`** from `base` for that path only.
> 
> Behavior for random task generation is unchanged: **`today`** and **`user_metadata`** still come from the same city metadata fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6fcf5e0d7cdea84d1154ff8a482ac36e9c4cfd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->