### PR TITLE
refactor(vis): unify form-action and regular-action HTML templates

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -8,6 +8,15 @@ from yutori.navigator import NAVIGATOR_COORDINATE_SCALE
 # sources) that represent an implicit "stop" action rather than a browser interaction.
 _STOP_ACTION_TYPES = ("Finished", "CallUser", "finished", "call_user")
 
+# Form recording actions get a distinct card style plus a leading icon in the action label.
+# Membership in this dict is also how the action-list renderer decides an action is form-related.
+_FORM_ACTION_ICONS: dict[str, str] = {
+    "add_question": "📝",
+    "add_input_options": "📋",
+    "add_choices": "📋",  # Legacy
+    "list_records": "📊",
+}
+
 
 def _truncate_preview(text: str, limit: int = 150) -> str:
     """Truncate ``text`` to ``limit`` characters, appending an ellipsis if shortened."""
@@ -1329,23 +1338,15 @@ def generate_visualization_html(
                     details.append("(outputs all recorded questions)")
 
                 # Special styling for form recording actions
-                if action_type in ("add_question", "add_input_options", "add_choices", "list_records"):
-                    icon = {
-                        "add_question": "📝",
-                        "add_input_options": "📋",
-                        "add_choices": "📋",  # Legacy
-                        "list_records": "📊",
-                    }.get(action_type, "")
-                    actions_html += f"""
-            <div class="action-item form-action">
-                <div class="action-type">{icon} {i + 1}. {action_type}</div>
-                <div class="action-details">{", ".join(details) if details else "No additional details"}</div>
-            </div>
-"""
+                if action_type in _FORM_ACTION_ICONS:
+                    css_class = "action-item form-action"
+                    label = f"{_FORM_ACTION_ICONS[action_type]} {i + 1}. {action_type}"
                 else:
-                    actions_html += f"""
-            <div class="action-item">
-                <div class="action-type">{i + 1}. {action_type}</div>
+                    css_class = "action-item"
+                    label = f"{i + 1}. {action_type}"
+                actions_html += f"""
+            <div class="{css_class}">
+                <div class="action-type">{label}</div>
                 <div class="action-details">{", ".join(details) if details else "No additional details"}</div>
             </div>
 """


### PR DESCRIPTION
## Summary
- `generate_visualization_html()` in `evaluation/vis.py` built two near-identical action-card HTML f-strings (form-action vs. regular action), differing only in CSS class and an optional icon prefix, with the icon lookup and the "is this a form action" 4-tuple duplicated as two separate literals for the same four action types.
- Extracts a module-level `_FORM_ACTION_ICONS` dict (mirroring the existing `_STOP_ACTION_TYPES` constant convention already in this file) that serves both as the icon lookup and the form-action membership check, and collapses the two template branches into one that only computes the `css_class`/`label` that actually differ.
- Pure refactor, zero behavior change — this only affects the debug/visualization HTML output, not any benchmark scoring/verifier logic.

## Verification
- Wrote a standalone before/after equivalence script (not committed) exercising all four form-action types plus non-form actions and confirmed byte-identical HTML output.
- Ran the full existing test suite: `42 passed`.
- `ruff check` / `ruff format --check` clean on the changed file.
- Manually rendered `generate_visualization_html()` end-to-end with a message history containing both an `add_question` and a `left_click` action and confirmed the output HTML still contains the expected `form-action` class, icon, and labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012c13G2DxwXxZnDqD19eXGm

---
_Generated by [Claude Code](https://claude.ai/code/session_012c13G2DxwXxZnDqD19eXGm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only HTML generation refactor with no scoring or runtime logic touched.
> 
> **Overview**
> In **`evaluation/vis.py`**, form-recording action cards in the eval debug HTML no longer use a separate inline icon map and duplicate “is form action?” tuple. Those are replaced by a module-level **`_FORM_ACTION_ICONS`** dict (same pattern as **`_STOP_ACTION_TYPES`**) that drives both membership and emoji labels.
> 
> The action-list renderer now uses **one** HTML template branch: it only varies **`css_class`** (`form-action` vs default) and the **`label`** (optional icon prefix) before appending the same card markup.
> 
> **Scope:** visualization HTML only; no change to scoring or verifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878037b19b6d95c13a09cf7317a51c9deb03fb08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->