### PR TITLE
refactor(dates): extract user_metadata_datetime helper

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -64,6 +64,7 @@ from evaluation.dataset import build_dataset
 from evaluation.recorder import Recorder, log_formatter
 from evaluation.stats import BaseTokenUsage, Crashed, TimingStats, log_section_header, show_results, show_timing_summary
 from navi_bench.base import BaseMetric, BaseTaskConfig, DatasetItem, instantiate
+from navi_bench.dates import user_metadata_datetime
 from yutori import AsyncYutoriClient
 from yutori.auth import resolve_api_key
 from yutori.navigator import denormalize_coordinates, estimate_messages_size_bytes, trimmed_messages_to_fit
@@ -170,10 +171,7 @@ async def run_agent(
     client: AsyncYutoriClient,
 ) -> tuple[BaseModel, TokenUsage, TimingStats]:
 
-    dt = datetime.fromtimestamp(
-        task_config.user_metadata.timestamp,
-        tz=ZoneInfo(task_config.user_metadata.timezone),
-    )
+    dt = user_metadata_datetime(task_config.user_metadata)
     user_prompt = f"""{task_config.task}
 
 # User Context

--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -224,12 +224,17 @@ def resolve_city_now(city_meta: dict) -> tuple[datetime, UserMetadata]:
     return today, user_metadata
 
 
+def user_metadata_datetime(user_metadata: UserMetadata) -> datetime:
+    """Reconstruct the tz-aware datetime a UserMetadata's timestamp/timezone pair represents."""
+    return datetime.fromtimestamp(user_metadata.timestamp, ZoneInfo(user_metadata.timezone))
+
+
 def initialize_placeholder_map(
     user_metadata: UserMetadata,
     values: dict[str, str],
 ) -> tuple[dict[str, tuple[str, list[str]]], date]:
     """Initialize the placeholder map with the current date and time."""
-    base_date = datetime.fromtimestamp(user_metadata.timestamp, ZoneInfo(user_metadata.timezone)).date()
+    base_date = user_metadata_datetime(user_metadata).date()
 
     placeholder_map = {}
     for placeholder_key, relative_description in values.items():


### PR DESCRIPTION
## Issue

`evaluation/eval_n1.py`'s `run_agent()` and `navi_bench/dates.py`'s `initialize_placeholder_map()` each independently reconstructed a tz-aware `datetime` from a `UserMetadata`'s `timestamp` + `timezone`:

```python
datetime.fromtimestamp(user_metadata.timestamp, ZoneInfo(user_metadata.timezone))
```

This is the same shape of duplication as the existing `resolve_city_now()` helper in `navi_bench/dates.py` (merged in #104) — just the `UserMetadata`-timestamp analog of that idiom instead of the `CITY_METADATA`-dict case. It was missed previously because the two call sites are split across `evaluation/` and `navi_bench/`.

## Improvement

Adds `user_metadata_datetime(user_metadata: UserMetadata) -> datetime` to `navi_bench/dates.py`, next to the other date helpers (`resolve_city_now`, `initialize_user_metadata`), and uses it from both call sites:

- `navi_bench/dates.py::initialize_placeholder_map` now calls `user_metadata_datetime(user_metadata).date()`
- `evaluation/eval_n1.py::run_agent` now calls `user_metadata_datetime(task_config.user_metadata)`

No behavior change — pure extraction.

## Verification

- Grepped the whole repo for `datetime.fromtimestamp(` and confirmed these were the only two call sites, both taking the identical two inputs.
- `PYTHONPATH=. python -m pytest tests/ -q` — all 46 existing tests pass.
- Manual check that both call sites produce byte-identical `datetime`/`date` values before and after the change (same `UserMetadata`, compared old inline expression vs. the new helper).
- Manual end-to-end sanity check of `initialize_placeholder_map` with a dynamic placeholder to confirm the refactor didn't change resolved output.
- `ruff check` passes on both touched files (pre-existing, unrelated formatting drift on two untouched lines was left as-is to keep the diff minimal).


---
_Generated by [Claude Code](https://claude.ai/code/session_0171mJWHAuH9BzKsMMkcD4Fu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure extraction with no logic changes; only centralizes existing datetime reconstruction.
> 
> **Overview**
> Introduces **`user_metadata_datetime`** in `navi_bench/dates.py` so a `UserMetadata` timestamp and timezone are turned into one tz-aware `datetime` in a single place, alongside helpers like `resolve_city_now`.
> 
> **`evaluation/eval_n1.py`** `run_agent` and **`initialize_placeholder_map`** in `dates.py` now call that helper instead of repeating `datetime.fromtimestamp(user_metadata.timestamp, ZoneInfo(...))`. Behavior is unchanged; this is deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 179c9f41d95a9654aff76dc1f9ec87dcd084ef2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->