### PR TITLE
refactor(base): extract hour_to_12h_period helper shared by resy and opentable

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -69,6 +69,15 @@ def fractional_coverage_score(n_covered: int, n_total: int) -> float:
     return n_covered / max(n_total, 1)
 
 
+def hour_to_12h_period(hour: int) -> tuple[int, str]:
+    """Convert a 24-hour ``hour`` (0-23) to its 12-hour display value and AM/PM period.
+
+    Returns ``(display_hour, period)`` with ``period`` lowercase (``"am"``/``"pm"``);
+    callers needing uppercase can ``.upper()`` it.
+    """
+    return hour % 12 or 12, "pm" if hour >= 12 else "am"
+
+
 def parse_filtered_query_params(query: str, ignored: Iterable[str]) -> dict[str, list[str]]:
     """Parse a URL query string and drop keys in ``ignored``.
 

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -19,6 +19,7 @@ from navi_bench.base import (
     UserMetadata,
     build_task_config,
     fractional_coverage_score,
+    hour_to_12h_period,
     read_sidecar,
 )
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
@@ -601,8 +602,7 @@ def time_to_natural_language(time_str: str) -> str:
     hour = int(parts[0])
     minute = int(parts[1]) if len(parts) > 1 else 0
 
-    hour_12 = hour % 12 or 12
-    period = "pm" if hour >= 12 else "am"
+    hour_12, period = hour_to_12h_period(hour)
 
     if minute == 0:
         return f"{hour_12}{period}"

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -19,6 +19,7 @@ from navi_bench.base import (
     UserMetadata,
     basic_normalize_url,
     build_task_config,
+    hour_to_12h_period,
     read_sidecar,
 )
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
@@ -798,10 +799,9 @@ def format_time_display(time_hhmm: str) -> str:
     hour = int(time_hhmm[:2])
     minute = int(time_hhmm[2:])
 
-    display_hour = hour % 12 or 12
-    period = "PM" if hour >= 12 else "AM"
+    display_hour, period = hour_to_12h_period(hour)
 
-    return f"{display_hour}:{minute:02d} {period}"
+    return f"{display_hour}:{minute:02d} {period.upper()}"
 
 
 def select_valid_date(base_date: datetime, date_range: tuple[int, int], closed_days: list[str]) -> datetime:


### PR DESCRIPTION
## What

`navi_bench/resy/resy_url_match.py::format_time_display` and `navi_bench/opentable/opentable_info_gathering.py::time_to_natural_language` each independently reimplemented the same 12-hour-clock arithmetic:

```python
display_hour = hour % 12 or 12
period = "PM" if hour >= 12 else "AM"   # or lowercase "pm"/"am"
```

before diverging on their own output formatting (colon/space/case conventions). Extracted the shared arithmetic into `navi_bench.base.hour_to_12h_period(hour) -> (display_hour, period)` (returns lowercase `period`) and updated both call sites to use it, keeping each function's own string formatting unchanged.

## Why this is safe

- Pure extraction of identical arithmetic — no change to either function's inputs/outputs.
- Verified output is byte-identical before and after across midnight/noon/AM/PM inputs for both functions:
  - `format_time_display`: `'0600'→'6:00 AM'`, `'1830'→'6:30 PM'`, `'0000'→'12:00 AM'`, `'1200'→'12:00 PM'`
  - `time_to_natural_language`: `'18:00'→'6pm'`, `'6:30'→'6:30am'`, `'0:00'→'12am'`, `'12:00'→'12pm'`
- Touches 3 files: the new helper in `navi_bench/base.py`, and the two call sites.
- `ruff check` / `ruff format --check` pass clean on all three files.

## Test plan

- [x] Manually verified both functions produce identical output for representative inputs before/after
- [x] `uv run ruff check navi_bench/base.py navi_bench/resy/resy_url_match.py navi_bench/opentable/opentable_info_gathering.py` — clean
- [x] `uv run ruff format --check ...` — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qu8shrbE61xET3ed7AyZ3M


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qu8shrbE61xET3ed7AyZ3M)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deduplication of identical arithmetic; domain-specific formatting is unchanged and outputs are intended to stay byte-identical.
> 
> **Overview**
> Adds **`hour_to_12h_period`** in `navi_bench.base` so Resy and OpenTable no longer duplicate the same 24→12-hour hour and am/pm logic.
> 
> **OpenTable** `time_to_natural_language` and **Resy** `format_time_display` now call the helper; each keeps its own string shape (compact `6pm` vs `6:00 PM`, with Resy uppercasing the period via `.upper()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a2ebf14f300e9bd520faad7099dd7babbc8abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->