### PR TITLE
refactor(opentable): unify multi/single-candidate query matching via shared helper

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -269,6 +269,78 @@ class OpenTableInfoGathering(BaseMetric):
         return False
 
     @classmethod
+    def _match_query_window(
+        cls,
+        query_dates: list[str] | None,
+        query_times: list[str] | None,
+        info: InfoDict,
+    ) -> tuple[Literal["no_online_availability", "range_unavailable", "plain_unavailable", "available"], bool]:
+        """Classify ``info``'s availability status and check whether it matches any of the given
+        candidate dates/times.
+
+        Returns a ``(branch, matched)`` pair: ``branch`` identifies which of the four status
+        patterns ``info["info"]`` falls into, and ``matched`` is True iff at least one
+        ``(date, time)`` combination drawn from ``query_dates`` x ``query_times`` (treating an
+        absent list as "no constraint on this axis") is covered by ``info``. For the two
+        window-based branches (``no_online_availability``, ``range_unavailable``) this requires
+        checking the joint date+time timestamp against a continuous window, so when both axes are
+        given every combination must be checked; for the other two branches date and time are
+        matched independently since they only ever require exact-value membership.
+
+        Shared by ``_check_multi_candidate_query`` (real, possibly multi-valued
+        ``query_dates``/``query_times``, which cares which branch matched in order to decide
+        whether to record ``info`` as unavailability evidence) and
+        ``_check_single_candidate_query`` (its scalar date/time wrapped into singleton lists,
+        which only cares about ``matched`` — see that method for why the branch is irrelevant
+        there).
+        """
+        available_info = info["info"].lower()
+
+        if "no online availability" in available_info:
+            if query_dates and query_times:
+                info_min_ts, info_max_ts = cls._parse_date_time_range(info["date"], info["time"], info["info"])
+                matched = any(
+                    info_min_ts <= cls._convert_date_time_to_timestamp(date, time) <= info_max_ts
+                    for date in query_dates
+                    for time in query_times
+                )
+            elif query_dates:
+                matched = info["date"] in query_dates
+            elif query_times:
+                matched = info["time"] in query_times
+            else:
+                matched = False
+            return "no_online_availability", matched
+
+        if (
+            "unavailable" in available_info
+            and info.get("startDate")
+            and info.get("startTime")
+            and info.get("endDate")
+            and info.get("endTime")
+        ):
+            if query_dates and query_times:
+                start_ts = cls._convert_date_time_to_timestamp(info["startDate"], info["startTime"])
+                end_ts = cls._convert_date_time_to_timestamp(info["endDate"], info["endTime"])
+                matched = any(
+                    start_ts <= cls._convert_date_time_to_timestamp(date, time) < end_ts
+                    for date in query_dates
+                    for time in query_times
+                )
+            elif query_dates:
+                matched = any(info["startDate"] <= date < info["endDate"] for date in query_dates)
+            elif query_times:
+                matched = any(info["startTime"] <= time < info["endTime"] for time in query_times)
+            else:
+                matched = False
+            return "range_unavailable", matched
+
+        matched = (not query_dates or info["date"] in query_dates) and (not query_times or info["time"] in query_times)
+        if "unavailable" in available_info or "unfortunately" in available_info:
+            return "plain_unavailable", matched
+        return "available", matched
+
+    @classmethod
     def _check_multi_candidate_query(
         cls, query: MultiCandidateQuery, info: InfoDict, evidences: list[InfoDict]
     ) -> bool:
@@ -286,85 +358,15 @@ class OpenTableInfoGathering(BaseMetric):
             if info["partySize"] not in party_sizes:
                 return False
 
-        query_dates = query.get("dates")
-        query_times = query.get("times")
+        branch, matched = cls._match_query_window(query.get("dates"), query.get("times"), info)
+        if branch == "available":
+            return matched
 
-        available_info = info["info"].lower()
-
-        if "no online availability" in available_info:
-            # restaurant is unavailable during a certain time period
-            if query_dates and query_times:
-                info_min_ts, info_max_ts = cls._parse_date_time_range(info["date"], info["time"], info["info"])
-                for date in query_dates:
-                    for time in query_times:
-                        query_ts = cls._convert_date_time_to_timestamp(date, time)
-                        if info_min_ts <= query_ts <= info_max_ts:
-                            evidences.append(info)
-                            return False
-            elif query_dates:
-                if info["date"] in query_dates:
-                    evidences.append(info)
-                    return False
-            elif query_times:
-                if info["time"] in query_times:
-                    evidences.append(info)
-                    return False
-
-            return False
-
-        elif (
-            "unavailable" in available_info
-            and info.get("startDate")
-            and info.get("startTime")
-            and info.get("endDate")
-            and info.get("endTime")
-        ):
-            # restaurant is unavailable during a certain time period
-            if query_dates and query_times:
-                start_ts = cls._convert_date_time_to_timestamp(info["startDate"], info["startTime"])
-                end_ts = cls._convert_date_time_to_timestamp(info["endDate"], info["endTime"])
-                for date in query_dates:
-                    for time in query_times:
-                        query_ts = cls._convert_date_time_to_timestamp(date, time)
-                        if start_ts <= query_ts < end_ts:
-                            evidences.append(info)
-                            return False
-            elif query_dates:
-                for query_date in query_dates:
-                    if info["startDate"] <= query_date < info["endDate"]:
-                        evidences.append(info)
-                        return False
-            elif query_times:
-                for query_time in query_times:
-                    if info["startTime"] <= query_time < info["endTime"]:
-                        evidences.append(info)
-                        return False
-            return False
-
-        elif "unavailable" in available_info or "unfortunately" in available_info:
-            # restaurant is unavailable at certain date and time
-            if query_dates:
-                if info["date"] not in query_dates:
-                    return False
-
-            if query_times:
-                if info["time"] not in query_times:
-                    return False
-
+        # The three unavailable-flavored branches only ever return False here; a match just
+        # means this info is evidence that the query is unavailable for at least one candidate.
+        if matched:
             evidences.append(info)
-            return False
-
-        else:
-            # restaurant is available
-            if query_dates:
-                if info["date"] not in query_dates:
-                    return False
-
-            if query_times:
-                if info["time"] not in query_times:
-                    return False
-
-            return True
+        return False
 
     @classmethod
     def _check_single_candidate_query(cls, query: SingleCandidateQuery, info: InfoDict) -> bool:
@@ -380,51 +382,16 @@ class OpenTableInfoGathering(BaseMetric):
         query_date = query.get("date")
         query_time = query.get("time")
 
-        if "no online availability" in info["info"].lower():
-            if query_date and query_time:
-                info_min_ts, info_max_ts = cls._parse_date_time_range(info["date"], info["time"], info["info"])
-                query_ts = cls._convert_date_time_to_timestamp(query_date, query_time)
-                if info_min_ts <= query_ts <= info_max_ts:
-                    return True
-            elif query_date:
-                if info["date"] == query_date:
-                    return True
-            elif query_time:
-                if info["time"] == query_time:
-                    return True
-            return False
-
-        elif (
-            "unavailable" in info["info"].lower()
-            and info.get("startDate")
-            and info.get("startTime")
-            and info.get("endDate")
-            and info.get("endTime")
-        ):
-            # restaurant is unavailable during a certain time period
-            if query_date and query_time:
-                start_ts = cls._convert_date_time_to_timestamp(info["startDate"], info["startTime"])
-                end_ts = cls._convert_date_time_to_timestamp(info["endDate"], info["endTime"])
-                query_ts = cls._convert_date_time_to_timestamp(query_date, query_time)
-                if start_ts <= query_ts < end_ts:
-                    return True
-            elif query_date:
-                if info["startDate"] <= query_date < info["endDate"]:
-                    return True
-            elif query_time:
-                if info["startTime"] <= query_time < info["endTime"]:
-                    return True
-            return False
-
-        else:
-            # restaurant is available at certain date and time
-            if query_date:
-                if info["date"] != query_date:
-                    return False
-            if query_time:
-                if info["time"] != query_time:
-                    return False
-            return True
+        # Unlike the multi-candidate check, the branch itself doesn't matter here: this method
+        # is only ever called (via `_is_exhausted`) against evidence already known to be
+        # unavailable-flavored, and for every branch "covered by the info" reduces to the same
+        # `matched` predicate regardless of which branch produced it.
+        _, matched = cls._match_query_window(
+            [query_date] if query_date else None,
+            [query_time] if query_time else None,
+            info,
+        )
+        return matched
 
     @classmethod
     def _is_exhausted(cls, query: MultiCandidateQuery, evidences: list[InfoDict]) -> bool:

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -1,0 +1,297 @@
+"""Characterization tests for OpenTableInfoGathering's query-matching logic.
+
+These tests pin the CURRENT behavior of ``_check_multi_candidate_query`` and
+``_check_single_candidate_query`` (and, transitively, ``_is_exhausted``) before a
+structural refactor extracts their shared four-way branch (``"no online availability"``
+/ time-range ``"unavailable"`` / plain ``"unavailable"``-or-``"unfortunately"`` /
+available). They are not meant to exhaustively spec the domain; they exist so a
+refactor of the shared branch logic can be verified as behavior-preserving without
+hand-tracing every case from scratch.
+"""
+
+import pytest
+
+from navi_bench.opentable.opentable_info_gathering import (
+    InfoDict,
+    MultiCandidateQuery,
+    OpenTableInfoGathering,
+    SingleCandidateQuery,
+)
+
+
+def _info(**kwargs) -> InfoDict:
+    base: InfoDict = {
+        "url": "https://www.opentable.com/r/example",
+        "restaurantName": "Chez TJ",
+        "partySize": 2,
+        "info": "",
+        "date": "2025-07-10",
+        "time": "19:00:00",
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestCheckMultiCandidateQuery:
+    """Pin `_check_multi_candidate_query`'s behavior across its four branches."""
+
+    def test_available_branch_returns_true_and_adds_no_evidence(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["19:00:00"]}
+        info = _info(info="Table for 2 is available.")
+        evidences: list[InfoDict] = []
+
+        result = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+
+        assert result is True
+        assert evidences == []
+
+    def test_available_branch_date_mismatch_returns_false_no_evidence(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-11"], "times": ["19:00:00"]}
+        info = _info(info="Table for 2 is available.")
+        evidences: list[InfoDict] = []
+
+        result = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+
+        assert result is False
+        assert evidences == []
+
+    def test_no_online_availability_window_match_adds_evidence(self):
+        # info's requested slot (2025-07-10 19:00) +/- 2 hours covers the query's slot.
+        query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["20:00:00"]}
+        info = _info(info="Sorry, there is no online availability within 2 hours of your requested time.")
+        evidences: list[InfoDict] = []
+
+        result = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+
+        assert result is False
+        assert evidences == [info]
+
+    def test_no_online_availability_window_miss_adds_no_evidence(self):
+        # Query's slot (23:00) falls outside the +/- 2 hour window around 19:00.
+        query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["23:00:00"]}
+        info = _info(info="Sorry, there is no online availability within 2 hours of your requested time.")
+        evidences: list[InfoDict] = []
+
+        result = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+
+        assert result is False
+        assert evidences == []
+
+    def test_range_unavailable_match_adds_evidence(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["19:00:00"]}
+        info = _info(
+            info="This restaurant is unavailable for online booking during this period.",
+            startDate="2025-07-10",
+            startTime="18:00:00",
+            endDate="2025-07-10",
+            endTime="21:00:00",
+        )
+        evidences: list[InfoDict] = []
+
+        result = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+
+        assert result is False
+        assert evidences == [info]
+
+    def test_range_unavailable_miss_adds_no_evidence(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["23:00:00"]}
+        info = _info(
+            info="This restaurant is unavailable for online booking during this period.",
+            startDate="2025-07-10",
+            startTime="18:00:00",
+            endDate="2025-07-10",
+            endTime="21:00:00",
+        )
+        evidences: list[InfoDict] = []
+
+        result = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+
+        assert result is False
+        assert evidences == []
+
+    def test_plain_unavailable_match_adds_evidence(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["19:00:00"]}
+        info = _info(info="Sorry, this time is unavailable.")
+        evidences: list[InfoDict] = []
+
+        result = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+
+        assert result is False
+        assert evidences == [info]
+
+    def test_plain_unfortunately_date_mismatch_adds_no_evidence(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-11"], "times": ["19:00:00"]}
+        info = _info(info="Unfortunately, there are no tables at this time.")
+        evidences: list[InfoDict] = []
+
+        result = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+
+        assert result is False
+        assert evidences == []
+
+
+class TestCheckSingleCandidateQuery:
+    """Pin `_check_single_candidate_query`'s behavior across the same four info flavors."""
+
+    def test_available_branch_match_is_true(self):
+        query: SingleCandidateQuery = {"date": "2025-07-10", "time": "19:00:00"}
+        info = _info(info="Table for 2 is available.")
+
+        assert OpenTableInfoGathering._check_single_candidate_query(query, info) is True
+
+    def test_available_branch_mismatch_is_false(self):
+        query: SingleCandidateQuery = {"date": "2025-07-11", "time": "19:00:00"}
+        info = _info(info="Table for 2 is available.")
+
+        assert OpenTableInfoGathering._check_single_candidate_query(query, info) is False
+
+    def test_no_online_availability_window_match_is_true(self):
+        query: SingleCandidateQuery = {"date": "2025-07-10", "time": "20:00:00"}
+        info = _info(info="Sorry, there is no online availability within 2 hours of your requested time.")
+
+        assert OpenTableInfoGathering._check_single_candidate_query(query, info) is True
+
+    def test_no_online_availability_window_miss_is_false(self):
+        query: SingleCandidateQuery = {"date": "2025-07-10", "time": "23:00:00"}
+        info = _info(info="Sorry, there is no online availability within 2 hours of your requested time.")
+
+        assert OpenTableInfoGathering._check_single_candidate_query(query, info) is False
+
+    def test_range_unavailable_match_is_true(self):
+        query: SingleCandidateQuery = {"date": "2025-07-10", "time": "19:00:00"}
+        info = _info(
+            info="This restaurant is unavailable for online booking during this period.",
+            startDate="2025-07-10",
+            startTime="18:00:00",
+            endDate="2025-07-10",
+            endTime="21:00:00",
+        )
+
+        assert OpenTableInfoGathering._check_single_candidate_query(query, info) is True
+
+    def test_range_unavailable_miss_is_false(self):
+        query: SingleCandidateQuery = {"date": "2025-07-10", "time": "23:00:00"}
+        info = _info(
+            info="This restaurant is unavailable for online booking during this period.",
+            startDate="2025-07-10",
+            startTime="18:00:00",
+            endDate="2025-07-10",
+            endTime="21:00:00",
+        )
+
+        assert OpenTableInfoGathering._check_single_candidate_query(query, info) is False
+
+    def test_plain_unavailable_match_is_true(self):
+        query: SingleCandidateQuery = {"date": "2025-07-10", "time": "19:00:00"}
+        info = _info(info="Sorry, this time is unavailable.")
+
+        assert OpenTableInfoGathering._check_single_candidate_query(query, info) is True
+
+    def test_plain_unfortunately_mismatch_is_false(self):
+        query: SingleCandidateQuery = {"date": "2025-07-11", "time": "19:00:00"}
+        info = _info(info="Unfortunately, there are no tables at this time.")
+
+        assert OpenTableInfoGathering._check_single_candidate_query(query, info) is False
+
+
+class TestIsExhausted:
+    """Pin `_is_exhausted`'s multi-candidate exhaustion behavior, including the
+    evidence-accumulation side effect that only `_check_multi_candidate_query` performs.
+    """
+
+    def test_multi_candidate_not_exhausted_when_one_date_uncovered(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-10", "2025-07-11"], "times": ["19:00:00"]}
+        # Only the 07-10 slot has "unavailable" evidence; 07-11 was never probed.
+        evidence_info = _info(date="2025-07-10", time="19:00:00", info="Sorry, this time is unavailable.")
+        evidences: list[InfoDict] = []
+        matched = OpenTableInfoGathering._check_multi_candidate_query(query, evidence_info, evidences)
+        assert matched is False
+        assert evidences == [evidence_info]
+
+        assert OpenTableInfoGathering._is_exhausted(query, evidences) is False
+
+    def test_multi_candidate_exhausted_when_all_dates_covered(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-10", "2025-07-11"], "times": ["19:00:00"]}
+        evidences: list[InfoDict] = []
+        for date in ["2025-07-10", "2025-07-11"]:
+            info = _info(date=date, time="19:00:00", info="Sorry, this time is unavailable.")
+            matched = OpenTableInfoGathering._check_multi_candidate_query(query, info, evidences)
+            assert matched is False
+
+        assert len(evidences) == 2
+        assert OpenTableInfoGathering._is_exhausted(query, evidences) is True
+
+    def test_multi_candidate_not_exhausted_with_no_evidence(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["19:00:00"]}
+        assert OpenTableInfoGathering._is_exhausted(query, []) is False
+
+
+@pytest.mark.parametrize(
+    ("info_kwargs", "query_dates", "query_times", "expect_matched"),
+    [
+        (
+            {"info": "Sorry, there is no online availability within 2 hours of your requested time."},
+            ["2025-07-10"],
+            ["20:00:00"],
+            True,
+        ),
+        (
+            {"info": "Sorry, there is no online availability within 2 hours of your requested time."},
+            ["2025-07-10"],
+            ["23:00:00"],
+            False,
+        ),
+        (
+            {
+                "info": "Unavailable during this period.",
+                "startDate": "2025-07-10",
+                "startTime": "18:00:00",
+                "endDate": "2025-07-10",
+                "endTime": "21:00:00",
+            },
+            ["2025-07-10"],
+            ["19:00:00"],
+            True,
+        ),
+        (
+            {"info": "Sorry, this time is unavailable."},
+            ["2025-07-10"],
+            ["19:00:00"],
+            True,
+        ),
+        (
+            {"info": "Table for 2 is available."},
+            ["2025-07-10"],
+            ["19:00:00"],
+            True,
+        ),
+    ],
+)
+def test_multi_and_single_candidate_agree_on_match_outcome(info_kwargs, query_dates, query_times, expect_matched):
+    """The list-valued and scalar-valued checks should agree on whether a singleton
+    query matches, even though only the multi-candidate path records evidence and
+    always returns False for the three unavailable-flavored branches.
+    """
+    info = _info(date="2025-07-10", time="19:00:00", **info_kwargs)
+    multi_query: MultiCandidateQuery = {"dates": query_dates, "times": query_times}
+    single_query: SingleCandidateQuery = {"date": query_dates[0], "time": query_times[0]}
+
+    evidences: list[InfoDict] = []
+    multi_result = OpenTableInfoGathering._check_multi_candidate_query(multi_query, info, evidences)
+    single_result = OpenTableInfoGathering._check_single_candidate_query(single_query, info)
+
+    assert single_result is expect_matched
+    # Whether evidence was recorded (i.e. the branch is unavailable-flavored and matched)
+    # should exactly track `expect_matched` for the unavailable branches, and multi should
+    # return True only for the "available" branch.
+    is_available_branch = "available" == info["info"].lower() or (
+        "unavailable" not in info["info"].lower()
+        and "unfortunately" not in info["info"].lower()
+        and "no online availability" not in info["info"].lower()
+    )
+    if is_available_branch:
+        assert multi_result is expect_matched
+        assert evidences == []
+    else:
+        assert multi_result is False
+        assert evidences == ([info] if expect_matched else [])


### PR DESCRIPTION
## What

`navi_bench/opentable/opentable_info_gathering.py`'s `OpenTableInfoGathering._check_multi_candidate_query`
(operates on list-valued `MultiCandidateQuery` fields) and `_check_single_candidate_query` (operates on
scalar-valued `SingleCandidateQuery` fields) ran the same four-way branch on `info["info"]`:

- `"no online availability"` (window-based match against a parsed `±N hours` range)
- time-range `"unavailable"` (window-based match against explicit `startDate`/`startTime`/`endDate`/`endTime`)
- plain `"unavailable"`/`"unfortunately"` (exact date/time match)
- otherwise, available (exact date/time match)

with parallel but not identical logic — the multi-candidate variant also accumulates `evidences` (used later
by `_is_exhausted`) as a side effect, which is exactly why this was flagged in this repo's refactor backlog as
"plausible but not mechanically verifiable" across the 2026-07-03 and 2026-07-06 audits, pending either added
tests or a careful hand-trace.

## Why this is safe

This repo has no test suite at all, so I didn't want to refactor rendered/verified-by-hand logic on faith.
Approach, in order:

1. **Added 24 characterization tests first** (`tests/test_opentable_info_gathering.py`), covering:
   - `_check_multi_candidate_query` across all four branches (match/no-match for each), asserting both the
     return value *and* whether evidence was recorded — the exact side effect the audits flagged as tricky.
   - `_check_single_candidate_query` across the same four info flavors.
   - `_is_exhausted` for a multi-candidate query: not-exhausted with partial evidence, exhausted once every
     date has matching evidence, and not-exhausted with no evidence.
   - A parametrized test asserting the multi-candidate and single-candidate checks agree on whether a
     singleton query "matches" a given piece of info, which is the load-bearing invariant the refactor
     below relies on.
   - Confirmed all 24 pass against the **pre-refactor** code (this repo does have `pytest`/`pytest-asyncio`
     listed as `dev` extras in `pyproject.toml`, just no `tests/` directory yet — this is the first).

2. **Then extracted the shared branch logic** into `_match_query_window(query_dates, query_times, info) ->
   (branch, matched)`. The key insight that makes this safe rather than just "structurally similar": for the
   three unavailable-flavored branches, `_check_multi_candidate_query` *always* returns `False` (matched or
   not — only whether evidence gets appended differs), while `_check_single_candidate_query`'s return value
   is `matched` for every branch, since it's only ever called (via `_is_exhausted`) against evidence already
   known to be unavailable-flavored, where "covered by the info" reduces to the same predicate regardless of
   which branch produced it. So:
   - `_check_multi_candidate_query` now calls the helper, returns `matched` directly for `"available"`, and
     for the other three branches appends evidence iff `matched` and always returns `False`.
   - `_check_single_candidate_query` wraps its scalar date/time into singleton lists and returns `matched`
     directly, ignoring the branch.

3. **Re-ran the same 24 tests, unchanged, against the refactored code** — all still pass, since they pin
   behavior rather than implementation.

## Verification

```
$ python3 -m pytest tests/ -v
24 passed in ...
$ ruff check .
All checks passed!
$ ruff format --check .
2 files already formatted
```

No behavior change intended or observed; this is a pure structural extraction with test coverage added
specifically to make the extraction mechanically verifiable, per the standing backlog recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hf7aVcBkci8428fdi6nyQ9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core benchmark query-coverage matching used for eval scores; risk is mitigated by a behavior-preserving refactor and new characterization tests, but a subtle branch/evidence bug would still skew coverage results.
> 
> **Overview**
> Pulls duplicated date/time matching out of `_check_multi_candidate_query` and `_check_single_candidate_query` into a new **`_match_query_window`** helper that classifies OpenTable availability text and returns `(branch, matched)`.
> 
> The multi-candidate path still returns **`matched`** only on the **available** branch and appends **`evidences`** on unavailable matches before returning false; the single-candidate path wraps scalar date/time as singleton lists and returns **`matched`** only. Window checks use **`any(...)`** over date×time combinations instead of nested loops.
> 
> Adds **`tests/test_opentable_info_gathering.py`** with characterization tests for both check methods, **`_is_exhausted`**, and multi vs single agreement on singleton queries—intended to lock behavior before/after the extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1c53e377f67d85f2486dcbabe18b2a9c6357ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->