### PR TITLE
refactor(opentable): generate DATE_OPTIONS weekday entries from calendar.day_name

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -1,3 +1,4 @@
+import calendar
 import functools
 import itertools
 import random
@@ -478,13 +479,7 @@ MEAL_TIMES = {
 DATE_OPTIONS = [
     "tomorrow",
     "day after tomorrow",
-    "for the upcoming Monday",
-    "for the upcoming Tuesday",
-    "for the upcoming Wednesday",
-    "for the upcoming Thursday",
-    "for the upcoming Friday",
-    "for the upcoming Saturday",
-    "for the upcoming Sunday",
+    *[f"for the upcoming {day}" for day in calendar.day_name],
     "upcoming weekend",
     "the following weekend",
     "the next two weekends",

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -12,6 +12,7 @@ hand-tracing every case from scratch.
 import pytest
 
 from navi_bench.opentable.opentable_info_gathering import (
+    DATE_OPTIONS,
     MEAL_TIMES,
     InfoDict,
     MultiCandidateQuery,
@@ -331,3 +332,28 @@ class TestMealTimes:
             "17:00:00", "17:15:00", "17:30:00", "17:45:00", "18:00:00", "18:15:00", "18:30:00", "18:45:00",
             "19:00:00", "19:15:00", "19:30:00", "19:45:00", "20:00:00",
         ]  # fmt: skip
+
+
+class TestDateOptions:
+    """Pin the exact ``DATE_OPTIONS`` entries, extracted verbatim from the hand-typed literal
+    list this held before the per-weekday entries were replaced by a generator over
+    ``calendar.day_name``. ``generate_task_config_random`` samples from this list, so a change
+    to its entries or ordering would silently change which date phrasings can be sampled.
+    """
+
+    def test_date_options_are_unchanged(self):
+        assert DATE_OPTIONS == [
+            "tomorrow",
+            "day after tomorrow",
+            "for the upcoming Monday",
+            "for the upcoming Tuesday",
+            "for the upcoming Wednesday",
+            "for the upcoming Thursday",
+            "for the upcoming Friday",
+            "for the upcoming Saturday",
+            "for the upcoming Sunday",
+            "upcoming weekend",
+            "the following weekend",
+            "the next two weekends",
+            "the first weekend of the next calendar month",
+        ]


### PR DESCRIPTION
## Issue

`navi_bench/opentable/opentable_info_gathering.py`'s `DATE_OPTIONS` list hand-typed all 7 `"for the upcoming {day}"` strings in calendar order — the same class of issue as the already-merged `MEAL_TIMES` quarter-hour generator (#114), a few lines above it in the same file: a literal that spells out a mechanical rule (one entry per weekday) instead of computing it, which can silently drift on a typo'd or dropped entry.

## Improvement

Replaced the 7 literal weekday entries with a generator over `calendar.day_name`, matching the convention `navi_bench/relative_dates.py` already uses for its `WEEKDAYS` mapping:

```python
DATE_OPTIONS = [
    "tomorrow",
    "day after tomorrow",
    *[f"for the upcoming {day}" for day in calendar.day_name],
    "upcoming weekend",
    "the following weekend",
    "the next two weekends",
    "the first weekend of the next calendar month",
]
```

## Why it's safe

- Single-file source change (plus its test), pure literal-generation dedup — no logic, scoring, or verifier code touched.
- Verified byte-for-byte equivalence before landing:
  ```python
  import calendar
  generated = [f"for the upcoming {day}" for day in calendar.day_name]
  hand_typed = ["for the upcoming Monday", ..., "for the upcoming Sunday"]
  generated == hand_typed  # True
  ```
- Confirmed via repo-wide grep that `DATE_OPTIONS` and the `"for the upcoming ..."` string pattern have no other call sites — the only consumer is `generate_task_config_random`'s `random.choice(available_date_options)`, which only cares about list membership/values, not literal construction.
- Added `TestDateOptions` in `tests/test_opentable_info_gathering.py`, mirroring the existing `TestMealTimes` characterization tests, pinning the exact previous `DATE_OPTIONS` list.
- `python -m pytest tests/test_opentable_info_gathering.py -q` → 29 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

This picks up the item flagged in `.claude/REFACTOR.md` (yutori-ai/yutori) as ready-to-land; a prior attempt (#116) was closed unmerged because it was stacked on stale branch state that would have reverted an unrelated, since-merged refactor (#115). This PR re-derives the same verified diff cleanly on top of current `main`.

🤖 Generated with automated refactor tooling.

Claude-Session: https://claude.ai/code/session_01Afjbwj25GDxdSEa9Emz44S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Afjbwj25GDxdSEa9Emz44S)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file literal refactor with a characterization test; no scoring or date-resolution logic changes.
> 
> **Overview**
> **`DATE_OPTIONS`** in `opentable_info_gathering.py` no longer lists seven `"for the upcoming {weekday}"` strings by hand. Those entries are built from **`calendar.day_name`** (with a new **`calendar`** import), in the same spirit as the existing **`MEAL_TIMES`** quarter-hour helper.
> 
> A **`TestDateOptions`** characterization test pins the full **`DATE_OPTIONS`** list (order and wording) so **`generate_task_config_random`**’s sampling behavior stays unchanged if the generator drifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cd274a5999e7fc86cccc1661314a4c198647f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->