### PR TITLE
refactor(opentable): generate DATE_OPTIONS weekday entries from calendar.day_name

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -1,3 +1,4 @@
+import calendar
 import functools
 import itertools
 import random
@@ -478,13 +479,7 @@ MEAL_TIMES = {
 DATE_OPTIONS = [
     "tomorrow",
     "day after tomorrow",
-    "for the upcoming Monday",
-    "for the upcoming Tuesday",
-    "for the upcoming Wednesday",
-    "for the upcoming Thursday",
-    "for the upcoming Friday",
-    "for the upcoming Saturday",
-    "for the upcoming Sunday",
+    *[f"for the upcoming {day}" for day in calendar.day_name],
     "upcoming weekend",
     "the following weekend",
     "the next two weekends",

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -12,6 +12,7 @@ hand-tracing every case from scratch.
 import pytest
 
 from navi_bench.opentable.opentable_info_gathering import (
+    DATE_OPTIONS,
     MEAL_TIMES,
     InfoDict,
     MultiCandidateQuery,
@@ -331,3 +332,28 @@ class TestMealTimes:
             "17:00:00", "17:15:00", "17:30:00", "17:45:00", "18:00:00", "18:15:00", "18:30:00", "18:45:00",
             "19:00:00", "19:15:00", "19:30:00", "19:45:00", "20:00:00",
         ]  # fmt: skip
+
+
+class TestDateOptions:
+    """Pin the exact ``DATE_OPTIONS`` entries, extracted verbatim from the hand-typed literal
+    list this held before the per-weekday entries were replaced by a generator over
+    ``calendar.day_name``. ``generate_task_config_random`` samples from this list, so a change
+    to its entries or ordering would silently change which date phrasings can be sampled.
+    """
+
+    def test_date_options_are_unchanged(self):
+        assert DATE_OPTIONS == [
+            "tomorrow",
+            "day after tomorrow",
+            "for the upcoming Monday",
+            "for the upcoming Tuesday",
+            "for the upcoming Wednesday",
+            "for the upcoming Thursday",
+            "for the upcoming Friday",
+            "for the upcoming Saturday",
+            "for the upcoming Sunday",
+            "upcoming weekend",
+            "the following weekend",
+            "the next two weekends",
+            "the first weekend of the next calendar month",
+        ]


### PR DESCRIPTION
## Issue

`navi_bench/opentable/opentable_info_gathering.py`'s `DATE_OPTIONS` list hand-typed all 7 `"for the upcoming <Weekday>"` strings in calendar order. This is the same class of issue as the already-merged `MEAL_TIMES` quarter-hour generator (#114) — in fact it lives a few lines below that fix in the same file: a literal that spells out a mechanical rule (one entry per weekday) instead of computing it, which can silently drift on a typo'd or dropped entry.

## Improvement

Replaced the 7 literal weekday entries with a generator over `calendar.day_name`, matching the convention `navi_bench/relative_dates.py` already uses for its `WEEKDAYS` mapping:

```python
DATE_OPTIONS = [
    "tomorrow",
    "day after tomorrow",
    *[f"for the upcoming {day}" for day in calendar.day_name],
    "upcoming weekend",
    "the following weekend",
    "the next two weekends",
    "the first weekend of the next calendar month",
]
```

## Why it's safe

- Single-file source change, pure literal-generation dedup — no logic, scoring, or verifier code touched.
- Verified byte-for-byte equivalence before landing:
  ```python
  import calendar
  generated = [f"for the upcoming {day}" for day in calendar.day_name]
  hand_typed = ["for the upcoming Monday", ..., "for the upcoming Sunday"]
  generated == hand_typed  # True
  ```
- Confirmed via repo-wide grep that `DATE_OPTIONS` and the `"for the upcoming ..."` string pattern have no other call sites — the only consumer is `generate_task_config_random`'s `random.choice(available_date_options)`, which only cares about list membership/values, not literal construction.
- Added `TestDateOptions` in `tests/test_opentable_info_gathering.py`, mirroring the existing `TestMealTimes` characterization tests, pinning the exact previous `DATE_OPTIONS` list *before* the refactor landed.
- Full test suite passes: `python -m pytest tests/ -q` → 47 passed (was 46 before the new test).
- `ruff check` and `ruff format --check` clean on both changed files.

https://claude.ai/code/session_0171mJWHAuH9BzKsMMkcD4Fu

---
_Generated by [Claude Code](https://claude.ai/code/session_0171mJWHAuH9BzKsMMkcD4Fu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Literal deduplication with a regression test; behavior is intended to stay byte-for-byte equivalent for sampled date phrasings.
> 
> **Overview**
> **`DATE_OPTIONS`** in `opentable_info_gathering.py` no longer lists seven weekday strings by hand. Those entries are built from **`calendar.day_name`** with the same `"for the upcoming {day}"` pattern, aligned with how weekday names are handled elsewhere (e.g. `relative_dates`).
> 
> A new **`TestDateOptions`** characterization test pins the full **`DATE_OPTIONS`** list (order and wording) so refactors cannot silently change what **`generate_task_config_random`** can sample via **`random.choice`**.
> 
> No scoring, verifier, or date-resolution logic is changed—only how the static option list is defined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217ecbc5880502c6279fdab7e5d48fd336837285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->