### PR TITLE
Drop hand-rolled query-string stripping in ResyUrlMatch._normalize_url_without_time

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -310,7 +310,7 @@ class ResyUrlMatch(BaseMetric):
             states.append(group_states)
         return states
 
-    def _normalize_url(self, url: str, ignore_seats_time: bool = False) -> str:
+    def _normalize_url(self, url: str, ignore_seats_time: bool = False, include_time: bool = True) -> str:
         """
         Normalize Resy URL for comparison.
 
@@ -329,6 +329,9 @@ class ResyUrlMatch(BaseMetric):
             ignore_seats_time: If True, exclude 'seats' and 'time' parameters from the normalized URL.
                               This is used when "no availability" is detected, since the entire day is
                               unavailable regardless of party size or time slot.
+            include_time: If False (and ignore_seats_time is False), include 'date' and 'seats' but
+                          drop 'time'. Used by ``_normalize_url_without_time`` for conditional matching
+                          when the time slot differs but everything else about the query matches.
         """
         parsed, fallback = basic_normalize_url(url, "resy.com")
         if parsed is None:
@@ -363,13 +366,16 @@ class ResyUrlMatch(BaseMetric):
         # parse_qs returns lists, so we take the first value
         normalized_params = {}
 
-        # Determine which parameters to include based on ignore_seats_time flag
+        # Determine which parameters to include based on ignore_seats_time/include_time flags
         if ignore_seats_time:
             # Only include date (ignore seats and time when no availability detected)
             params_to_include = ["date"]
-        else:
+        elif include_time:
             # Include all parameters for strict matching
             params_to_include = ["date", "seats", "time"]
+        else:
+            # Include date and seats, but drop time (conditional matching)
+            params_to_include = ["date", "seats"]
 
         for key in params_to_include:
             if key in query_params and query_params[key]:
@@ -384,19 +390,7 @@ class ResyUrlMatch(BaseMetric):
         return result
 
     def _normalize_url_without_time(self, url: str) -> str:
-        normalized = self._normalize_url(url, ignore_seats_time=False)
-        return self._remove_query_param(normalized, "time")
-
-    def _remove_query_param(self, url: str, param: str) -> str:
-        if not url or "?" not in url:
-            return url
-        base, query = url.split("?", 1)
-        if not query:
-            return base
-        kept = [p for p in query.split("&") if not p.startswith(f"{param}=")]
-        if not kept:
-            return base
-        return f"{base}?{'&'.join(kept)}"
+        return self._normalize_url(url, ignore_seats_time=False, include_time=False)
 
     async def _extract_availabilities(self, page: PageLike) -> list[AvailabilitySlot]:
         try:


### PR DESCRIPTION
## Summary

- `ResyUrlMatch._normalize_url_without_time` (`navi_bench/resy/resy_url_match.py`) built its result by calling `_normalize_url()` — which already decides which query params to keep via `params_to_include` — and then re-parsing and hand-stripping the `time=` param back out of the resulting string with a bespoke `_remove_query_param` string splitter.
- Gave `_normalize_url()` a new `include_time: bool = True` parameter so it can compute `params_to_include = ["date", "seats"]` directly (mirroring the existing `ignore_seats_time` branch that already does this kind of conditional param selection), and `_normalize_url_without_time` now just calls `self._normalize_url(url, ignore_seats_time=False, include_time=False)`.
- Deleted the now-unused `_remove_query_param` helper.

## Why this is safe

- **On-domain (resy.com) URLs**: the parsed branch now computes `params_to_include = ["date", "seats"]` directly instead of `["date", "seats", "time"]` followed by post-hoc removal of `time=...` from the reconstructed string — these are equivalent for every code path that builds the query string (same sort order, same join logic).
- **Off-domain URLs**: `_normalize_url` returns the `fallback` string before any param-filtering logic runs, in both the old and new code — so `include_time` has no effect there either way. The only theoretical divergence (an off-domain fallback string that happens to contain a literal `time=` substring) can't change any match outcome: the only place `_normalize_url_without_time`'s result is used is an equality check (`normalized_url_without_time == state.base_without_time`) against a ground-truth URL that always canonicalizes through the on-domain (resy.com) branch, so an off-domain result — with or without a stray `time=` fragment — can never equal it regardless.
- Blast radius: 1 file. `_normalize_url`/`_normalize_url_without_time`/`_remove_query_param` have no other callers in the repo.

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] `pytest tests/test_resy_url_match.py` — 10 passed
- [x] Full suite: `pytest tests/` — 114 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dgjc4giTunTrMPp53jm3pn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dgjc4giTunTrMPp53jm3pn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor of benchmark URL normalization with equivalent logic for on-domain Resy URLs; existing tests cover the matcher.
> 
> **Overview**
> **ResyUrlMatch** URL normalization no longer builds a full query string and then strips `time=` with a separate string helper.
> 
> `_normalize_url` gains an **`include_time`** flag (default `True`) so it can emit only `date` and `seats` when time should be ignored—same idea as the existing **`ignore_seats_time`** branch. **`_normalize_url_without_time`** now calls `_normalize_url(..., include_time=False)` instead of normalize-then-strip.
> 
> The unused **`_remove_query_param`** helper is removed. Matching behavior for conditional “same venue/date/seats, different time” checks should stay the same for canonical Resy URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825f78b29377eff4b7f11fe35ff9d8ea9fe2b777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->