### PR TITLE
refactor(vis): merge duplicate observation/tool role branches

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -221,10 +221,8 @@ def generate_visualization_html(
             else:
                 if user_query is None:
                     user_query = content
-        elif role == "observation":
-            current_observation = content if isinstance(content, list) else [content]
-        elif role == "tool":
-            # Tool role contains observations (screenshots, text results)
+        elif role in ("observation", "tool"):
+            # "tool" role contains observations (screenshots, text results)
             current_observation = content if isinstance(content, list) else [content]
         elif role == "assistant":
             # Pair with the previous observation


### PR DESCRIPTION
## Issue

In `evaluation/vis.py`, `generate_visualization_html()` had two adjacent `elif` branches with byte-identical bodies:

```python
elif role == "observation":
    current_observation = content if isinstance(content, list) else [content]
elif role == "tool":
    # Tool role contains observations (screenshots, text results)
    current_observation = content if isinstance(content, list) else [content]
```

## Improvement

Collapsed the two branches into one:

```python
elif role in ("observation", "tool"):
    # "tool" role contains observations (screenshots, text results)
    current_observation = content if isinstance(content, list) else [content]
```

## Why it's safe

- Pure structural dedup — no logic changed, just merged into a single condition covering both role values.
- Verified programmatically that `generate_visualization_html()` produces byte-identical HTML output for a message list using `role: "observation"` vs. the same list with `role: "tool"` (the only way these roles are populated elsewhere in the codebase — always list-valued content from screenshots/tool results).
- All 42 existing tests pass (`pytest -q`).
- `ruff check` and `ruff format --check` are clean on the changed file.

This is in the same spirit as prior structural cleanups in this file (e.g. #101, #111 which extracted other duplicated constants/templates from this same function).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NUrfhmTwVpS2JJ1B9mD6HT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural refactor with identical behavior; limited to evaluation visualization parsing.
> 
> **Overview**
> In **`generate_visualization_html`** (`evaluation/vis.py`), two adjacent **`elif`** branches for **`role == "observation"`** and **`role == "tool"`** that did the same thing are replaced with a single **`elif role in ("observation", "tool")`** branch. The shared logic—normalizing message **`content`** into **`current_observation`**—is unchanged; only the control flow is deduplicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfda6fb17cbec0a619493551452a0668d1ab266c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->