### PR TITLE
refactor(vis): extract shared _first_present coordinate lookup helper

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -17,6 +17,23 @@ _FORM_ACTION_ICONS: dict[str, str] = {
     "list_records": "📊",
 }
 
+# Sentinel distinguishing "no key present" from a present-but-falsy (e.g. ``None``) value.
+_UNSET = object()
+
+
+def _first_present(action: dict, *keys: str) -> object:
+    """Return the value of the first of ``keys`` that is present in ``action`` (checked via
+    ``in``, not truthiness), or ``_UNSET`` if none are present.
+
+    Shared by the "prefer the new ``coordinates`` field, fall back to legacy
+    ``center_coordinates`` (and ``end_coordinates`` for drag end-points)" lookups in
+    ``_build_action_detail_lines`` and ``_get_action_marker_style``.
+    """
+    for key in keys:
+        if key in action:
+            return action[key]
+    return _UNSET
+
 
 def _truncate_preview(text: str, limit: int = 150) -> str:
     """Truncate ``text`` to ``limit`` characters, appending an ellipsis if shortened."""
@@ -131,13 +148,9 @@ def _build_action_detail_lines(action: dict) -> list[str]:
     # Handle element reference (browser tool ref-based targeting)
     if "ref" in action:
         details.append(f"ref: {action['ref']}")
-    # Handle coordinates (new format uses "coordinates")
-    if "coordinates" in action:
-        coords = action["coordinates"]
-        details.append(f"coords: ({coords[0]}, {coords[1]})")
-    elif "center_coordinates" in action:
-        # Legacy support
-        coords = action["center_coordinates"]
+    # Handle coordinates (new format uses "coordinates", falls back to legacy "center_coordinates")
+    coords = _first_present(action, "coordinates", "center_coordinates")
+    if coords is not _UNSET:
         details.append(f"coords: ({coords[0]}, {coords[1]})")
     if "start_coordinates" in action:
         coords = action["start_coordinates"]
@@ -206,15 +219,14 @@ def _get_action_marker_style(
     # Handle coordinate-based actions
     # Check drag first since drags have both start_coordinates and coordinates
     if "start_coordinates" in action and action_type.lower() in ("drag", "left_click_drag"):
-        end_xy = action.get("coordinates", action.get("center_coordinates", action.get("end_coordinates", [0, 0])))
+        end_xy = _first_present(action, "coordinates", "center_coordinates", "end_coordinates")
+        if end_xy is _UNSET:
+            end_xy = [0, 0]
         result["start_x"], result["start_y"] = to_pct(action["start_coordinates"])
         result["end_x"], result["end_y"] = to_pct(end_xy)
         result["has_drag"] = True
-    elif "coordinates" in action:
-        result["x"], result["y"] = to_pct(action["coordinates"])
-        result["has_point"] = True
-    elif "center_coordinates" in action:
-        result["x"], result["y"] = to_pct(action["center_coordinates"])
+    elif (coords := _first_present(action, "coordinates", "center_coordinates")) is not _UNSET:
+        result["x"], result["y"] = to_pct(coords)
         result["has_point"] = True
     else:
         result["has_point"] = False

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -14,7 +14,12 @@ so a refactor of the inline chain can be verified as behavior-preserving.
 import json
 import re
 
-from evaluation.vis import generate_visualization_html, _render_response_section, _render_section
+from evaluation.vis import (
+    generate_visualization_html,
+    _get_action_marker_style,
+    _render_response_section,
+    _render_section,
+)
 
 
 def _messages_with_action(action_args: dict, name: str = "left_click") -> list[dict]:
@@ -122,6 +127,78 @@ class TestActionCardStyling:
         )
         assert css_class == "action-item form-action"
         assert label == "📝 1. add_question"
+
+
+class TestGetActionMarkerStyle:
+    """Characterization tests for ``_get_action_marker_style``, pinning its current
+    coordinate-field fallback behavior (new ``coordinates`` field preferred over legacy
+    ``center_coordinates``, plus a third ``end_coordinates`` fallback and a ``[0, 0]``
+    default for drag end-points) before extracting a shared coordinate-lookup helper.
+    Uses ``coord_space_width=100, coord_space_height=200`` so the resulting percentages
+    are easy to hand-check.
+    """
+
+    def test_no_coordinates_and_no_ref(self):
+        result = _get_action_marker_style({"action_type": "wait"}, 100, 200)
+        assert result == {"type": "wait", "has_point": False, "has_ref_only": False}
+
+    def test_ref_only_carries_ref_through_without_a_point(self):
+        result = _get_action_marker_style({"action_type": "left_click", "ref": "e1"}, 100, 200)
+        assert result == {"type": "left_click", "ref": "e1", "has_point": False, "has_ref_only": True}
+
+    def test_coordinates_field(self):
+        result = _get_action_marker_style({"action_type": "left_click", "coordinates": [50, 100]}, 100, 200)
+        assert result == {"type": "left_click", "x": 50.0, "y": 50.0, "has_point": True}
+
+    def test_center_coordinates_legacy_field(self):
+        result = _get_action_marker_style({"action_type": "left_click", "center_coordinates": [25, 50]}, 100, 200)
+        assert result == {"type": "left_click", "x": 25.0, "y": 25.0, "has_point": True}
+
+    def test_coordinates_takes_precedence_over_center_coordinates(self):
+        action = {"action_type": "left_click", "coordinates": [10, 20], "center_coordinates": [90, 90]}
+        result = _get_action_marker_style(action, 100, 200)
+        assert result["x"] == 10.0
+        assert result["y"] == 10.0
+
+    def test_drag_uses_start_coordinates_and_coordinates_as_end(self):
+        action = {"action_type": "drag", "start_coordinates": [0, 0], "coordinates": [100, 200]}
+        result = _get_action_marker_style(action, 100, 200)
+        assert result == {
+            "type": "drag",
+            "start_x": 0.0,
+            "start_y": 0.0,
+            "end_x": 100.0,
+            "end_y": 100.0,
+            "has_drag": True,
+        }
+
+    def test_left_click_drag_action_type_also_treated_as_drag(self):
+        action = {"action_type": "left_click_drag", "start_coordinates": [0, 0], "center_coordinates": [50, 100]}
+        result = _get_action_marker_style(action, 100, 200)
+        assert result["has_drag"] is True
+        assert result["end_x"] == 50.0
+
+    def test_drag_falls_back_to_end_coordinates_when_no_coordinates_or_center_coordinates(self):
+        action = {"action_type": "drag", "start_coordinates": [0, 0], "end_coordinates": [100, 200]}
+        result = _get_action_marker_style(action, 100, 200)
+        assert result["end_x"] == 100.0
+        assert result["end_y"] == 100.0
+
+    def test_drag_defaults_end_to_zero_when_no_end_coordinate_field_present(self):
+        action = {"action_type": "drag", "start_coordinates": [50, 100]}
+        result = _get_action_marker_style(action, 100, 200)
+        assert result["end_x"] == 0.0
+        assert result["end_y"] == 0.0
+
+    def test_start_coordinates_without_drag_action_type_is_not_treated_as_drag(self):
+        # The drag branch also requires action_type to be "drag"/"left_click_drag";
+        # a plain click with a stray start_coordinates field falls through to the
+        # regular point branch instead.
+        action = {"action_type": "left_click", "start_coordinates": [1, 2], "coordinates": [3, 4]}
+        result = _get_action_marker_style(action, 100, 200)
+        assert result.get("has_drag") is None
+        assert result["has_point"] is True
+        assert result["x"] == 3.0
 
 
 class TestRenderSection:


### PR DESCRIPTION
## What

`_build_action_detail_lines` and `_get_action_marker_style` in `evaluation/vis.py` each independently implemented the same "prefer the new `coordinates` field, fall back to legacy `center_coordinates` (and `end_coordinates` for drag end-points)" lookup chain:

```python
# _build_action_detail_lines
if "coordinates" in action:
    coords = action["coordinates"]
    ...
elif "center_coordinates" in action:
    coords = action["center_coordinates"]
    ...

# _get_action_marker_style
end_xy = action.get("coordinates", action.get("center_coordinates", action.get("end_coordinates", [0, 0])))
...
elif "coordinates" in action:
    ...
elif "center_coordinates" in action:
    ...
```

Extracted a shared `_first_present(action, *keys)` helper that returns the value of the first present key (checked via `in`, not truthiness — an `_UNSET` sentinel distinguishes "no key present" from a present-but-falsy value like `None`, so the extraction is exactly behavior-preserving even for that edge case). Both call sites now delegate to it.

## Tests

`_get_action_marker_style` had **zero** existing test coverage. Per this repo's convention (PRs #109, #110, #121, #122) of adding characterization tests before refactoring previously-untested code, added 10 tests in `tests/test_vis.py` pinning:
- ref-only / no-coordinates behavior
- `coordinates` vs. legacy `center_coordinates` precedence
- the drag end-coordinate 3-way fallback chain (`coordinates` → `center_coordinates` → `end_coordinates` → `[0, 0]` default)
- that `start_coordinates` alone (without a drag `action_type`) does not trigger the drag branch

Verified these pass unchanged against both the pre- and post-refactor code (confirmed via `git stash`).

## Verification

- `python -m pytest tests/` — 114/114 pass (104 pre-existing + 10 new)
- `ruff check` / `ruff format --check` — clean

Scope: 1 file changed (`evaluation/vis.py`), plus its test file. No behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_013KZ9QxJGgUJKJ2VjRz9Dwe)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Evaluation-only visualization refactor with new tests locking prior behavior; no auth, data, or runtime eval logic changes.
> 
> **Overview**
> Deduplicates coordinate-field resolution in eval HTML visualization by introducing **`_first_present`** (with an **`_UNSET`** sentinel so “key missing” differs from a present **`None`**). **`_build_action_detail_lines`** and **`_get_action_marker_style`** now share the same precedence: **`coordinates`** → legacy **`center_coordinates`**, and for drags an end-point chain through **`end_coordinates`** with **`[0, 0]`** when nothing is present.
> 
> Adds **10 characterization tests** for **`_get_action_marker_style`** (ref-only, precedence, drag branches, non-drag **`start_coordinates`**) ahead of the refactor; intended as behavior-preserving only in **`evaluation/vis.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ce8ab5502065cd8e901a8ff5eb16d4ec291931c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->