### PR TITLE
refactor(dates): extract ensure_resolved_dates helper for empty-placeholder guard

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -189,6 +189,17 @@ def render_task_statement(task: str, resolved_placeholders: dict[str, tuple[str,
     return result
 
 
+def ensure_resolved_dates(dates: list[str], placeholder_key: str) -> None:
+    """Raise if a placeholder resolved to no dates via :func:`initialize_placeholder_map`.
+
+    Shared guard used by resy's and opentable's ``_render_placeholders_in_queries_{any,all}``
+    helpers, which each consume a placeholder's resolved ISO-date list and must reject an
+    empty one (e.g. a relative-date description that only matched past dates) before use.
+    """
+    if not dates:
+        raise ValueError(f"No future dates resolved for placeholder '{placeholder_key}'")
+
+
 def initialize_user_metadata(
     timezone: str,
     location: str,

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -22,7 +22,12 @@ from navi_bench.base import (
     hour_to_12h_period,
     read_sidecar,
 )
-from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
+from navi_bench.dates import (
+    ensure_resolved_dates,
+    initialize_placeholder_map,
+    initialize_user_metadata,
+    render_task_statement,
+)
 
 
 class SingleCandidateQuery(TypedDict, total=False):
@@ -887,8 +892,7 @@ def _render_placeholders_in_queries_any(
     """
     for placeholder_key, (_, dates) in resolved_placeholders.items():
         template_string = "{" + placeholder_key + "}"
-        if not dates:
-            raise ValueError(f"No future dates resolved for placeholder '{placeholder_key}'")
+        ensure_resolved_dates(dates, placeholder_key)
 
         for query in queries:
             for candidate_obj in query:
@@ -916,8 +920,7 @@ def _render_placeholders_in_queries_all(
 
     queries = []
     for placeholder_key, (_, dates) in resolved_placeholders.items():
-        if not dates:
-            raise ValueError(f"No future dates resolved for placeholder '{placeholder_key}'")
+        ensure_resolved_dates(dates, placeholder_key)
 
         for date in dates:
             for restaurant_name in template_query_dict.get("restaurant_names", [None]):

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -22,7 +22,12 @@ from navi_bench.base import (
     hour_to_12h_period,
     read_sidecar,
 )
-from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
+from navi_bench.dates import (
+    ensure_resolved_dates,
+    initialize_placeholder_map,
+    initialize_user_metadata,
+    render_task_statement,
+)
 
 
 @runtime_checkable
@@ -1037,8 +1042,7 @@ def _render_placeholders_in_queries_any(
     """
     for placeholder_key, (_, dates) in resolved_placeholders.items():
         template_string = "{" + placeholder_key + "}"
-        if not dates:
-            raise ValueError(f"No future dates resolved for placeholder '{placeholder_key}'")
+        ensure_resolved_dates(dates, placeholder_key)
         if len(dates) != 1:
             raise ValueError(
                 "generate_task_config_deterministic (mode='any') expects descriptions resolving to a single date. "
@@ -1076,8 +1080,7 @@ def _render_placeholders_in_queries_all(
     queries = []
     for placeholder_key, (_, dates) in resolved_placeholders.items():
         template_string = "{" + placeholder_key + "}"
-        if not dates:
-            raise ValueError(f"No future dates resolved for placeholder '{placeholder_key}'")
+        ensure_resolved_dates(dates, placeholder_key)
         _ensure_within_booking_window(dates, base_date, booking_window, placeholder_key)
         for d in dates:
             queries.append([template_url.replace(template_string, d)])


### PR DESCRIPTION
## Structural issue

`navi_bench/resy/resy_url_match.py` and `navi_bench/opentable/opentable_info_gathering.py` each define a pair of placeholder-rendering helpers (`_render_placeholders_in_queries_any` / `_render_placeholders_in_queries_all`). All four of these functions independently duplicated the exact same guard clause, verbatim, including the error message:

```python
if not dates:
    raise ValueError(f"No future dates resolved for placeholder '{placeholder_key}'")
```

This is the same duplicated-literal/duplicated-check pattern that recent PRs in this repo (#100–#105) have been steadily extracting elsewhere (`_maybe_iso_list`, `fractional_coverage_score`, `hour_to_12h_period`, etc.) — this was simply the last remaining instance of that pattern that hadn't been swept yet.

## Fix

Extracted the check into a single `ensure_resolved_dates(dates, placeholder_key)` function in `navi_bench/dates.py` (next to `initialize_placeholder_map`, which is what produces the `resolved_placeholders` dict all four call sites consume). All four call sites now call the shared helper instead of duplicating the `if`/`raise`.

## Why this is safe

This repo has no test suite, so verification was done by:
1. **Mechanical equivalence**: the extracted function's body is a byte-for-byt (down to the f-string) copy of what was inlined at each of the four call sites — there is no behavior change, only a change in where the check lives.
2. **Static checks**: `ruff check .` passes repo-wide; the touched files are unaffected by the one pre-existing `ruff format` diff in `dates.py` (confirmed via `git stash` that the same formatting diff exists on `main` before this change, unrelated to this PR).
3. **Manual exercise**: ran all four affected code paths directly against the actual public entry points:
   - `resy_url_match.generate_task_config_deterministic(mode="any", ...)` and `mode="all"`
   - `opentable_info_gathering.generate_task_config_deterministic(mode="any", ...)` and `mode="all"`
   
   confirming each produces the same resolved `queries` output as before, and separately confirmed `ensure_resolved_dates([], key)` raises the identical `ValueError` message that was previously inlined, and is a no-op for a non-empty list.

No behavior changes; this is a pure refactor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H2QGzBM7YAi9X2d83Pon79)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical guard logic and messages; no functional or security impact.
> 
> **Overview**
> **Deduplicates** the empty ISO-date list guard that appeared in four Resy and OpenTable placeholder-rendering helpers by adding **`ensure_resolved_dates`** in `navi_bench/dates.py` (alongside `initialize_placeholder_map`).
> 
> **OpenTable** and **Resy** `_render_placeholders_in_queries_any` / `_render_placeholders_in_queries_all` now import and call that helper instead of inlining the same `ValueError` when a placeholder resolves to no future dates. Behavior and error message are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b540e3c5fee3f91f920c6afe9e04612ce8bf034c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->