### PR TITLE
refactor(vis): extract _build_action_detail_lines helper for per-action detail strings

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -113,6 +113,72 @@ def _block_field(block: object, field: str, default: object = None) -> object:
     return getattr(block, field, default)
 
 
+def _build_action_detail_lines(action: dict) -> list[str]:
+    """Build the "key: value" detail strings shown in an action card, in field-check order.
+
+    Extracted from the inline ``details = []; if "<key>" in action: details.append(...)``
+    chain in ``generate_visualization_html``: each recognized action-payload field
+    (``ref``, ``coordinates``/``center_coordinates`` (elif, so ``coordinates`` wins if both
+    are present), ``start_coordinates``, ``text``, ``direction``, ``amount``, ``key_comb``,
+    ``url``, ``press_enter_after``, ``clear_before_typing``, ``duration``, ``value``)
+    contributes its own line when present, plus a fixed block for form-recording
+    ``action_type``s (``add_question``, ``add_input_options``, ``add_choices`` (legacy
+    name), ``list_records``).
+    """
+    details: list[str] = []
+    action_type = action.get("action_type", "unknown")
+
+    # Handle element reference (browser tool ref-based targeting)
+    if "ref" in action:
+        details.append(f"ref: {action['ref']}")
+    # Handle coordinates (new format uses "coordinates")
+    if "coordinates" in action:
+        coords = action["coordinates"]
+        details.append(f"coords: ({coords[0]}, {coords[1]})")
+    elif "center_coordinates" in action:
+        # Legacy support
+        coords = action["center_coordinates"]
+        details.append(f"coords: ({coords[0]}, {coords[1]})")
+    if "start_coordinates" in action:
+        coords = action["start_coordinates"]
+        details.append(f"start: ({coords[0]}, {coords[1]})")
+    if "text" in action:
+        details.append(f'text: "{action["text"]}"')
+    if "direction" in action:
+        details.append(f"direction: {action['direction']}")
+    if "amount" in action:
+        details.append(f"amount: {action['amount']}")
+    if "key_comb" in action:
+        details.append(f"key: {action['key_comb']}")
+    if "url" in action:
+        details.append(f"url: {action['url']}")
+    if "press_enter_after" in action:
+        details.append(f"press_enter_after: {action['press_enter_after']}")
+    if "clear_before_typing" in action:
+        details.append(f"clear_before_typing: {action['clear_before_typing']}")
+    if "duration" in action:
+        details.append(f"duration: {action['duration']}s")
+    if "value" in action:
+        details.append(f'value: "{action["value"]}"')
+
+    # Form recording actions: add_question and add_input_options (renamed from add_choices)
+    if action_type == "add_question":
+        details.append(f"index: {action.get('index', '?')}")
+        details.append(f'question: "{action.get("question", "")}"')
+        details.append(f"response_type: {action.get('response_type', '?')}")
+    if action_type == "add_input_options":
+        details.append(f"question_index: {action.get('question_index', '?')}")
+        details.append(f'input_options: "{action.get("input_options", "")}"')
+    if action_type == "add_choices":
+        # Legacy support for old name
+        details.append(f"question_index: {action.get('question_index', '?')}")
+        details.append(f'choices: "{action.get("choices", "")}"')
+    if action_type == "list_records":
+        details.append("(outputs all recorded questions)")
+
+    return details
+
+
 def _get_action_marker_style(
     action: dict,
     coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
@@ -1285,55 +1351,7 @@ def generate_visualization_html(
                 # Skip stop actions already rendered above
                 if action_type in _STOP_ACTION_TYPES:
                     continue
-                details = []
-
-                # Handle element reference (browser tool ref-based targeting)
-                if "ref" in action:
-                    details.append(f"ref: {action['ref']}")
-                # Handle coordinates (new format uses "coordinates")
-                if "coordinates" in action:
-                    coords = action["coordinates"]
-                    details.append(f"coords: ({coords[0]}, {coords[1]})")
-                elif "center_coordinates" in action:
-                    # Legacy support
-                    coords = action["center_coordinates"]
-                    details.append(f"coords: ({coords[0]}, {coords[1]})")
-                if "start_coordinates" in action:
-                    coords = action["start_coordinates"]
-                    details.append(f"start: ({coords[0]}, {coords[1]})")
-                if "text" in action:
-                    details.append(f'text: "{action["text"]}"')
-                if "direction" in action:
-                    details.append(f"direction: {action['direction']}")
-                if "amount" in action:
-                    details.append(f"amount: {action['amount']}")
-                if "key_comb" in action:
-                    details.append(f"key: {action['key_comb']}")
-                if "url" in action:
-                    details.append(f"url: {action['url']}")
-                if "press_enter_after" in action:
-                    details.append(f"press_enter_after: {action['press_enter_after']}")
-                if "clear_before_typing" in action:
-                    details.append(f"clear_before_typing: {action['clear_before_typing']}")
-                if "duration" in action:
-                    details.append(f"duration: {action['duration']}s")
-                if "value" in action:
-                    details.append(f'value: "{action["value"]}"')
-
-                # Form recording actions: add_question and add_input_options (renamed from add_choices)
-                if action_type == "add_question":
-                    details.append(f"index: {action.get('index', '?')}")
-                    details.append(f'question: "{action.get("question", "")}"')
-                    details.append(f"response_type: {action.get('response_type', '?')}")
-                if action_type == "add_input_options":
-                    details.append(f"question_index: {action.get('question_index', '?')}")
-                    details.append(f'input_options: "{action.get("input_options", "")}"')
-                if action_type == "add_choices":
-                    # Legacy support for old name
-                    details.append(f"question_index: {action.get('question_index', '?')}")
-                    details.append(f'choices: "{action.get("choices", "")}"')
-                if action_type == "list_records":
-                    details.append("(outputs all recorded questions)")
+                details = _build_action_detail_lines(action)
 
                 # Special styling for form recording actions
                 if action_type in _FORM_ACTION_ICONS:

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,0 +1,124 @@
+"""Characterization tests for the per-action "details" strings rendered inside each
+step's action card by ``generate_visualization_html``.
+
+These pin the CURRENT behavior of the inline field-by-field ``details.append(...)``
+chain in ``generate_visualization_html`` (one ``if "<key>" in action: ...`` per
+recognized action field, plus an ``action_type``-specific block for form-recording
+actions) before it is extracted into a standalone ``_build_action_detail_lines``
+helper. They exercise the public entry point end-to-end (rather than a not-yet-existing
+helper) via the OpenAI-style ``tool_calls`` parsing path used in production
+(``evaluation/eval_n1.py`` appends ``message.model_dump(...)`` messages in this shape),
+so a refactor of the inline chain can be verified as behavior-preserving.
+"""
+
+import json
+import re
+
+from evaluation.vis import generate_visualization_html
+
+
+def _messages_with_action(action_args: dict, name: str = "left_click") -> list[dict]:
+    return [
+        {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "t1", "type": "function", "function": {"name": name, "arguments": json.dumps(action_args)}}
+            ],
+        },
+    ]
+
+
+def _render_action_details(action_args: dict, name: str = "left_click") -> str:
+    """Render one action and return the text of its ``action-details`` div."""
+    html = generate_visualization_html("task1", _messages_with_action(action_args, name), None)
+    match = re.search(r'<div class="action-details">(.*?)</div>', html)
+    assert match is not None, html
+    return match.group(1)
+
+
+def _render_action_card(action_args: dict, name: str = "left_click") -> tuple[str, str]:
+    """Render one action and return (css_class, action-type label text)."""
+    html = generate_visualization_html("task1", _messages_with_action(action_args, name), None)
+    match = re.search(r'<div class="(action-item[^"]*)">\s*<div class="action-type">([^<]*)</div>', html)
+    assert match is not None, html
+    return match.group(1), match.group(2)
+
+
+class TestActionDetailFields:
+    def test_no_recognized_fields_renders_placeholder(self):
+        assert _render_action_details({}, name="wait") == "No additional details"
+
+    def test_ref_field(self):
+        assert _render_action_details({"ref": "e1"}) == "ref: e1"
+
+    def test_coordinates_field(self):
+        assert _render_action_details({"coordinates": [10, 20]}) == "coords: (10, 20)"
+
+    def test_center_coordinates_legacy_field(self):
+        assert _render_action_details({"center_coordinates": [5, 6]}) == "coords: (5, 6)"
+
+    def test_coordinates_takes_precedence_over_center_coordinates(self):
+        # `coordinates` and `center_coordinates` are checked via if/elif, so when both are
+        # present only `coordinates` is used.
+        assert _render_action_details({"coordinates": [1, 2], "center_coordinates": [9, 9]}) == "coords: (1, 2)"
+
+    def test_start_coordinates_combines_with_coordinates(self):
+        # start_coordinates uses a separate `if`, so it can appear alongside coords.
+        result = _render_action_details({"start_coordinates": [1, 2], "coordinates": [3, 4]}, name="drag")
+        assert result == "coords: (3, 4), start: (1, 2)"
+
+    def test_text_field(self):
+        assert _render_action_details({"text": 'hello "world"'}, name="type") == 'text: "hello "world""'
+
+    def test_direction_and_amount_fields(self):
+        result = _render_action_details({"direction": "down", "amount": 3}, name="scroll")
+        assert result == "direction: down, amount: 3"
+
+    def test_key_comb_field(self):
+        assert _render_action_details({"key_comb": "Control+A"}, name="key_press") == "key: Control+A"
+
+    def test_url_field(self):
+        assert _render_action_details({"url": "https://x.com"}, name="goto_url") == "url: https://x.com"
+
+    def test_press_enter_after_and_clear_before_typing_fields(self):
+        result = _render_action_details({"press_enter_after": True, "clear_before_typing": False}, name="type")
+        assert result == "press_enter_after: True, clear_before_typing: False"
+
+    def test_duration_field(self):
+        assert _render_action_details({"duration": 5}, name="wait") == "duration: 5s"
+
+    def test_value_field(self):
+        assert _render_action_details({"value": "abc"}, name="select") == 'value: "abc"'
+
+
+class TestFormActionDetailFields:
+    def test_add_question(self):
+        result = _render_action_details({"index": 0, "question": "Q?", "response_type": "text"}, name="add_question")
+        assert result == 'index: 0, question: "Q?", response_type: text'
+
+    def test_add_input_options(self):
+        result = _render_action_details({"question_index": 0, "input_options": "a,b"}, name="add_input_options")
+        assert result == 'question_index: 0, input_options: "a,b"'
+
+    def test_add_choices_legacy(self):
+        result = _render_action_details({"question_index": 0, "choices": "a,b"}, name="add_choices")
+        assert result == 'question_index: 0, choices: "a,b"'
+
+    def test_list_records(self):
+        assert _render_action_details({}, name="list_records") == "(outputs all recorded questions)"
+
+
+class TestActionCardStyling:
+    def test_regular_action_uses_plain_css_class_and_label(self):
+        css_class, label = _render_action_card({"ref": "e1"}, name="left_click")
+        assert css_class == "action-item"
+        assert label == "1. left_click"
+
+    def test_form_action_uses_form_css_class_and_icon_label(self):
+        css_class, label = _render_action_card(
+            {"index": 0, "question": "Q?", "response_type": "text"}, name="add_question"
+        )
+        assert css_class == "action-item form-action"
+        assert label == "📝 1. add_question"


### PR DESCRIPTION
## Issue

`evaluation/vis.py`'s `generate_visualization_html` contains a ~1500-line function that parses agent messages and renders them to a static HTML report. Buried in the middle of its per-step rendering loop was a ~35-line inline chain:

```python
details = []
if "ref" in action:
    details.append(...)
if "coordinates" in action:
    ...
elif "center_coordinates" in action:
    ...
# ... 8 more field checks ...
if action_type == "add_question":
    ...
# ... 3 more action_type-specific blocks ...
```

This block builds the "key: value" detail strings shown in each action card. It's a pure function of a single `action` dict, but it was inline in the middle of a much larger function mixing message-parsing state and HTML templating, making it impossible to test in isolation and harder to reason about independently from the surrounding rendering logic.

## Fix

Extracted the block verbatim into a standalone `_build_action_detail_lines(action: dict) -> list[str]` helper (same file), and replaced the inline chain with a single call: `details = _build_action_detail_lines(action)`. No behavior change — this is a pure extraction, same order of checks, same `if`/`elif` precedence for `coordinates` vs. `center_coordinates`.

This mirrors the extraction style of prior refactors in this repo (e.g. `_get_action_marker_style`, `_normalize_apartment_features`): pull a self-contained, pure sub-computation out of a large function into its own named, independently testable helper.

## Safety / testing

`vis.py` had **zero** prior test coverage in this repo. Following this repo's established process for refactors here (see recent history: `_match_query_window`, `_validate_placeholder_dates_and_get_template_string`, etc.), I added characterization tests **first**, before touching any implementation code:

- Added `tests/test_vis.py` with 19 tests exercising `generate_visualization_html` end-to-end via its OpenAI-style `tool_calls` message shape (the same shape produced by `evaluation/eval_n1.py`'s `message.model_dump(...)`).
- Coverage includes every recognized action field (`ref`, `coordinates`, `center_coordinates`, `start_coordinates`, `text`, `direction`, `amount`, `key_comb`, `url`, `press_enter_after`, `clear_before_typing`, `duration`, `value`), the `coordinates`/`center_coordinates` `if`/`elif` precedence, all four form-recording `action_type`s (`add_question`, `add_input_options`, `add_choices` legacy, `list_records`), the "no recognized fields" placeholder text, and the form-action vs. regular-action CSS class/label styling.
- Confirmed all 19 tests **pass against the pre-refactor code** (inline chain), then performed the extraction, then re-ran the full suite: **68/68 tests pass unchanged** (49 pre-existing + 19 new), confirming the refactor is behavior-preserving.
- Ran `ruff check` and `ruff format` — both clean.

## Backlog mapping

This maps to the general "extract self-contained pure helper out of a large function, guarded by characterization tests added first" pattern already established in this repo's refactor history (e.g. `_match_query_window`, `all_or_nothing_coverage_result`, `_FORM_ACTION_ICONS`). It is a new instance of that pattern applied to `evaluation/vis.py`'s previously untested and unexamined `generate_visualization_html`, which prior audits (per repo history) had reviewed but not found a bounded candidate in until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015r1z8e5hMc5C6hkdDGhYrC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in evaluation-only HTML rendering, guarded by new characterization tests; no runtime or security paths affected.
> 
> **Overview**
> Pulls the per-action **key: value** detail string logic out of `generate_visualization_html` into a new **`_build_action_detail_lines(action)`** helper in `evaluation/vis.py`, and swaps the long inline `details.append(...)` chain for **`details = _build_action_detail_lines(action)`**. Field order, `coordinates` vs `center_coordinates` precedence, and form-recording action types are unchanged.
> 
> Adds **`tests/test_vis.py`** with characterization tests that drive **`generate_visualization_html`** through OpenAI-style **`tool_calls`** messages. They lock in detail text for browser action fields, form actions, the empty-details placeholder, and form vs regular action card CSS/labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1622ef791adbf332a816ff749edf0eae329f308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->