### PR TITLE
refactor(base): extract shared unwrap_optional_type helper for Optional[T]/T|None detection

### DIFF
--- a/evaluation/cli.py
+++ b/evaluation/cli.py
@@ -2,10 +2,11 @@ import argparse
 import asyncio
 import functools
 import inspect
-import types
-from typing import Union, get_args, get_origin
+from typing import get_args, get_origin
 
 from pydantic_core import PydanticUndefined
+
+from navi_bench.base import unwrap_optional_type
 
 
 def cli(fn):
@@ -57,10 +58,9 @@ def _build_argparse_kwargs(annotation, default, *, nullable: bool = False) -> di
     args = get_args(annotation)
 
     # Handle T | None or Optional[T]
-    if origin is types.UnionType or origin is Union:
-        non_none = [a for a in args if a is not type(None)]
-        if len(non_none) == 1:
-            return _build_argparse_kwargs(non_none[0], default, nullable=True)
+    unwrapped, is_optional = unwrap_optional_type(annotation)
+    if is_optional:
+        return _build_argparse_kwargs(unwrapped, default, nullable=True)
 
     # Handle list[T]
     if origin is list:

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -171,6 +171,24 @@ def instantiate(
         return config
 
 
+def unwrap_optional_type(annotation: Any) -> tuple[Any, bool]:
+    """Detect a two-member ``T | None`` / ``Optional[T]`` union and unwrap it to ``T``.
+
+    Returns ``(T, True)`` when ``annotation`` is a union with exactly one non-``NoneType``
+    member (i.e. a "simple optional"), and ``(annotation, False)`` unchanged otherwise --
+    including for non-union annotations and for unions with more than one non-``None``
+    member (e.g. ``int | str | None``), which callers should treat as "not a simple
+    optional" and handle accordingly (e.g. raise or fall back to a default).
+    """
+    origin = get_origin(annotation)
+    if origin not in (Union, types.UnionType):
+        return annotation, False
+    non_none = tuple(a for a in get_args(annotation) if a is not type(None))
+    if len(non_none) == 1:
+        return non_none[0], True
+    return annotation, False
+
+
 def basic_pydantic_to_hf_features(model_class: type[BaseModel]) -> Features:
     """
     Basic function to convert a pydantic model to a HuggingFace Features dictionary.
@@ -182,11 +200,10 @@ def basic_pydantic_to_hf_features(model_class: type[BaseModel]) -> Features:
 
         # unwrap the optional field
         if get_origin(field_type) in (Union, types.UnionType):
-            args = tuple(a for a in get_args(field_type) if a is not type(None))
-            if len(args) == 1 and len(get_args(field_type)) == 2:
-                field_type = args[0]
-            else:
+            unwrapped, is_optional = unwrap_optional_type(field_type)
+            if not is_optional:
                 raise ValueError(f"Unexpected union type: {field_type}")
+            field_type = unwrapped
 
         # recursive if the field is a pydantic model
         if issubclass(field_type, BaseModel):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,7 +7,16 @@ helper can be verified as behavior-preserving for both call sites.
 
 import asyncio
 
-from navi_bench.base import FinalResult, all_or_nothing_coverage_result
+import pytest
+from datasets import Value
+from pydantic import BaseModel
+
+from navi_bench.base import (
+    FinalResult,
+    all_or_nothing_coverage_result,
+    basic_pydantic_to_hf_features,
+    unwrap_optional_type,
+)
 from navi_bench.google_flights.google_flights_search_match import GoogleFlightsSearchMatch
 from navi_bench.resy.resy_url_match import ResyUrlMatch
 
@@ -78,3 +87,79 @@ class TestGoogleFlightsSearchMatchComputeUsesSharedHelper:
         result = asyncio.run(metric.compute())
 
         assert result.score == 1.0
+
+
+class TestUnwrapOptionalType:
+    """Characterization tests for the shared ``Optional[T]``/``T | None`` unwrapping logic,
+    extracted from the near-identical duplicate in ``basic_pydantic_to_hf_features`` and
+    ``evaluation.cli._build_argparse_kwargs``. Both call sites relied on the same "a union
+    with exactly one non-None member is a simple optional" semantics, which this helper
+    now centralizes.
+    """
+
+    def test_pipe_none_union_unwraps(self):
+        assert unwrap_optional_type(int | None) == (int, True)
+
+    def test_optional_typing_alias_unwraps(self):
+        from typing import Optional
+
+        assert unwrap_optional_type(Optional[str]) == (str, True)
+
+    def test_plain_type_is_not_optional(self):
+        assert unwrap_optional_type(int) == (int, False)
+
+    def test_two_member_non_none_union_is_not_optional(self):
+        assert unwrap_optional_type(int | str) == (int | str, False)
+
+    def test_three_member_union_with_none_is_not_optional(self):
+        annotation = int | str | None
+        assert unwrap_optional_type(annotation) == (annotation, False)
+
+
+class TestBasicPydanticToHfFeatures:
+    def test_basic_types(self):
+        class Model(BaseModel):
+            a: str
+            b: int
+            c: float
+            d: bool
+
+        features = basic_pydantic_to_hf_features(Model)
+
+        assert features["a"] == Value(dtype="string")
+        assert features["b"] == Value(dtype="int64")
+        assert features["c"] == Value(dtype="float64")
+        assert features["d"] == Value(dtype="bool")
+
+    def test_optional_field_unwraps_to_inner_type(self):
+        class Model(BaseModel):
+            a: str | None = None
+
+        features = basic_pydantic_to_hf_features(Model)
+
+        assert features["a"] == Value(dtype="string")
+
+    def test_nested_pydantic_model(self):
+        class Inner(BaseModel):
+            x: int
+
+        class Outer(BaseModel):
+            inner: Inner
+
+        features = basic_pydantic_to_hf_features(Outer)
+
+        assert features["inner"]["x"] == Value(dtype="int64")
+
+    def test_non_optional_union_raises(self):
+        class Model(BaseModel):
+            a: int | str
+
+        with pytest.raises(ValueError, match="Unexpected union type"):
+            basic_pydantic_to_hf_features(Model)
+
+    def test_unsupported_type_raises(self):
+        class Model(BaseModel):
+            a: list[str]
+
+        with pytest.raises(ValueError, match="Unexpected field type"):
+            basic_pydantic_to_hf_features(Model)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+"""Characterization tests for ``evaluation.cli._build_argparse_kwargs``, which shares its
+``Optional[T]``/``T | None`` detection with ``navi_bench.base.basic_pydantic_to_hf_features``
+via the extracted ``navi_bench.base.unwrap_optional_type`` helper. These pin the pre-refactor
+behavior for optional, list, bool, basic, and "not a simple optional" annotations.
+"""
+
+import argparse
+
+from evaluation.cli import _build_argparse_kwargs
+
+
+class TestBuildArgparseKwargs:
+    def test_basic_type(self):
+        kwargs = _build_argparse_kwargs(str, default="x")
+
+        assert kwargs == {"default": "x", "type": str}
+
+    def test_bool_uses_boolean_optional_action(self):
+        kwargs = _build_argparse_kwargs(bool, default=False)
+
+        assert kwargs == {"default": False, "action": argparse.BooleanOptionalAction}
+
+    def test_list_type(self):
+        kwargs = _build_argparse_kwargs(list[int], default=None)
+
+        assert kwargs == {"default": None, "nargs": "+", "type": int}
+
+    def test_optional_basic_type_unwraps_and_uses_star_nargs_if_list(self):
+        kwargs = _build_argparse_kwargs(int | None, default=None)
+
+        assert kwargs == {"default": None, "type": int}
+
+    def test_optional_list_type_uses_star_nargs(self):
+        kwargs = _build_argparse_kwargs(list[str] | None, default=None)
+
+        assert kwargs == {"default": None, "nargs": "*", "type": str}
+
+    def test_unsupported_type_falls_back_to_str(self):
+        kwargs = _build_argparse_kwargs(dict, default=None)
+
+        assert kwargs == {"default": None, "type": str}
+
+    def test_non_optional_union_falls_back_to_str(self):
+        # A union that isn't a simple `T | None` optional (more than one non-None member)
+        # is not unwrapped; it falls through to the str fallback rather than raising.
+        kwargs = _build_argparse_kwargs(int | str, default=None)
+
+        assert kwargs == {"default": None, "type": str}


### PR DESCRIPTION
## Structural issue

`navi_bench/base.py`'s `basic_pydantic_to_hf_features` and `evaluation/cli.py`'s `_build_argparse_kwargs` each hand-rolled the identical "is this annotation a union with exactly one non-`NoneType` member (i.e. a simple `Optional[T]`/`T | None`)" detection:

```python
# base.py
if get_origin(field_type) in (Union, types.UnionType):
    args = tuple(a for a in get_args(field_type) if a is not type(None))
    if len(args) == 1 and len(get_args(field_type)) == 2:
        field_type = args[0]
    else:
        raise ValueError(...)

# cli.py
if origin is types.UnionType or origin is Union:
    non_none = [a for a in args if a is not type(None)]
    if len(non_none) == 1:
        return _build_argparse_kwargs(non_none[0], default, nullable=True)
```

These two subsystems (core pydantic-to-HF-Features schema conversion, and CLI argparse generation) hadn't been cross-referenced by prior refactor passes on this repo, which mostly focused on domain-matcher URL/date logic and `evaluation/vis.py` HTML building.

## The fix

Extracted `navi_bench.base.unwrap_optional_type(annotation) -> tuple[Any, bool]` as the single implementation. Both call sites now delegate to it and keep their own differing post-detection behavior (`base.py` raises `ValueError` when a union isn't a simple optional; `cli.py` silently falls through to a `str`-typed default) — the extraction only centralizes *detection*, not the two call sites' distinct handling of the "not optional" case.

`evaluation/cli.py` already imports several other things from `navi_bench.base` elsewhere in the codebase's convention (`evaluation/{browser,custom_task,dataset,eval_n1,recorder,stats}.py` all do), so this adds no new architectural coupling.

## Why it's safe

- Pure, deterministic type-introspection code — no I/O, no side effects.
- Neither function had any prior test coverage. Added characterization tests for both (`tests/test_base.py::TestBasicPydanticToHfFeatures`, new `tests/test_cli.py::TestBuildArgparseKwargs`) plus direct tests of the new helper (`tests/test_base.py::TestUnwrapOptionalType`), covering: plain types, `T | None`, `Optional[T]`, non-optional unions (`int | str`), 3-member unions with `None` (`int | str | None`), `list[T]`, and `list[T] | None`.
- Independently verified behavior parity by running the pre-refactor logic side-by-side with the new helper across a dozen annotation shapes (plain types, optionals, multi-member unions, generics) — all outputs matched exactly.
- Full suite: 131/131 tests pass (114 pre-existing + 17 new). `ruff format`/`ruff check` clean.
- Scoped to 2 production files (`navi_bench/base.py`, `evaluation/cli.py`) + 2 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S57gNfAh5WsASCjwgujrZ6


---
_Generated by [Claude Code](https://claude.ai/code/session_01S57gNfAh5WsASCjwgujrZ6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure type-introspection refactor with pinned tests; no change to distinct error/fallback behavior at each call site.
> 
> **Overview**
> Centralizes duplicated **`T | None` / `Optional[T]`** type-introspection in a new **`unwrap_optional_type`** helper in `navi_bench/base.py`, replacing inline union checks in **`basic_pydantic_to_hf_features`** and **`evaluation/cli._build_argparse_kwargs`**.
> 
> Each call site keeps its prior behavior when a union is not a “simple optional”: HF feature conversion still **raises** on multi-member unions; CLI argparse building still **falls back to `str`**. Adds characterization tests for the helper, **`basic_pydantic_to_hf_features`**, and **`_build_argparse_kwargs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849820bbfb89528146aa9a0d5f250c6e5067dd58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->