### PR TITLE
refactor(evaluation): reuse read_sidecar for prepare_page.js

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -3,12 +3,11 @@ import functools
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from os import path as osp
 
 from loguru import logger
 from playwright.async_api import Browser, BrowserContext, Error as PlaywrightError, Page, Playwright
 
-from navi_bench.base import BaseTaskConfig
+from navi_bench.base import BaseTaskConfig, read_sidecar
 
 
 LOCATION_COORDS = {
@@ -39,8 +38,7 @@ def _url_matches_domain(url: str, domains: tuple[str, ...]) -> bool:
 
 @functools.cache
 def get_prepare_page_js() -> str:
-    with open(osp.join(osp.dirname(__file__), "prepare_page.js"), "r") as f:
-        return f.read()
+    return read_sidecar(__file__, "prepare_page.js")
 
 
 async def wait_for_page_ready(page: Page, step_idx: int = -1, sleep_s: float = 1.0) -> None:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,23 @@
+"""Characterization test for ``evaluation.browser.get_prepare_page_js``.
+
+Pins the pre-refactor behavior (reading ``prepare_page.js`` from the same directory as
+``evaluation/browser.py``, open-coded via ``os.path``) before switching the implementation to
+delegate to ``navi_bench.base.read_sidecar`` -- the same sidecar-file-read helper already used by
+``navi_bench/resy/resy_url_match.py`` and ``navi_bench/opentable/opentable_info_gathering.py``.
+"""
+
+from pathlib import Path
+
+from evaluation.browser import get_prepare_page_js
+
+
+class TestGetPreparePageJs:
+    def test_returns_prepare_page_js_contents(self):
+        expected = (Path(__file__).parent.parent / "evaluation" / "prepare_page.js").read_text()
+
+        assert get_prepare_page_js() == expected
+
+    def test_result_is_cached(self):
+        # get_prepare_page_js is decorated with functools.cache; repeated calls must return
+        # the exact same string object, not just an equal one.
+        assert get_prepare_page_js() is get_prepare_page_js()


### PR DESCRIPTION
## What
`evaluation/browser.py`'s `get_prepare_page_js()` hand-rolled a "read a file next to this module" via `open(osp.join(osp.dirname(__file__), "prepare_page.js"))`, instead of using `navi_bench.base.read_sidecar(module_file, filename)` — the exact helper already extracted for and used by this same pattern in `navi_bench/resy/resy_url_match.py` (`resy_no_availability_check.js`, `resy_availability_extractor.js`) and `navi_bench/opentable/opentable_info_gathering.py` (`opentable_info_gathering.js`).

## Why
Mechanical duplication: this was the one remaining call site in the repo still open-coding the sidecar-file-read pattern `read_sidecar` centralizes. Consolidating it removes a redundant `from os import path as osp` import (now dropped, since it was used nowhere else in the file) and keeps the "read a JS sidecar next to this module" convention in one place.

## Why safe
- Single file behavior change (`evaluation/browser.py`), plus a new test file.
- `read_sidecar` is `(Path(module_file).parent / filename).read_text()` — byte-identical to the previous `open(...).read()` for this file.
- `evaluation/browser.py` had no prior test coverage for `get_prepare_page_js`, so per repo convention a characterization test (`tests/test_browser.py`) was added first, pinning both the exact file contents returned and the `functools.cache` identity behavior (repeated calls return the same string object).
- Full local suite: 49/49 tests pass (47 pre-existing + 2 new). `ruff check` / `ruff format --check` clean.

No functional/behavioral changes — output of `get_prepare_page_js()` is identical before and after.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CwWfdvVWcnMm4QVuYfz81u)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-function mechanical refactor with characterization tests; no intended runtime behavior change beyond consolidating file reads.
> 
> **Overview**
> **`get_prepare_page_js()`** now loads **`prepare_page.js`** through **`read_sidecar(__file__, ...)`** instead of an inline **`os.path`** open, aligning with other sidecar JS readers in the repo. The unused **`os.path`** import is removed from **`evaluation/browser.py`**.
> 
> **`tests/test_browser.py`** adds characterization coverage that the returned script text still matches **`evaluation/prepare_page.js`** and that **`functools.cache`** still returns the same string object on repeat calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27195319c255e27edada17f434db08dae7fa4988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->