### PR TITLE
refactor(opentable): delegate _parse_date_time_range to _convert_date_time_to_timestamp

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -474,7 +474,7 @@ class OpenTableInfoGathering(BaseMetric):
 
     @classmethod
     def _parse_date_time_range(cls, date: str, time: str, info: str) -> tuple[float, float]:
-        base_ts = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M:%S").timestamp()
+        base_ts = cls._convert_date_time_to_timestamp(date, time)
 
         if match := re.search(r"within ([\d\.]+) hours", info):
             hours = float(match.group(1))


### PR DESCRIPTION
## Structural issue

`OpenTableInfoGathering._parse_date_time_range` re-derived `base_ts` by re-typing the exact same expression already encapsulated by the sibling classmethod `_convert_date_time_to_timestamp`:

```python
@classmethod
def _convert_date_time_to_timestamp(cls, date: str, time: str) -> float:
    return datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M:%S").timestamp()

@classmethod
def _parse_date_time_range(cls, date: str, time: str, info: str) -> tuple[float, float]:
    base_ts = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M:%S").timestamp()
    ...
```

Both methods are called side-by-side from `_check_multi_candidate_query` on the same `(date, time)` pair, so this is the same "duplicated helper logic" pattern prior PRs in this repo have been steadily sweeping (`hour_to_12h_period`, `fractional_coverage_score`, `resolve_city_now`, `ensure_resolved_dates`, `clamp_day` delegation, etc.) — just an instance that hadn't been caught yet, this time within a single file/class rather than across resy/opentable.

## Fix

`_parse_date_time_range` now calls `cls._convert_date_time_to_timestamp(date, time)` instead of duplicating the `datetime.strptime(...).timestamp()` expression. Single source of truth for the date+time → epoch conversion.

## Why this is safe

- Pure delegation: `cls._convert_date_time_to_timestamp(date, time)` evaluates to the exact same expression that was previously inlined — no change to the parsing format, inputs, or outputs.
- Contained to one file, one line changed.
- This repo has no test suite, so I verified correctness directly:
  - Imported `OpenTableInfoGathering` and confirmed `_convert_date_time_to_timestamp(date, time)` and the `base_ts` computed inside `_parse_date_time_range` are numerically identical across several date/time inputs (including midnight and end-of-year edge cases).
  - Confirmed the "within N hours" branch still returns `(base_ts - hours*3600, base_ts + hours*3600)` and the no-match fallback still returns `(base_ts, base_ts)`, both unchanged from before the refactor.

## Test plan

- [x] `python -c "..."` — imported the module and confirmed `_convert_date_time_to_timestamp` and `_parse_date_time_range`'s internal `base_ts` match exactly for `2025-06-30 18:00:00`, `2025-01-01 00:00:00`, and `2025-12-31 23:59:59`
- [x] Confirmed the "within N hours" range math and the no-match fallback both produce identical output to before the change

Found and implemented by the hourly automated structural-refactor job.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U7TgzVBkSAtUZzXbbgkWSA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line pure delegation with identical behavior; no logic, API, or test surface changes beyond DRY cleanup in one classmethod.
> 
> **Overview**
> **`OpenTableInfoGathering._parse_date_time_range`** no longer inlines `datetime.strptime(...).timestamp()` for the anchor epoch; it calls **`cls._convert_date_time_to_timestamp(date, time)`** instead, matching how **`_check_multi_candidate_query`** and related paths already convert query slots.
> 
> The **"within N hours"** window math and the **no-match** `(base_ts, base_ts)` fallback are unchanged—only the source of **`base_ts`** is centralized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2af16f80dfe9bd643ffe329cbc6a7b5244349c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->