### PR TITLE
refactor(opentable): reuse nth_weekday_of_month for first-Saturday calculation

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -28,7 +28,7 @@ from navi_bench.dates import (
     render_task_statement,
     resolve_city_now,
 )
-from navi_bench.relative_dates import WEEKDAYS
+from navi_bench.relative_dates import WEEKDAYS, nth_weekday_of_month
 
 
 class SingleCandidateQuery(TypedDict, total=False):
@@ -576,17 +576,13 @@ def get_first_weekend_of_next_month_offsets(today: datetime) -> list[int]:
     else:
         first_of_next_month = datetime(today.year, today.month + 1, 1, tzinfo=today.tzinfo)
 
-    # Find what day of the week the 1st is (0=Monday, 6=Sunday)
-    first_day_weekday = first_of_next_month.weekday()
-
-    # Calculate days from the 1st to the first Saturday
-    if first_day_weekday <= 5:  # Monday-Saturday
-        days_to_first_sat = 5 - first_day_weekday
-    else:  # Sunday (6)
-        days_to_first_sat = 6  # Next Saturday is 6 days away
-
     # First Saturday of the next calendar month
-    first_saturday = first_of_next_month + timedelta(days=days_to_first_sat)
+    first_saturday_date = nth_weekday_of_month(
+        first_of_next_month.year, first_of_next_month.month, WEEKDAYS["saturday"], 1
+    )
+    first_saturday = datetime(
+        first_saturday_date.year, first_saturday_date.month, first_saturday_date.day, tzinfo=today.tzinfo
+    )
     first_sunday = first_saturday + timedelta(days=1)
 
     # Calculate offsets from today (using normalized date)


### PR DESCRIPTION
## Summary
- `get_first_weekend_of_next_month_offsets` in `navi_bench/opentable/opentable_info_gathering.py` hand-rolled a "find the first Saturday of a month" calculation via manual weekday arithmetic (a `<=5`/`else` branch computing `days_to_first_sat`).
- This duplicated the generic `nth_weekday_of_month(year, month, weekday, n)` helper already defined in `navi_bench/relative_dates.py`, whose `WEEKDAYS` map this same file already imports.
- Replaced the inline block with a call to `nth_weekday_of_month(first_of_next_month.year, first_of_next_month.month, WEEKDAYS["saturday"], 1)`, keeping the surrounding "next calendar month" / day-offset-from-today logic unchanged.

## Why this is safe
- Hand-traced both formulas for all 7 possible weekdays of the 1st of the month (Monday through Sunday) — outputs match exactly in every case.
- Brute-force compared old vs. new implementation output across 5 years of dates (1,825 days) — 0 mismatches.
- `tests/test_opentable_info_gathering.py` (29 tests) and the full repo test suite (138 tests) pass unchanged.
- `ruff check` / `ruff format` are clean.

## Test plan
- [x] `uv run pytest tests/test_opentable_info_gathering.py -q` — 29 passed
- [x] `uv run pytest -q` (full suite) — 138 passed
- [x] `uv run ruff check` / `ruff format --diff` — clean
- [x] Manual brute-force equivalence check across 5 years of dates — 0 mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGJbxJryvF2eMS7wyKLKZo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in benchmark date-label resolution; PR author verified equivalence across calendar cases and tests pass unchanged.
> 
> **Overview**
> **`get_first_weekend_of_next_month_offsets`** no longer hand-computes days from the 1st to the first Saturday; it delegates to **`nth_weekday_of_month`** from `relative_dates` (with **`WEEKDAYS["saturday"]`**, `n=1`) and wraps the result in a timezone-aware `datetime`.
> 
> Next-month boundaries and day-offset math from “today” to that Saturday/Sunday pair are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc8900fa8d4cffc9e54727456a42dad205eab29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->