### PR TITLE
refactor(base): extract shared all-or-nothing coverage scoring helper

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -9,6 +9,7 @@ from typing import Any, TypedDict, Union, get_args, get_origin
 from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value
+from loguru import logger
 from pydantic import BaseModel, Field
 
 
@@ -253,6 +254,21 @@ class FinalResult(BaseModel):
 
     score: float  # 1.0 if match, 0.0 if no match
     reasoning: str | None = None
+
+
+def all_or_nothing_coverage_result(class_name: str, is_covered: list[bool]) -> FinalResult:
+    """Score 1.0 iff every element of ``is_covered`` is True, else 0.0.
+
+    Centralizes the ``all(...) -> score -> sum(...) -> FinalResult -> log`` tail that
+    domain matchers requiring every ground-truth query/info to be covered (e.g. resy's
+    and google_flights') each repeated verbatim, differing only in the class name used
+    in the log message. Contrast with :func:`fractional_coverage_score`, which scores
+    partial coverage instead of requiring all-or-nothing.
+    """
+    n_covered = sum(is_covered)
+    result = FinalResult(score=1.0 if all(is_covered) else 0.0)
+    logger.info(f"{class_name}.compute result: {result} ({n_covered}/{len(is_covered)} queries covered)")
+    return result
 
 
 class DatasetItem(BaseModel):

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -8,7 +8,14 @@ from typing import Any
 from beartype import beartype
 from loguru import logger
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, FinalResult, UrlMetricInput, build_task_config
+from navi_bench.base import (
+    BaseMetric,
+    BaseTaskConfig,
+    FinalResult,
+    UrlMetricInput,
+    all_or_nothing_coverage_result,
+    build_task_config,
+)
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 from navi_bench.google_flights.google_flights_pb2 import Info
 
@@ -155,14 +162,7 @@ class GoogleFlightsSearchMatch(BaseMetric):
                     break
 
         # Score is 1.0 only if all infos are covered
-        all_covered = all(is_info_covered)
-        score = 1.0 if all_covered else 0.0
-        n_covered = sum(is_info_covered)
-        result = FinalResult(score=score)
-        logger.info(
-            f"GoogleFlightsUrlMatch.compute result: {result} ({n_covered}/{len(self._gt_base_info)} queries covered)"
-        )
-        return result
+        return all_or_nothing_coverage_result("GoogleFlightsUrlMatch", is_info_covered)
 
 
 def resolve_date_references(gt_info: list[dict], resolved_values: dict[str, Any]) -> list[dict]:

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -15,6 +15,7 @@ from navi_bench.base import (
     BaseMetric,
     BaseTaskConfig,
     FinalResult,
+    all_or_nothing_coverage_result,
     basic_normalize_url,
     build_task_config,
     hour_to_12h_period,
@@ -279,11 +280,7 @@ class ResyUrlMatch(BaseMetric):
 
     async def compute(self) -> FinalResult:
         # Score is 1.0 only if all queries are covered
-        all_covered = all(self._is_query_covered)
-        score = 1.0 if all_covered else 0.0
-        n_covered = sum(self._is_query_covered)
-        result = FinalResult(score=score)
-        logger.info(f"ResyUrlMatch.compute result: {result} ({n_covered}/{len(self.queries)} queries covered)")
+        result = all_or_nothing_coverage_result("ResyUrlMatch", self._is_query_covered)
         for idx, info in enumerate(self._coverage_reasons):
             if info is None:
                 logger.info(f"ResyUrlMatch.compute coverage detail q{idx}: NOT COVERED")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,80 @@
+"""Tests for ``all_or_nothing_coverage_result``, extracted from the near-identical
+``all(...) -> score -> sum(...) -> FinalResult -> log`` tail that ``ResyUrlMatch.compute()``
+and ``GoogleFlightsSearchMatch.compute()`` each used to repeat verbatim (differing only in
+the class name baked into the log message). These pin the scoring semantics so the shared
+helper can be verified as behavior-preserving for both call sites.
+"""
+
+import asyncio
+
+from navi_bench.base import FinalResult, all_or_nothing_coverage_result
+from navi_bench.google_flights.google_flights_search_match import GoogleFlightsSearchMatch
+from navi_bench.resy.resy_url_match import ResyUrlMatch
+
+
+class TestAllOrNothingCoverageResult:
+    def test_all_covered_scores_one(self):
+        result = all_or_nothing_coverage_result("SomeMatcher", [True, True, True])
+
+        assert result == FinalResult(score=1.0)
+
+    def test_any_uncovered_scores_zero(self):
+        result = all_or_nothing_coverage_result("SomeMatcher", [True, False, True])
+
+        assert result == FinalResult(score=0.0)
+
+    def test_empty_list_scores_one(self):
+        # vacuously true, mirroring Python's builtin all([]) == True
+        result = all_or_nothing_coverage_result("SomeMatcher", [])
+
+        assert result == FinalResult(score=1.0)
+
+    def test_all_uncovered_scores_zero(self):
+        result = all_or_nothing_coverage_result("SomeMatcher", [False, False])
+
+        assert result == FinalResult(score=0.0)
+
+
+class TestResyUrlMatchComputeUsesSharedHelper:
+    def test_all_queries_covered_scores_one(self):
+        metric = ResyUrlMatch(queries=[["https://resy.com/cities/sf/venues/foo?date=2025-07-15&seats=2"]])
+        metric._is_query_covered = [True]
+
+        result = asyncio.run(metric.compute())
+
+        assert result.score == 1.0
+
+    def test_uncovered_query_scores_zero(self):
+        metric = ResyUrlMatch(queries=[["https://resy.com/cities/sf/venues/foo?date=2025-07-15&seats=2"]])
+
+        result = asyncio.run(metric.compute())
+
+        assert result.score == 0.0
+
+
+class TestGoogleFlightsSearchMatchComputeUsesSharedHelper:
+    _GT_INFO = [
+        {
+            "segments": [{"from": "SFO", "to": "MSP", "date": "2025-12-27", "max_stops": 0}],
+            "passengers": ["ADULT"],
+            "seat": "ECONOMY",
+            "trip": "ONE_WAY",
+        }
+    ]
+
+    def test_no_matching_url_scores_zero(self):
+        metric = GoogleFlightsSearchMatch(gt_info=self._GT_INFO)
+
+        result = asyncio.run(metric.compute())
+
+        assert result.score == 0.0
+
+    def test_matching_flight_info_scores_one(self):
+        metric = GoogleFlightsSearchMatch(gt_info=self._GT_INFO)
+        # Directly populate the covered-URL map with the exact base Info the ground truth
+        # resolves to, mirroring what `update()` would store after decoding a matching URL.
+        metric._url_to_flight_info["https://www.google.com/travel/flights?tfs=fake"] = metric._gt_base_info[0]
+
+        result = asyncio.run(metric.compute())
+
+        assert result.score == 1.0


### PR DESCRIPTION
## What

`ResyUrlMatch.compute()` and `GoogleFlightsSearchMatch.compute()` each repeated the same scoring tail verbatim:

```python
all_covered = all(is_covered)
score = 1.0 if all_covered else 0.0
n_covered = sum(is_covered)
result = FinalResult(score=score)
logger.info(f"{ClassName}.compute result: {result} ({n_covered}/{len(is_covered)} queries covered)")
```

Differing only in the class-name string baked into the log message. This is the *all-or-nothing* sibling of the fractional-coverage pattern `base.py` already centralizes via `fractional_coverage_score` (used by craigslist/opentable) — this scoring shape just hadn't been deduplicated yet for the two matchers that require every query/info to be covered.

## Change

- Added `all_or_nothing_coverage_result(class_name: str, is_covered: list[bool]) -> FinalResult` to `navi_bench/base.py`, placed next to `fractional_coverage_score` for discoverability.
- Both `ResyUrlMatch.compute()` and `GoogleFlightsSearchMatch.compute()` now just call the shared helper for their final scoring step.
- The coverage-*determination* loops in each `compute()` (which differ meaningfully between the two domains — resy's conditional time-slot logic vs. google_flights' protobuf equality check) are untouched. Only the shared scoring/logging tail is deduplicated.

## Why it's safe

- Pure extraction — no logic change to either domain's coverage-matching semantics, only where the final `all`/`sum`/`FinalResult`/log block lives.
- Added `tests/test_base.py`:
  - 4 unit tests pinning the new helper's score semantics directly (all-covered → 1.0, partially-covered → 0.0, all-uncovered → 0.0, empty-list → 1.0, matching Python's `all([]) == True`).
  - 4 tests exercising `ResyUrlMatch.compute()` and `GoogleFlightsSearchMatch.compute()` end-to-end (covered vs. uncovered cases) to confirm both call sites still score correctly through the shared helper.
- All 42 tests in the repo pass (`python -m pytest tests/ -q`).
- Ran both modules' `python -m navi_bench.resy.resy_url_match` / `python -m navi_bench.google_flights.google_flights_search_match` demo entrypoints manually — `generate_task_config` and evaluator instantiation are unaffected.
- `ruff check` and `ruff format --check` pass clean on all touched files.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01UqZLtVkFeQMzMidQiLLB7z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of scoring/logging only; new tests lock semantics. Resy and Google Flights eval scoring should be unchanged.
> 
> **Overview**
> Introduces **`all_or_nothing_coverage_result`** in `navi_bench/base.py` next to **`fractional_coverage_score`**, so Resy and Google Flights matchers share the same final step: score **1.0** only when every coverage flag is true, otherwise **0.0**, plus the standard result log line.
> 
> **`ResyUrlMatch.compute()`** and **`GoogleFlightsSearchMatch.compute()`** now delegate that tail to the helper; domain-specific coverage logic is unchanged. Resy still logs per-query coverage details after scoring.
> 
> Adds **`tests/test_base.py`** with unit tests for the helper (including empty-list → 1.0) and short integration checks that both matchers still score correctly through it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ef8f7edbce51911c38608515f8855cf407e4fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->