### PR TITLE
refactor(dates): extract _MONTH_DAY_RANGE_PATTERN for duplicated month-day range regex

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -46,6 +46,12 @@ _MOD_NONCAP = "(?:" + "|".join(_MODIFIERS) + ")"
 _ORDINAL_DAY = r"(\d{1,2}(?:st|nd|rd|th)?)"
 _DAY_NUM = r"(\d{1,2})(?:st|nd|rd|th)?"
 
+# "[<mod>] [<month>] <d1>-<d2>" range pattern, e.g. "next May 11-14" or bare "18-21".
+# Shared by the two `parse_relative_dates` branches that match a month-day range: the
+# per-chunk "<month-ref> <dd-dd> and <month-ref> <dd-dd> ..." case and the single-range
+# fallback case.
+_MONTH_DAY_RANGE_PATTERN = re.compile(rf"(?:({_MOD_NONCAP}\s+)?([a-z.]+)\s+)?{_DAY_NUM}\s*-\s*{_DAY_NUM}")
+
 
 def _days_in_month(year: int, month: int) -> int:
     return calendar.monthrange(year, month)[1]
@@ -678,10 +684,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
         context_modifier = ""
         for ch in chunks:
             # match "[<mod>] <month> <d1>-<d2>"
-            m = re.fullmatch(
-                rf"(?:({_MOD_NONCAP}\s+)?([a-z.]+)\s+)?{_DAY_NUM}\s*-\s*{_DAY_NUM}",
-                ch,
-            )
+            m = _MONTH_DAY_RANGE_PATTERN.fullmatch(ch)
             if m:
                 if m.group(2):  # has month (maybe with modifier)
                     mon_ref = ((m.group(1) or "") + (m.group(2) or "")).strip()
@@ -780,10 +783,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
     #    - Simple "in <month-ref>" with weekday phrase on the left already covered above
     #    - Otherwise, try single-date parser and return [that date]
     # ------------------------------------------------------------
-    m = re.fullmatch(
-        rf"(?:({_MOD_NONCAP}\s+)?([a-z.]+)\s+)?{_DAY_NUM}\s*-\s*{_DAY_NUM}",
-        s,
-    )
+    m = _MONTH_DAY_RANGE_PATTERN.fullmatch(s)
     if m:
         modifier = _normalize_modifier(m.group(1))
         if m.group(2):

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -1,0 +1,153 @@
+"""Characterization tests for ``navi_bench.relative_dates``.
+
+This module has no prior test coverage even though it feeds ground-truth date generation
+for resy, opentable, and google_flights via ``dates.py``'s ``resolve_placeholder_values``.
+These tests pin the current, verified-correct output of ``parse_relative_date`` and
+``parse_relative_dates`` against a fixed base date, using the worked examples already
+documented in the module's own ``if __name__ == "__main__":`` block. They exist primarily
+to give this module a safety net (matching this repo's convention of adding
+characterization tests before/alongside structural refactors of untested code) and to pin
+behavior across the ``_MONTH_DAY_RANGE_PATTERN`` regex-dedup refactor in this file.
+"""
+
+from datetime import date
+
+import pytest
+
+from navi_bench.relative_dates import parse_relative_date, parse_relative_dates
+
+
+BASE_DATE = date(2025, 11, 6)  # a Thursday
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("upcoming Friday", "2025-11-07"),
+        ("on the 26th next month", "2025-12-26"),
+        ("26th next month", "2025-12-26"),
+        ("26th of the next month", "2025-12-26"),
+        ("15th in 3 months", "2026-02-15"),
+        ("the 3rd next December", "2025-12-03"),
+        ("3rd next December", "2025-12-03"),
+        ("the 3rd of December next", "2025-12-03"),
+        ("the 3rd of December", "2025-12-03"),
+        ("next Dec. 3rd", "2025-12-03"),
+        ("July 4th", "2026-07-04"),
+        ("next Valentine's Day", "2026-02-14"),
+        ("the next Valentine's Day", "2026-02-14"),
+        ("the next Monday", "2025-11-10"),
+        ("next MLK Day", "2026-01-19"),
+        ("this Thanksgiving", "2025-11-27"),
+        ("last Christmas", "2024-12-25"),
+        ("in 2 weeks", "2025-11-20"),
+    ],
+)
+def test_parse_relative_date(text, expected):
+    assert parse_relative_date(text, BASE_DATE) == expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("upcoming Friday", ["2025-11-07"]),
+        ("upcoming Thanksgiving", ["2025-11-27"]),
+        (
+            "Saturdays and Sundays in next month",
+            [
+                "2025-12-06",
+                "2025-12-07",
+                "2025-12-13",
+                "2025-12-14",
+                "2025-12-20",
+                "2025-12-21",
+                "2025-12-27",
+                "2025-12-28",
+            ],
+        ),  # fmt: skip
+        (
+            "weekends in the next month",
+            [
+                "2025-12-06",
+                "2025-12-07",
+                "2025-12-13",
+                "2025-12-14",
+                "2025-12-20",
+                "2025-12-21",
+                "2025-12-27",
+                "2025-12-28",
+            ],
+        ),  # fmt: skip
+        (
+            "next May 11-14 and May 18-21",
+            [
+                "2026-05-11",
+                "2026-05-12",
+                "2026-05-13",
+                "2026-05-14",
+                "2026-05-18",
+                "2026-05-19",
+                "2026-05-20",
+                "2026-05-21",
+            ],
+        ),  # fmt: skip
+        (
+            "Sat and Sun from next Oct 12 through Nov 25",
+            [
+                "2026-10-17",
+                "2026-10-18",
+                "2026-10-24",
+                "2026-10-25",
+                "2026-10-31",
+                "2026-11-01",
+                "2026-11-07",
+                "2026-11-08",
+                "2026-11-14",
+                "2026-11-15",
+                "2026-11-21",
+                "2026-11-22",
+            ],
+        ),  # fmt: skip
+        (
+            "next Nov 9th, 16th, 23th, 30th, and Dec 7th",
+            [
+                "2025-11-09",
+                "2025-11-16",
+                "2025-11-23",
+                "2025-11-30",
+                "2025-12-07",
+            ],
+        ),  # fmt: skip
+    ],
+)
+def test_parse_relative_dates(text, expected):
+    assert parse_relative_dates(text, BASE_DATE) == expected
+
+
+class TestMonthDayRangePattern:
+    """Targeted coverage for the two ``parse_relative_dates`` branches that share the
+    extracted ``_MONTH_DAY_RANGE_PATTERN`` regex: the per-chunk "and"-joined multi-range
+    case, and the single-range fallback case."""
+
+    def test_multi_chunk_month_day_range_with_modifier_and_carried_month(self):
+        # "May 18-21" (second chunk) has no month keyword of its own for the day range but
+        # carries the year/modifier context established by "next May 11-14".
+        assert parse_relative_dates("next May 11-14 and May 18-21", BASE_DATE) == [
+            "2026-05-11",
+            "2026-05-12",
+            "2026-05-13",
+            "2026-05-14",
+            "2026-05-18",
+            "2026-05-19",
+            "2026-05-20",
+            "2026-05-21",
+        ]
+
+    def test_single_range_fallback_with_month_and_modifier(self):
+        assert parse_relative_dates("next Dec 3-5", BASE_DATE) == ["2025-12-03", "2025-12-04", "2025-12-05"]
+
+    def test_single_range_fallback_bare_days_uses_current_month(self):
+        assert parse_relative_dates("10-12", BASE_DATE) == ["2025-11-10", "2025-11-11", "2025-11-12"]
+
+    def test_single_range_fallback_reversed_range_is_normalized(self):
+        assert parse_relative_dates("Dec 5-3", BASE_DATE) == ["2025-12-03", "2025-12-04", "2025-12-05"]


### PR DESCRIPTION
## Issue

`navi_bench/relative_dates.py`'s `parse_relative_dates()` had the exact same composed regex literal duplicated verbatim in two branches:

```python
rf"(?:({_MOD_NONCAP}\s+)?([a-z.]+)\s+)?{_DAY_NUM}\s*-\s*{_DAY_NUM}"
```

- Once in the "`<month-ref> <dd-dd> and <month-ref> <dd-dd> ...`" branch (matched per-chunk against `ch`).
- Once in the "single month-day range fallback" branch (matched against the whole string `s`).

This is the same class of issue the file already guards against elsewhere: `_MOD_GROUP`, `_MOD_NONCAP`, `_ORDINAL_DAY`, and `_DAY_NUM` are all module-level regex-fragment constants specifically so they aren't retyped at each use site — this one composed pattern was simply missed.

## Improvement

Extracted the duplicated literal into a single compiled module-level constant, `_MONTH_DAY_RANGE_PATTERN`, placed next to the other fragment constants. Both call sites now do `_MONTH_DAY_RANGE_PATTERN.fullmatch(...)` instead of re-typing the `rf"..."` literal.

Also added `tests/test_relative_dates.py` — this module previously had **no test coverage at all**, despite feeding ground-truth date generation for resy/opentable/google_flights via `dates.py`. Added characterization tests (parametrized over `parse_relative_date`/`parse_relative_dates`, using the worked examples already documented in the module's own `if __name__ == "__main__":` block) plus targeted tests for both `_MONTH_DAY_RANGE_PATTERN` call sites, per this repo's convention of pinning current behavior with tests before/alongside refactoring previously-untested logic.

## Safety

- The extracted regex is byte-identical to the original (same pattern string, same capture groups) — zero behavior change.
- Verified by running the new test file against both the pre-refactor and post-refactor code (via `git stash`): all 29 new tests pass identically both ways.
- Full suite: 97/97 passing (68 pre-existing + 29 new).
- `ruff check` and `ruff format --check` clean.
- Touches exactly 2 files (1 source file, 1 new test file), no changes to task-generation or verifier/scoring behavior.

🤖 Generated as part of an automated hourly refactor pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TfLGkJNtzoBrTwFr34mJd2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Regex is byte-identical and only call sites change; new tests lock behavior with no production logic changes beyond deduplication.
> 
> **Overview**
> Deduplicates the month-day range regex in **`parse_relative_dates`** by introducing a compiled **`_MONTH_DAY_RANGE_PATTERN`** next to the other regex fragments, and wires both the **and-joined multi-range** branch and the **single-range fallback** to use **`fullmatch`** on that constant instead of repeating the same **`rf"..."`** literal.
> 
> Adds **`tests/test_relative_dates.py`** with parametrized characterization tests for **`parse_relative_date`** / **`parse_relative_dates`** (fixed base **`2025-11-06`**, aligned with the module’s **`__main__`** examples) plus focused cases for the two shared-regex paths (multi-chunk with carried month, single range with modifier, bare days, reversed range).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f90c0023f73206dc5f7414bba14c060f030416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->