### PR TITLE
refactor: consolidate duplicated __repr__ boilerplate across metrics

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -13,6 +13,7 @@ from navi_bench.base import (
     basic_normalize_url,
     build_task_config,
     parse_filtered_query_params,
+    repr_with_attr,
 )
 from navi_bench.dates import initialize_user_metadata
 
@@ -31,7 +32,7 @@ class ApartmentsUrlMatch(BaseMetric):
         self._found_match = False
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(gt_urls={self.gt_urls})"
+        return repr_with_attr(self, "gt_urls")
 
     async def reset(self) -> None:
         self._found_match = False

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -266,15 +266,19 @@ class BaseMetric:
     async def reset(self) -> None: ...
 
 
-def repr_with_attr(instance: object, attr_name: str) -> str:
-    """Render ``ClassName(attr_name=value)`` for a single-attribute ``__repr__``.
+def repr_with_attr(instance: object, attr_name: str, *, label: str | None = None) -> str:
+    """Render ``ClassName(label=value)`` for a single-attribute ``__repr__``.
 
     Centralizes the ``f"{self.__class__.__name__}({attr}={self.{attr}})"`` one-liner that
     several :class:`BaseMetric` subclasses (apartments, craigslist, resy, opentable, google_flights)
     each hand-rolled. Uses ``type(instance).__name__`` rather than a hardcoded literal so it
     reflects the actual runtime class, including subclasses.
+
+    ``label`` defaults to ``attr_name`` but can be overridden when the displayed name should
+    differ from the underlying attribute (e.g. ``GoogleFlightsSearchMatch`` historically
+    labeled its ``_gt_base_info`` attribute as ``gt_info``, matching its constructor kwarg).
     """
-    return f"{type(instance).__name__}({attr_name}={getattr(instance, attr_name)})"
+    return f"{type(instance).__name__}({label if label is not None else attr_name}={getattr(instance, attr_name)})"
 
 
 class FinalResult(BaseModel):

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -266,6 +266,17 @@ class BaseMetric:
     async def reset(self) -> None: ...
 
 
+def repr_with_attr(instance: object, attr_name: str) -> str:
+    """Render ``ClassName(attr_name=value)`` for a single-attribute ``__repr__``.
+
+    Centralizes the ``f"{self.__class__.__name__}({attr}={self.{attr}})"`` one-liner that
+    several :class:`BaseMetric` subclasses (apartments, craigslist, resy, opentable, google_flights)
+    each hand-rolled. Uses ``type(instance).__name__`` rather than a hardcoded literal so it
+    reflects the actual runtime class, including subclasses.
+    """
+    return f"{type(instance).__name__}({attr_name}={getattr(instance, attr_name)})"
+
+
 class FinalResult(BaseModel):
     """Standard result returned by URL-based domain matchers."""
 

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -11,6 +11,7 @@ from navi_bench.base import (
     build_task_config,
     fractional_coverage_score,
     parse_filtered_query_params,
+    repr_with_attr,
 )
 from navi_bench.dates import initialize_user_metadata
 
@@ -35,7 +36,7 @@ class CraigslistUrlMatch(BaseMetric):
         self._intermediate_url_to_state = {}
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(gt_urls={self.gt_urls})"
+        return repr_with_attr(self, "gt_urls")
 
     async def reset(self) -> None:
         self._intermediate_url_to_state = {}

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -78,7 +78,7 @@ class GoogleFlightsSearchMatch(BaseMetric):
         self._url_to_flight_info = defaultdict(Info)
 
     def __repr__(self) -> str:
-        return repr_with_attr(self, "_gt_base_info")
+        return repr_with_attr(self, "_gt_base_info", label="gt_info")
 
     @classmethod
     def _decode_google_flights_url(cls, url: str) -> Info | None:

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -15,6 +15,7 @@ from navi_bench.base import (
     UrlMetricInput,
     all_or_nothing_coverage_result,
     build_task_config,
+    repr_with_attr,
 )
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
 from navi_bench.google_flights.google_flights_pb2 import Info
@@ -77,7 +78,7 @@ class GoogleFlightsSearchMatch(BaseMetric):
         self._url_to_flight_info = defaultdict(Info)
 
     def __repr__(self) -> str:
-        return f"GoogleFlightsSearchMatch(gt_info={self._gt_base_info})"
+        return repr_with_attr(self, "_gt_base_info")
 
     @classmethod
     def _decode_google_flights_url(cls, url: str) -> Info | None:

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -20,6 +20,7 @@ from navi_bench.base import (
     fractional_coverage_score,
     hour_to_12h_period,
     read_sidecar,
+    repr_with_attr,
 )
 from navi_bench.dates import (
     ensure_resolved_dates,
@@ -92,7 +93,7 @@ class OpenTableInfoGathering(BaseMetric):
         ]
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(queries={self.queries})"
+        return repr_with_attr(self, "queries")
 
     @functools.cached_property
     def js_script(self) -> str:

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -20,6 +20,7 @@ from navi_bench.base import (
     build_task_config,
     hour_to_12h_period,
     read_sidecar,
+    repr_with_attr,
 )
 from navi_bench.dates import (
     ensure_resolved_dates,
@@ -153,7 +154,7 @@ class ResyUrlMatch(BaseMetric):
         self._coverage_reasons: list[dict[str, Any] | None] = [None] * len(queries)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(queries={self.queries})"
+        return repr_with_attr(self, "queries")
 
     @functools.cached_property
     def js_script(self) -> str:


### PR DESCRIPTION
## Summary
- Five `BaseMetric` subclasses (`ApartmentsUrlMatch`, `CraigslistUrlMatch`, `ResyUrlMatch`, `OpenTableInfoGathering`, `GoogleFlightsSearchMatch`) each hand-rolled the identical `f"{self.__class__.__name__}(<attr>={self.<attr>})"` one-liner for `__repr__` — two pairs (apartments/craigslist on `gt_urls`, resy/opentable on `queries`) were byte-for-byte identical strings.
- `GoogleFlightsSearchMatch.__repr__` was the one outlier: it hardcoded the literal string `"GoogleFlightsSearchMatch"` instead of using the class name dynamically. This is a real, verifiable bug — if this class were ever subclassed, `repr()` would print the wrong class name.
- Added a single `repr_with_attr(instance, attr_name)` helper to `navi_bench/base.py` and had all five `__repr__` methods delegate to it (using `type(instance).__name__` under the hood).

## Why this is safe
- Pure boilerplate extraction — no behavior change for any of the four classes that already used `self.__class__.__name__`.
- Verified via a repo-wide grep for `repr(` / `__repr__` that no test anywhere asserts on the exact `repr()` output string of any of these five classes.
- The one classes whose repr *string* value could change if subclassed (`GoogleFlightsSearchMatch`) now correctly reflects the runtime class name — verified locally that a subclass now renders its own name instead of the hardcoded literal, and that the base class's own `repr()` output is byte-identical to before.
- Full test suite passes locally (138 passed).
- `ruff check` passes clean on all six changed files.

## Test plan
- [x] Ran `python3 -m pytest -q` — 138 passed
- [x] Ran `python3 -m ruff check` on all changed files — all checks passed
- [x] Manually verified `repr()` output for all five classes matches previous behavior, and that a `GoogleFlightsSearchMatch` subclass now shows its own class name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B9u54cvz7vM1DJtwM8DCg

---
_Generated by [Claude Code](https://claude.ai/code/session_015B9u54cvz7vM1DJtwM8DCg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only refactor with no eval or scoring path changes; repr output is intended to stay the same except for the Google Flights subclass-name fix.
> 
> **Overview**
> Adds **`repr_with_attr`** in `navi_bench/base.py` and switches five **`BaseMetric`** subclasses to use it for **`__repr__`** instead of duplicated one-liners.
> 
> **ApartmentsUrlMatch**, **CraigslistUrlMatch**, **ResyUrlMatch**, and **OpenTableInfoGathering** now delegate with their existing attribute names (`gt_urls` or `queries`). **GoogleFlightsSearchMatch** uses the optional **`label`** so repr still shows **`gt_info=...`** while reading **`_gt_base_info`**, and class names come from **`type(instance).__name__`** instead of a hardcoded **`GoogleFlightsSearchMatch`** string (so subclasses would repr correctly).
> 
> No changes to metric **`update`**, **`compute`**, or task config generation—debug/display only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a508858f154b7f751a1da9c976d3afaa4cf3838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->