### PR TITLE
refactor(vis): extract shared collapsible-section helpers in evaluation/vis.py

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -223,6 +223,35 @@ def _get_action_marker_style(
     return result
 
 
+def _render_section(title: str, text: str, *, collapsed: bool = False) -> str:
+    """Render a top-level collapsible ``.section`` block (System Prompt / User Query / Result)."""
+    collapsed_class = " collapsed" if collapsed else ""
+    return f"""
+        <div class="section{collapsed_class}">
+            <div class="section-header" onclick="this.parentElement.classList.toggle('collapsed')">
+                <h2>{title}</h2>
+                <span class="chevron">▼</span>
+            </div>
+            <div class="section-content">
+                <pre>{_escape_html(text)}</pre>
+            </div>
+        </div>
+"""
+
+
+def _render_response_section(label: str, content_html: str, *, collapsed: bool = False) -> str:
+    """Render a per-step collapsible ``.response-section`` block (Actions / Text Observations / Raw Response)."""
+    collapsed_class = " collapsed" if collapsed else ""
+    return f"""<div class="response-section{collapsed_class}">
+                        <div class="response-section-header" onclick="this.parentElement.classList.toggle('collapsed')">
+                            <span>▼</span> {label}
+                        </div>
+                        <div class="response-section-content">
+                            {content_html}
+                        </div>
+                    </div>"""
+
+
 def generate_visualization_html(
     task_id: str,
     messages: list[dict],
@@ -1220,31 +1249,11 @@ def generate_visualization_html(
 
     # System prompt section
     if system_prompt:
-        html += f"""
-        <div class="section collapsed">
-            <div class="section-header" onclick="this.parentElement.classList.toggle('collapsed')">
-                <h2>🔧 System Prompt</h2>
-                <span class="chevron">▼</span>
-            </div>
-            <div class="section-content">
-                <pre>{_escape_html(system_prompt)}</pre>
-            </div>
-        </div>
-"""
+        html += _render_section("🔧 System Prompt", system_prompt, collapsed=True)
 
     # User query section
     if user_query:
-        html += f"""
-        <div class="section">
-            <div class="section-header" onclick="this.parentElement.classList.toggle('collapsed')">
-                <h2>💬 User Query</h2>
-                <span class="chevron">▼</span>
-            </div>
-            <div class="section-content">
-                <pre>{_escape_html(user_query)}</pre>
-            </div>
-        </div>
-"""
+        html += _render_section("💬 User Query", user_query)
 
     # Steps
     for step in steps:
@@ -1374,6 +1383,11 @@ def generate_visualization_html(
             <div class="text-observation">{_escape_html(text_obs[:2000])}</div>
 """
 
+        no_actions_placeholder = '<div style="color: var(--text-secondary);">No actions</div>'
+        actions_content = f"""<div class="action-list">
+                                {actions_html if actions_html else no_actions_placeholder}
+                            </div>"""
+
         html += f"""
         <div class="step" id="step-{step_num}">
             <div class="step-header">
@@ -1392,38 +1406,13 @@ def generate_visualization_html(
         }
                 </div>
                 <div class="response-panel">
-                    <div class="response-section">
-                        <div class="response-section-header" onclick="this.parentElement.classList.toggle('collapsed')">
-                            <span>▼</span> Actions ({len(actions)})
-                        </div>
-                        <div class="response-section-content">
-                            <div class="action-list">
-                                {
-            actions_html if actions_html else '<div style="color: var(--text-secondary);">No actions</div>'
-        }
-                            </div>
-                        </div>
-                    </div>
+                    {_render_response_section(f"Actions ({len(actions)})", actions_content)}
                     {
-            f'''<div class="response-section collapsed">
-                        <div class="response-section-header" onclick="this.parentElement.classList.toggle('collapsed')">
-                            <span>▼</span> Text Observations
-                        </div>
-                        <div class="response-section-content">
-                            {text_obs_html}
-                        </div>
-                    </div>'''
-            if text_observations
-            else ""
+            _render_response_section("Text Observations", text_obs_html, collapsed=True) if text_observations else ""
         }
-                    <div class="response-section collapsed">
-                        <div class="response-section-header" onclick="this.parentElement.classList.toggle('collapsed')">
-                            <span>▼</span> Raw Response
-                        </div>
-                        <div class="response-section-content">
-                            <pre>{_escape_html(assistant_response)}</pre>
-                        </div>
-                    </div>
+                    {
+            _render_response_section("Raw Response", f"<pre>{_escape_html(assistant_response)}</pre>", collapsed=True)
+        }
                 </div>
             </div>
             <div class="legend">
@@ -1438,17 +1427,7 @@ def generate_visualization_html(
 
     # Result section
     if result_json:
-        html += f"""
-        <div class="section">
-            <div class="section-header" onclick="this.parentElement.classList.toggle('collapsed')">
-                <h2>📋 Evaluation Result</h2>
-                <span class="chevron">▼</span>
-            </div>
-            <div class="section-content">
-                <pre>{_escape_html(result_json)}</pre>
-            </div>
-        </div>
-"""
+        html += _render_section("📋 Evaluation Result", result_json)
 
     # Build modal data for JavaScript
     modal_steps_data = []

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -14,7 +14,7 @@ so a refactor of the inline chain can be verified as behavior-preserving.
 import json
 import re
 
-from evaluation.vis import generate_visualization_html
+from evaluation.vis import generate_visualization_html, _render_response_section, _render_section
 
 
 def _messages_with_action(action_args: dict, name: str = "left_click") -> list[dict]:
@@ -122,3 +122,94 @@ class TestActionCardStyling:
         )
         assert css_class == "action-item form-action"
         assert label == "📝 1. add_question"
+
+
+class TestRenderSection:
+    """Characterization tests for ``_render_section``, the shared helper behind the top-level
+    collapsible System Prompt / User Query / Evaluation Result blocks in
+    ``generate_visualization_html``. Pins the exact markup (including the toggle-on-click
+    handler and the collapsed-class placement) so the three call sites stay byte-identical
+    to the pre-extraction inline templates.
+    """
+
+    def test_not_collapsed_by_default(self):
+        html = _render_section("💬 User Query", "hello")
+        assert html == (
+            "\n"
+            '        <div class="section">\n'
+            '            <div class="section-header" onclick="this.parentElement.classList.toggle(\'collapsed\')">\n'
+            "                <h2>💬 User Query</h2>\n"
+            '                <span class="chevron">▼</span>\n'
+            "            </div>\n"
+            '            <div class="section-content">\n'
+            "                <pre>hello</pre>\n"
+            "            </div>\n"
+            "        </div>\n"
+        )
+
+    def test_collapsed(self):
+        html = _render_section("🔧 System Prompt", "sys", collapsed=True)
+        assert '<div class="section collapsed">' in html
+        assert "<h2>🔧 System Prompt</h2>" in html
+
+    def test_escapes_text(self):
+        html = _render_section("Title", "<script>alert(1)</script>")
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+
+class TestRenderResponseSection:
+    """Characterization tests for ``_render_response_section``, the shared helper behind the
+    per-step collapsible Actions / Text Observations / Raw Response blocks.
+    """
+
+    def test_not_collapsed_by_default(self):
+        html = _render_response_section("Actions (2)", "<div>content</div>")
+        assert html == (
+            '<div class="response-section">\n'
+            '                        <div class="response-section-header" '
+            "onclick=\"this.parentElement.classList.toggle('collapsed')\">\n"
+            "                            <span>▼</span> Actions (2)\n"
+            "                        </div>\n"
+            '                        <div class="response-section-content">\n'
+            "                            <div>content</div>\n"
+            "                        </div>\n"
+            "                    </div>"
+        )
+
+    def test_collapsed(self):
+        html = _render_response_section("Raw Response", "<pre>hi</pre>", collapsed=True)
+        assert '<div class="response-section collapsed">' in html
+        assert "<span>▼</span> Raw Response" in html
+
+
+class TestTopLevelSectionsEndToEnd:
+    """Confirms ``generate_visualization_html`` wires ``_render_section`` for the System
+    Prompt (collapsed by default), User Query, and Evaluation Result sections in the
+    right order and with the right collapsed state.
+    """
+
+    def test_system_prompt_and_user_query_and_result(self):
+        from pydantic import BaseModel
+
+        class _Result(BaseModel):
+            score: float = 1.0
+
+        messages = [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+        ]
+        html = generate_visualization_html("task1", messages, _Result())
+
+        assert '<div class="section collapsed">\n            <div class="section-header"' in html
+        assert "<h2>🔧 System Prompt</h2>" in html
+        assert "<h2>💬 User Query</h2>" in html
+        assert "<h2>📋 Evaluation Result</h2>" in html
+        # User Query and Evaluation Result sections are not collapsed by default.
+        assert re.search(r'<div class="section">\s*<div class="section-header"[^>]*>\s*<h2>💬 User Query', html)
+        assert re.search(r'<div class="section">\s*<div class="section-header"[^>]*>\s*<h2>📋 Evaluation Result', html)
+
+    def test_no_system_prompt_omits_section(self):
+        messages = [{"role": "user", "content": [{"type": "text", "text": "do the task"}]}]
+        html = generate_visualization_html("task1", messages, None)
+        assert "System Prompt" not in html


### PR DESCRIPTION
## Issue

`generate_visualization_html()` built three near-identical top-level `.section` blocks (System Prompt / User Query / Evaluation Result) and three near-identical per-step `.response-section` blocks (Actions / Text Observations / Raw Response). Each repeated the same `onclick="this.parentElement.classList.toggle('collapsed')"` header markup verbatim, differing only in title/label, collapsed-by-default state, and inner content.

## Change

Extracted two small helpers:
- `_render_section(title, text, *, collapsed=False)` for the top-level System Prompt / User Query / Evaluation Result blocks.
- `_render_response_section(label, content_html, *, collapsed=False)` for the per-step Actions / Text Observations / Raw Response blocks.

All six call sites now delegate to one of these. This is the same duplication-elimination pattern already applied to this file in #101, #111, #113, and #120.

## Verification

- Added `tests/test_vis.py` coverage: direct unit tests for both new helpers (default vs. collapsed state, HTML escaping) plus an end-to-end test confirming `generate_visualization_html` wires the three top-level sections with the right collapsed state and ordering.
- Confirmed **byte-identical** `generate_visualization_html()` output before vs. after the refactor for two fixtures: a multi-step run exercising every branch (system prompt, user query, result, screenshot + no-screenshot steps, a form action, a stop action, a final-answer-without-tool-call step, and a text observation) and a minimal run with no system prompt / user query / result.
- Full suite: 104/104 tests pass (was 97 before this PR's 7 new tests).
- `ruff check` and `ruff format --check` clean on the touched files.

Debug/visualization output only — no behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KNVkXcciTZi25u2VbEGcbD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug/visualization HTML only; refactor is covered by tests aiming for byte-identical output with no runtime eval logic changes.
> 
> **Overview**
> **Refactors** eval HTML visualization by pulling repeated collapsible markup into **`_render_section`** (System Prompt, User Query, Evaluation Result) and **`_render_response_section`** (per-step Actions, Text Observations, Raw Response). **`generate_visualization_html`** now calls these helpers instead of duplicating the same header/toggle/`collapsed` templates; step Actions content is built once as **`actions_content`** before being passed into the response-section helper.
> 
> **Adds** characterization tests in **`tests/test_vis.py`** for both helpers (default vs collapsed, HTML escaping) and an end-to-end check that top-level sections appear with the expected collapsed defaults and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1733d6b57f6c595874bbeea8d89f9069d6ecb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->