### PR TITLE
refactor(vis): extract shared _ACTION_COLOR_CLASSES constant for marker color mapping

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -17,6 +17,22 @@ _FORM_ACTION_ICONS: dict[str, str] = {
     "list_records": "📊",
 }
 
+# Action-type -> marker color class, shared by the per-step marker HTML (Python) and the
+# modal's ``getMarkerHtml`` (JavaScript). The JS side additionally maps a few marker types
+# ("longpress", "pressenter", "launch") that only appear in modal-only marker data; those
+# extra entries are layered on top via object spread where this constant is injected, so
+# this dict stays the single source of truth for the classes both sides agree on.
+_ACTION_COLOR_CLASSES: dict[str, str] = {
+    "left_click": "click",
+    "double_click": "click",
+    "triple_click": "click",
+    "right_click": "click",
+    "click": "click",  # Legacy support
+    "scroll": "scroll",
+    "type": "type",
+    "hover": "hover",
+}
+
 # Sentinel distinguishing "no key present" from a present-but-falsy (e.g. ``None``) value.
 _UNSET = object()
 
@@ -1283,16 +1299,7 @@ def generate_visualization_html(
             if marker.get("has_point"):
                 action_type = marker["type"]
                 # Map action types to color classes
-                color_class = {
-                    "left_click": "click",
-                    "double_click": "click",
-                    "triple_click": "click",
-                    "right_click": "click",
-                    "click": "click",  # Legacy support
-                    "scroll": "scroll",
-                    "type": "type",
-                    "hover": "hover",
-                }.get(action_type.lower(), "click")
+                color_class = _ACTION_COLOR_CLASSES.get(action_type.lower(), "click")
                 markers_html += f"""
                 <div class="action-marker" style="left: {marker["x"]}%; top: {marker["y"]}%;">
                     <div class="action-point {color_class}"></div>
@@ -1458,6 +1465,7 @@ def generate_visualization_html(
 
     modal_data_json = _escape_json_for_script_tag(json.dumps(modal_steps_data))
     stop_answers_json = _escape_json_for_script_tag(json.dumps(stop_answers_data))
+    action_color_classes_json = json.dumps(_ACTION_COLOR_CLASSES)
 
     # Navigation and closing tags
     html += f"""
@@ -1497,19 +1505,7 @@ def generate_visualization_html(
 
         function getMarkerHtml(marker, index) {{
             if (marker.has_point) {{
-                const colorClass = {{
-                    'left_click': 'click',
-                    'double_click': 'click',
-                    'triple_click': 'click',
-                    'right_click': 'click',
-                    'click': 'click',
-                    'scroll': 'scroll',
-                    'type': 'type',
-                    'hover': 'hover',
-                    'longpress': 'click',
-                    'pressenter': 'type',
-                    'launch': 'scroll'
-                }}[marker.type.toLowerCase()] || 'click';
+                const colorClass = {{...{action_color_classes_json}, 'longpress': 'click', 'pressenter': 'type', 'launch': 'scroll'}}[marker.type.toLowerCase()] || 'click';
                 return `<div class="action-marker" style="left: ${{marker.x}}%; top: ${{marker.y}}%;">
                     <div class="action-point ${{colorClass}}"></div>
                     <div class="action-label">${{index + 1}}. ${{marker.type}}</div>

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -19,6 +19,7 @@ from evaluation.vis import (
     _get_action_marker_style,
     _render_response_section,
     _render_section,
+    _ACTION_COLOR_CLASSES,
 )
 
 
@@ -127,6 +128,58 @@ class TestActionCardStyling:
         )
         assert css_class == "action-item form-action"
         assert label == "📝 1. add_question"
+
+
+class TestActionMarkerColorClass:
+    """Characterization tests for the marker color-class mapping shared between the
+    per-step marker HTML (Python, ``_ACTION_COLOR_CLASSES``) and the modal's
+    ``getMarkerHtml`` (JavaScript, injected via ``json.dumps(_ACTION_COLOR_CLASSES)``
+    plus modal-only overrides for ``longpress``/``pressenter``/``launch``). Pins that
+    both sides resolve to the same CSS class for every action type they share.
+    """
+
+    def _color_class_for(self, action_type: str) -> str:
+        # Screenshot markers are only rendered when the step has a screenshot_url, so an
+        # observation image must precede the assistant's tool call (unlike the other
+        # helpers in this file, which don't need markers rendered at all).
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+            {"role": "observation", "content": [{"type": "image_url", "image_url": {"url": "http://x/1.png"}}]},
+            *_messages_with_action({"coordinates": [10, 20]}, name=action_type)[1:],
+        ]
+        html = generate_visualization_html("task1", messages, None)
+        match = re.search(r'<div class="action-point ([a-z]+)"></div>', html)
+        assert match is not None, html
+        return match.group(1)
+
+    def test_click_aliases_map_to_click(self):
+        for action_type in ("left_click", "double_click", "triple_click", "right_click", "click"):
+            assert self._color_class_for(action_type) == "click"
+
+    def test_scroll_maps_to_scroll(self):
+        assert self._color_class_for("scroll") == "scroll"
+
+    def test_type_maps_to_type(self):
+        assert self._color_class_for("type") == "type"
+
+    def test_hover_maps_to_hover(self):
+        assert self._color_class_for("hover") == "hover"
+
+    def test_unrecognized_action_type_defaults_to_click(self):
+        assert self._color_class_for("some_unrecognized_action") == "click"
+
+    def test_case_insensitive_lookup(self):
+        assert self._color_class_for("LEFT_CLICK") == "click"
+
+    def test_js_modal_snippet_embeds_shared_constant_and_layers_extra_keys(self):
+        html = generate_visualization_html("task1", _messages_with_action({"coordinates": [10, 20]}), None)
+        match = re.search(r"const colorClass = (\{.*?\})\[marker\.type\.toLowerCase\(\)\] \|\| 'click';", html)
+        assert match is not None, html
+        js_snippet = match.group(1)
+        for action_type, css_class in _ACTION_COLOR_CLASSES.items():
+            assert f'"{action_type}": "{css_class}"' in js_snippet
+        for action_type, css_class in (("longpress", "click"), ("pressenter", "type"), ("launch", "scroll")):
+            assert f"'{action_type}': '{css_class}'" in js_snippet
 
 
 class TestGetActionMarkerStyle:


### PR DESCRIPTION
## What

`generate_visualization_html()` in `evaluation/vis.py` duplicated the action-type -> marker-color-class mapping in two places:
- the Python per-step marker renderer (`color_class = {...}.get(action_type.lower(), "click")`)
- the JS-side `getMarkerHtml()` used by the screenshot modal (`const colorClass = {...}[marker.type.toLowerCase()] || 'click'`)

The JS copy also carried three extra modal-only keys (`longpress`/`pressenter`/`launch`) not present on the Python side. Prior refactor audits logged in `yutori-ai/yutori`'s `.claude/REFACTOR.md` flagged this duplication but explicitly held off, because unifying the two maps naively would force a decision about that extra vocabulary (does the Python side need those three types too?), which isn't a purely mechanical question.

## Fix

Sidesteps that question entirely: the eight entries that genuinely overlap are now a single module-level `_ACTION_COLOR_CLASSES` constant (same convention as the existing `_STOP_ACTION_TYPES`/`_FORM_ACTION_ICONS`), used directly on the Python side and injected into the JS template as a JSON literal via `json.dumps(_ACTION_COLOR_CLASSES)`. The three modal-only keys are layered on top via JS object spread (`{...{json literal}, 'longpress': 'click', 'pressenter': 'type', 'launch': 'scroll'}`), so no vocabulary decision is made — the generated JS resolves to the exact same final mapping as before for every marker type.

## Safety

- Verified byte-identical `colorClass` resolution for all marker types (shared + modal-only + unknown + case variants) with a Node script comparing the old inline JS object literal against the new spread form.
- Verified the actual generated HTML/JS output is unchanged in structure by rendering before/after.
- Added `TestActionMarkerColorClass` in `tests/test_vis.py` (7 new tests) pinning both the Python-rendered CSS class per action type and the contents of the injected JS snippet.
- Full suite: 138/138 passing (up from 131 baseline). `ruff check` clean; `ruff format --check` shows no new issues (pre-existing drift in 3 unrelated files on `main` is untouched by this diff).
- Diff is scoped to 2 files: `evaluation/vis.py` and `tests/test_vis.py`.

No functional/behavioral change — this is a pure duplication-removal refactor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeSWLi6tkzNij13KKdgCX7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of visualization HTML generation with tests locking prior marker styling; no auth, data, or runtime API changes.
> 
> **Overview**
> **Deduplicates** the action-type → screenshot marker CSS class mapping in eval visualization HTML generation.
> 
> Previously the same eight-type lookup lived inline in Python (per-step markers) and again in the modal’s `getMarkerHtml` JavaScript, with three extra modal-only types on the JS side only. The shared entries now live in module-level `_ACTION_COLOR_CLASSES` (aligned with `_FORM_ACTION_ICONS` / `_STOP_ACTION_TYPES`). Python reads that dict directly; the generated script embeds it via `json.dumps` and the modal still adds `longpress`, `pressenter`, and `launch` with object spread so behavior stays the same.
> 
> **Tests:** new `TestActionMarkerColorClass` checks Python-rendered classes and that the injected JS snippet contains the shared map plus the modal-only overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e28e884cd730265912e9f99e4503a3f023191c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->