### PR TITLE
refactor(opentable): generate DATE_OPTIONS weekday entries from calendar.day_name

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -1,3 +1,4 @@
+import calendar
 import functools
 import itertools
 import random
@@ -478,13 +479,7 @@ MEAL_TIMES = {
 DATE_OPTIONS = [
     "tomorrow",
     "day after tomorrow",
-    "for the upcoming Monday",
-    "for the upcoming Tuesday",
-    "for the upcoming Wednesday",
-    "for the upcoming Thursday",
-    "for the upcoming Friday",
-    "for the upcoming Saturday",
-    "for the upcoming Sunday",
+    *[f"for the upcoming {day}" for day in calendar.day_name],
     "upcoming weekend",
     "the following weekend",
     "the next two weekends",

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -12,6 +12,7 @@ hand-tracing every case from scratch.
 import pytest
 
 from navi_bench.opentable.opentable_info_gathering import (
+    DATE_OPTIONS,
     MEAL_TIMES,
     InfoDict,
     MultiCandidateQuery,
@@ -331,3 +332,28 @@ class TestMealTimes:
             "17:00:00", "17:15:00", "17:30:00", "17:45:00", "18:00:00", "18:15:00", "18:30:00", "18:45:00",
             "19:00:00", "19:15:00", "19:30:00", "19:45:00", "20:00:00",
         ]  # fmt: skip
+
+
+class TestDateOptions:
+    """Pin the exact ``DATE_OPTIONS`` entries, extracted verbatim from the hand-typed literal
+    list this held before the per-weekday entries were replaced by a generator over
+    ``calendar.day_name``. ``generate_task_config_random`` samples from this list, so a change
+    to its entries or ordering would silently change which date phrasings can be sampled.
+    """
+
+    def test_date_options_are_unchanged(self):
+        assert DATE_OPTIONS == [
+            "tomorrow",
+            "day after tomorrow",
+            "for the upcoming Monday",
+            "for the upcoming Tuesday",
+            "for the upcoming Wednesday",
+            "for the upcoming Thursday",
+            "for the upcoming Friday",
+            "for the upcoming Saturday",
+            "for the upcoming Sunday",
+            "upcoming weekend",
+            "the following weekend",
+            "the next two weekends",
+            "the first weekend of the next calendar month",
+        ]


### PR DESCRIPTION
## What

`DATE_OPTIONS` in `navi_bench/opentable/opentable_info_gathering.py` hand-typed all 7 `"for the upcoming {day}"` strings in calendar order instead of generating them from `calendar.day_name` — the same convention `navi_bench/relative_dates.py` already uses for its `WEEKDAYS` mapping, and the same class of fix as the already-merged `MEAL_TIMES` quarter-hour generator (#114) and the `WEEKDAYS` map reuse (#112).

Replaced the 7 literals with:
```python
*[f"for the upcoming {day}" for day in calendar.day_name]
```

## Why this is an improvement

Removes a hand-maintained list that could silently drift out of calendar order or develop a typo, in favor of deriving it from the same stdlib source (`calendar.day_name`) the rest of the file already trusts for weekday names.

## Why this is safe

- **No behavioral change** — `calendar.day_name` iterates Monday through Sunday, byte-for-byte matching the original hand-typed order.
- Added `TestDateOptions.test_date_options_are_unchanged` (mirrors the existing `TestMealTimes` pattern) that pins the exact pre-refactor `DATE_OPTIONS` list, so any future drift would fail loudly.
- Full test suite passes: 47 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

This was previously implemented and verified (see PR #116, closed unmerged only because the repo's automated refactor job caps at one PR per run and #115 had already shipped that cycle). This PR re-applies the same verified commit on top of current `main`.

Removes the corresponding backlog item from `.claude/REFACTOR.md` in `yutori-ai/yutori` in a companion change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KxweurNT49jN4u9otdkqtg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving bench config refactor with a pinned golden list test; no auth, data, or runtime logic changes beyond string list construction.
> 
> **Overview**
> **`DATE_OPTIONS`** no longer lists seven `"for the upcoming {day}"` strings by hand. Those entries are built from **`calendar.day_name`** (Monday–Sunday), with a new **`import calendar`**, matching how weekday names are sourced elsewhere (e.g. **`relative_dates.WEEKDAYS`**).
> 
> A **`TestDateOptions`** characterization test pins the full pre-refactor list and order so **`generate_task_config_random`** sampling cannot drift silently if the generator or stdlib ordering changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812eea6a7faf418108c1756892df6ed532e65e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->