### PR TITLE
refactor(opentable): reuse relative_dates.WEEKDAYS instead of local weekday_map

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -27,6 +27,7 @@ from navi_bench.dates import (
     render_task_statement,
     resolve_city_now,
 )
+from navi_bench.relative_dates import WEEKDAYS
 
 
 class SingleCandidateQuery(TypedDict, total=False):
@@ -695,16 +696,7 @@ def get_days_until_date(date_label: str, today: datetime) -> list[int]:
     elif date_label.startswith("for the upcoming "):
         # Extract weekday name
         weekday_name = date_label.replace("for the upcoming ", "")
-        weekday_map = {
-            "Monday": 0,
-            "Tuesday": 1,
-            "Wednesday": 2,
-            "Thursday": 3,
-            "Friday": 4,
-            "Saturday": 5,
-            "Sunday": 6,
-        }
-        target_day = weekday_map[weekday_name]
+        target_day = WEEKDAYS[weekday_name.lower()]
 
         # Calculate days until next occurrence of this weekday
         current_day = today.weekday()  # 0=Monday, 6=Sunday


### PR DESCRIPTION
## Issue

`get_days_until_date()` in `navi_bench/opentable/opentable_info_gathering.py` hand-rolled a local
`weekday_map = {"Monday": 0, ..., "Sunday": 6}` dict to resolve a weekday name to its
`date.weekday()`-style index. `navi_bench/relative_dates.py` already builds an equivalent mapping
(`WEEKDAYS = {name.lower(): i for i, name in enumerate(calendar.day_name)}`, plus abbreviations)
that is used throughout the rest of the date-parsing code (including by `navi_bench/dates.py`,
which already imports from `relative_dates.py`).

## Improvement

Import `WEEKDAYS` from `navi_bench.relative_dates` and replace the local dict + lookup with
`WEEKDAYS[weekday_name.lower()]`. Removes a duplicated 9-line literal in favor of the existing
shared source of truth.

## Safety justification

- Single file changed, pure dedup — no new logic introduced.
- The only two places `get_days_until_date` is ever called with a `"for the upcoming <Weekday>"`
  label pass a full capitalized weekday name from a fixed constant list (lines 542-548 and 1017
  of the same file), so `WEEKDAYS[weekday_name.lower()]` resolves to exactly the same integer as
  the old dict for every real input.
- Verified via `git stash`/`git stash pop` before/after comparison that `get_days_until_date(f"for the upcoming {wd}", today)` returns byte-identical output for all seven weekdays.
- Full test suite passes unchanged: `pytest tests/` → 42 passed (before and after).
- `ruff check` / `ruff format --check` clean on the touched file.

This follows the established pattern in this repo's refactor history of consolidating duplicated
calendar/date literals into `relative_dates.py`'s shared constants (see prior PRs extracting
`_days_in_month`, `add_months`/`clamp_day`, `hour_to_12h_period`, etc.).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFgxKQh2rGG7qQA9aHXPqs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file dedup with no new logic; weekday resolution should match prior mapping for existing call-site inputs.
> 
> **Overview**
> **`get_days_until_date`** no longer defines a local Monday–Sunday index map for `"for the upcoming <Weekday>"` labels. It imports shared **`WEEKDAYS`** from **`navi_bench.relative_dates`** and resolves the weekday with **`WEEKDAYS[weekday_name.lower()]`**, matching the rest of the date-parsing stack.
> 
> Behavior for the fixed capitalized weekday strings used in this file should be unchanged; lookup is case-insensitive via **`.lower()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 599ee3de4d74eb9fc57fd5fe615fada1324250c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->