### PR TITLE
refactor(resy): extract shared placeholder-date validation helper

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -906,6 +906,34 @@ def _render_placeholders_in_queries(
     return new_queries
 
 
+def _validate_placeholder_dates_and_get_template_string(
+    dates: list[str],
+    placeholder_key: str,
+    base_date: date,
+    booking_window: int | None,
+    *,
+    require_single_date: bool = False,
+) -> str:
+    """Validate a placeholder's resolved dates and return its ``{key}`` template string.
+
+    Shared by ``_render_placeholders_in_queries_any``/``_all``: both must reject an empty
+    ``dates`` list (via :func:`ensure_resolved_dates`) and reject dates beyond the booking
+    window (via :func:`_ensure_within_booking_window`) before substituting the placeholder.
+    ``_any`` additionally requires exactly one resolved date; that check runs between the
+    other two, matching the original per-function order, so it takes precedence over the
+    booking-window check for a placeholder that is both multi-valued and out of window.
+    """
+    template_string = "{" + placeholder_key + "}"
+    ensure_resolved_dates(dates, placeholder_key)
+    if require_single_date and len(dates) != 1:
+        raise ValueError(
+            "generate_task_config_deterministic (mode='any') expects descriptions resolving to a single date. "
+            "Use generate_task_config_deterministic (mode='all') for multi-date placeholders."
+        )
+    _ensure_within_booking_window(dates, base_date, booking_window, placeholder_key)
+    return template_string
+
+
 def generate_task_config_random(
     restaurant: RestaurantDict,
     date_range: tuple[int, int] | None = None,
@@ -1033,14 +1061,9 @@ def _render_placeholders_in_queries_any(
         Updated queries with placeholders replaced by single dates
     """
     for placeholder_key, (_, dates) in resolved_placeholders.items():
-        template_string = "{" + placeholder_key + "}"
-        ensure_resolved_dates(dates, placeholder_key)
-        if len(dates) != 1:
-            raise ValueError(
-                "generate_task_config_deterministic (mode='any') expects descriptions resolving to a single date. "
-                "Use generate_task_config_deterministic (mode='all') for multi-date placeholders."
-            )
-        _ensure_within_booking_window(dates, base_date, booking_window, placeholder_key)
+        template_string = _validate_placeholder_dates_and_get_template_string(
+            dates, placeholder_key, base_date, booking_window, require_single_date=True
+        )
         queries = _render_placeholders_in_queries(queries, template_string, dates[0])
 
     return queries
@@ -1071,9 +1094,9 @@ def _render_placeholders_in_queries_all(
 
     queries = []
     for placeholder_key, (_, dates) in resolved_placeholders.items():
-        template_string = "{" + placeholder_key + "}"
-        ensure_resolved_dates(dates, placeholder_key)
-        _ensure_within_booking_window(dates, base_date, booking_window, placeholder_key)
+        template_string = _validate_placeholder_dates_and_get_template_string(
+            dates, placeholder_key, base_date, booking_window
+        )
         for d in dates:
             queries.append([template_url.replace(template_string, d)])
 

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -1,0 +1,109 @@
+"""Characterization tests for ResyUrlMatch's placeholder-rendering helpers.
+
+These tests pin the CURRENT behavior of ``_render_placeholders_in_queries_any`` and
+``_render_placeholders_in_queries_all`` before a structural refactor extracts their shared
+per-placeholder validation preamble (build the ``{key}`` template string, reject empty
+resolved dates via ``ensure_resolved_dates``, reject dates beyond the booking window via
+``_ensure_within_booking_window``). ``_any`` additionally requires exactly one resolved date,
+checked *between* the other two validations in the original code — a couple of these tests
+exist specifically to pin that ordering (which error wins when a placeholder is both
+multi-valued and out of the booking window) so the refactor can be verified as
+behavior-preserving without hand-tracing every case from scratch.
+"""
+
+from datetime import date
+
+import pytest
+
+from navi_bench.resy.resy_url_match import (
+    _render_placeholders_in_queries_all,
+    _render_placeholders_in_queries_any,
+)
+
+
+BASE_DATE = date(2025, 7, 10)
+
+
+class TestRenderPlaceholdersInQueriesAny:
+    def test_single_date_substitution(self):
+        queries = [["https://resy.com/cities/sf/venues/foo?date={date}&seats=2"]]
+        resolved = {"date": ("July 15, 2025", ["2025-07-15"])}
+
+        result = _render_placeholders_in_queries_any(queries, resolved, BASE_DATE, None)
+
+        assert result == [["https://resy.com/cities/sf/venues/foo?date=2025-07-15&seats=2"]]
+
+    def test_empty_dates_raises_no_future_dates_error(self):
+        queries = [["https://resy.com/cities/sf/venues/foo?date={date}&seats=2"]]
+        resolved = {"date": ("some description", [])}
+
+        with pytest.raises(ValueError, match="No future dates resolved for placeholder 'date'"):
+            _render_placeholders_in_queries_any(queries, resolved, BASE_DATE, None)
+
+    def test_multiple_dates_raises_single_date_expected_error(self):
+        queries = [["https://resy.com/cities/sf/venues/foo?date={date}&seats=2"]]
+        resolved = {"date": ("a range", ["2025-07-15", "2025-07-16"])}
+
+        with pytest.raises(ValueError, match="expects descriptions resolving to a single date"):
+            _render_placeholders_in_queries_any(queries, resolved, BASE_DATE, None)
+
+    def test_date_beyond_booking_window_raises(self):
+        queries = [["https://resy.com/cities/sf/venues/foo?date={date}&seats=2"]]
+        resolved = {"date": ("August 15, 2025", ["2025-08-15"])}
+
+        with pytest.raises(ValueError, match="beyond the booking window"):
+            _render_placeholders_in_queries_any(queries, resolved, BASE_DATE, 10)
+
+    def test_date_within_booking_window_passes(self):
+        queries = [["https://resy.com/cities/sf/venues/foo?date={date}&seats=2"]]
+        resolved = {"date": ("July 15, 2025", ["2025-07-15"])}
+
+        result = _render_placeholders_in_queries_any(queries, resolved, BASE_DATE, 10)
+
+        assert result == [["https://resy.com/cities/sf/venues/foo?date=2025-07-15&seats=2"]]
+
+    def test_multi_date_and_out_of_window_raises_single_date_error_not_window_error(self):
+        """Pins ordering: the single-date check fires before the booking-window check."""
+        queries = [["https://resy.com/cities/sf/venues/foo?date={date}&seats=2"]]
+        resolved = {"date": ("a range far out", ["2025-08-20", "2025-08-21"])}
+
+        with pytest.raises(ValueError, match="expects descriptions resolving to a single date"):
+            _render_placeholders_in_queries_any(queries, resolved, BASE_DATE, 5)
+
+
+class TestRenderPlaceholdersInQueriesAll:
+    def test_multi_date_expansion(self):
+        template_query = [["https://resy.com/cities/ny/venues/bar?date={dateRange}&seats=13"]]
+        resolved = {"dateRange": ("Dec 5-6", ["2025-07-15", "2025-07-16"])}
+
+        result = _render_placeholders_in_queries_all(template_query, resolved, BASE_DATE, None)
+
+        assert result == [
+            ["https://resy.com/cities/ny/venues/bar?date=2025-07-15&seats=13"],
+            ["https://resy.com/cities/ny/venues/bar?date=2025-07-16&seats=13"],
+        ]
+
+    def test_empty_dates_raises_no_future_dates_error(self):
+        template_query = [["https://resy.com/cities/ny/venues/bar?date={dateRange}&seats=13"]]
+        resolved = {"dateRange": ("some description", [])}
+
+        with pytest.raises(ValueError, match="No future dates resolved for placeholder 'dateRange'"):
+            _render_placeholders_in_queries_all(template_query, resolved, BASE_DATE, None)
+
+    def test_date_beyond_booking_window_raises(self):
+        template_query = [["https://resy.com/cities/ny/venues/bar?date={dateRange}&seats=13"]]
+        resolved = {"dateRange": ("far out", ["2025-07-15", "2025-08-20"])}
+
+        with pytest.raises(ValueError, match="beyond the booking window"):
+            _render_placeholders_in_queries_all(template_query, resolved, BASE_DATE, 10)
+
+    def test_dates_within_booking_window_pass(self):
+        template_query = [["https://resy.com/cities/ny/venues/bar?date={dateRange}&seats=13"]]
+        resolved = {"dateRange": ("close in", ["2025-07-15", "2025-07-16"])}
+
+        result = _render_placeholders_in_queries_all(template_query, resolved, BASE_DATE, 10)
+
+        assert result == [
+            ["https://resy.com/cities/ny/venues/bar?date=2025-07-15&seats=13"],
+            ["https://resy.com/cities/ny/venues/bar?date=2025-07-16&seats=13"],
+        ]


### PR DESCRIPTION
## What

`navi_bench/resy/resy_url_match.py`'s `_render_placeholders_in_queries_any` and
`_render_placeholders_in_queries_all` each repeated the same per-placeholder preamble:

```python
template_string = "{" + placeholder_key + "}"
ensure_resolved_dates(dates, placeholder_key)
_ensure_within_booking_window(dates, base_date, booking_window, placeholder_key)
```

with `_any` additionally requiring exactly one resolved date, checked *between* the other
two validations:

```python
template_string = "{" + placeholder_key + "}"
ensure_resolved_dates(dates, placeholder_key)
if len(dates) != 1:
    raise ValueError(...)
_ensure_within_booking_window(dates, base_date, booking_window, placeholder_key)
```

## Why this is safe

This repo has no CI-enforced test coverage for this file, so I didn't want to refactor
without pinning behavior first. Approach:

1. **Added 10 characterization tests** (`tests/test_resy_url_match.py`) covering both
   functions across: valid substitution, empty resolved dates (`ensure_resolved_dates`
   error), the `_any`-only single-date error, booking-window violations, and — the subtle
   case — a placeholder that is **both** multi-valued **and** out of the booking window,
   asserting the single-date error wins (pinning the original statement order). Ran them
   first against the pre-refactor code; all 10 passed.
2. Extracted `_validate_placeholder_dates_and_get_template_string(dates, placeholder_key,
   base_date, booking_window, require_single_date=False)`, preserving the exact original
   call order (`ensure_resolved_dates` → optional single-date check → booking-window check)
   so error precedence for the empty/multi-date/out-of-window edge cases is unchanged.
3. Re-ran the same 10 tests, unchanged, after the refactor — all still pass, along with the
   pre-existing 24 `tests/test_opentable_info_gathering.py` tests (34/34 total).
4. `ruff check` and `ruff format --check` both pass.
5. Manually exercised both modes end-to-end via `generate_task_config_deterministic` to
   confirm the real call sites still produce identical rendered URLs.

## Scope

Single file touched (`navi_bench/resy/resy_url_match.py`) plus the new test file. No
behavior change — pure duplication extraction with error-precedence explicitly preserved
and pinned by tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZTpbQv2ejSvDHGxWgk6Qn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of benchmark task-config URL rendering with no intended behavior change; new tests explicitly guard validation order and error messages.
> 
> **Overview**
> Pulls duplicated per-placeholder validation out of **`_render_placeholders_in_queries_any`** and **`_render_placeholders_in_queries_all`** into a new **`_validate_placeholder_dates_and_get_template_string`** helper that builds the `{key}` token, runs **`ensure_resolved_dates`**, optionally enforces a single date for `mode='any'`, then **`_ensure_within_booking_window`**, preserving the original check order (including single-date errors winning over booking-window errors when both apply).
> 
> Adds **`tests/test_resy_url_match.py`** with characterization tests for substitution, empty dates, booking-window limits, and that error precedence so the refactor stays behavior-preserving.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb4a25c63964da9f66a8e3f8fb41d7de62cb66f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->