### PR TITLE
refactor(vis): consolidate duplicated block-field lookup in _block_type

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -124,26 +124,21 @@ def _anthropic_image_to_data_url(block: dict) -> str | None:
     return f"data:{media_type};base64,{data}"
 
 
-def _block_type(block: object) -> str | None:
-    """Read ``"type"`` from an Anthropic content block.
+def _block_field(block: object, field: str, default: object = None) -> object:
+    """Read an arbitrary attribute from an Anthropic content block.
 
     Blocks arrive either as plain dicts (JSON-serialized history) or as
     pydantic objects (Anthropic SDK response), so callers need to branch on
     ``isinstance(block, dict)`` before reaching for ``.get`` or ``getattr``.
     """
     if isinstance(block, dict):
-        return block.get("type")
-    return getattr(block, "type", None)
-
-
-def _block_field(block: object, field: str, default: object = None) -> object:
-    """Read an arbitrary attribute from an Anthropic content block.
-
-    Mirrors :func:`_block_type` but for fields other than ``type``.
-    """
-    if isinstance(block, dict):
         return block.get(field, default)
     return getattr(block, field, default)
+
+
+def _block_type(block: object) -> str | None:
+    """Read ``"type"`` from an Anthropic content block. Thin wrapper over :func:`_block_field`."""
+    return _block_field(block, "type")
 
 
 def _build_action_detail_lines(action: dict) -> list[str]:

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -16,11 +16,59 @@ import re
 
 from evaluation.vis import (
     generate_visualization_html,
+    _block_field,
+    _block_type,
     _get_action_marker_style,
     _render_response_section,
     _render_section,
     _ACTION_COLOR_CLASSES,
 )
+
+
+class _FakeBlock:
+    """Minimal stand-in for an Anthropic SDK content-block object (attribute access,
+    not dict-style ``[]``/``.get``), used to exercise the ``getattr`` branch of
+    ``_block_type``/``_block_field`` that a plain-dict content block never reaches."""
+
+    def __init__(self, **attrs):
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+class TestBlockTypeAndField:
+    """Characterization tests for ``_block_type``/``_block_field``, the two content-block
+    accessors that branch on ``isinstance(block, dict)`` to support both JSON-serialized
+    history (plain dicts) and live Anthropic SDK responses (pydantic objects, read via
+    ``getattr``). Pins current behavior for both branches, including missing-key/attribute
+    defaults, before ``_block_type`` is consolidated to delegate to ``_block_field``.
+    """
+
+    def test_block_type_dict_present(self):
+        assert _block_type({"type": "text", "text": "hi"}) == "text"
+
+    def test_block_type_dict_missing_defaults_to_none(self):
+        assert _block_type({"text": "hi"}) is None
+
+    def test_block_type_object_present(self):
+        assert _block_type(_FakeBlock(type="tool_use")) == "tool_use"
+
+    def test_block_type_object_missing_defaults_to_none(self):
+        assert _block_type(_FakeBlock(text="hi")) is None
+
+    def test_block_field_dict_present(self):
+        assert _block_field({"text": "hello"}, "text") == "hello"
+
+    def test_block_field_dict_missing_uses_default(self):
+        assert _block_field({}, "name", "unknown") == "unknown"
+
+    def test_block_field_dict_missing_no_default_is_none(self):
+        assert _block_field({}, "name") is None
+
+    def test_block_field_object_present(self):
+        assert _block_field(_FakeBlock(name="tool_a"), "name", "unknown") == "tool_a"
+
+    def test_block_field_object_missing_uses_default(self):
+        assert _block_field(_FakeBlock(), "name", "unknown") == "unknown"
 
 
 def _messages_with_action(action_args: dict, name: str = "left_click") -> list[dict]:


### PR DESCRIPTION
## Issue

`evaluation/vis.py` had two near-identical helpers for reading a value off an Anthropic
content block, which arrives either as a plain dict (JSON-serialized history) or a
pydantic object (live Anthropic SDK response):

```python
def _block_type(block: object) -> str | None:
    if isinstance(block, dict):
        return block.get("type")
    return getattr(block, "type", None)


def _block_field(block: object, field: str, default: object = None) -> object:
    if isinstance(block, dict):
        return block.get(field, default)
    return getattr(block, field, default)
```

`_block_type(block)` is exactly `_block_field(block, "type")` — the `isinstance`/`getattr`
branching logic was duplicated verbatim, just specialized to a single hardcoded key.

## Fix

`_block_type` now delegates to `_block_field` instead of reimplementing the same branch,
so there's a single implementation of the dict-vs-object field lookup:

```python
def _block_field(block: object, field: str, default: object = None) -> object:
    if isinstance(block, dict):
        return block.get(field, default)
    return getattr(block, field, default)


def _block_type(block: object) -> str | None:
    """Thin wrapper over _block_field."""
    return _block_field(block, "type")
```

## Why this is safe

- **Added characterization tests first** (`tests/test_vis.py::TestBlockTypeAndField`, 9 new
  tests), covering both branches (dict and non-dict/`getattr`) and both present/missing-key
  behavior, including the untested `getattr`-with-default path (existing tests only ever
  passed dict-shaped blocks). Confirmed these pass against the **pre-refactor** code first.
- Ran the full suite before and after: **147/147 pass** (138 existing + 9 new), identical
  behavior.
- `ruff check` and `ruff format --check` both clean.
- Single file touched (plus its test file), no behavior/functionality change — pure
  delegation, same defaults, same branch order.

## Test plan

- [x] `pytest tests/` — 147 passed
- [x] `ruff check evaluation/vis.py tests/test_vis.py` — all checks passed
- [x] `ruff format --check evaluation/vis.py tests/test_vis.py` — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrhohMfGuUVCUfMkiigpct


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrhohMfGuUVCUfMkiigpct)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor in eval visualization helpers with no call-site changes and new tests confirming identical behavior.
> 
> **Overview**
> **`_block_type`** in `evaluation/vis.py` no longer duplicates the dict-vs-SDK-object lookup; it now calls **`_block_field(block, "type")`**, leaving a single implementation for reading Anthropic content blocks. **`_block_field`** is defined first and keeps the shared docstring; **`_block_type`** is a thin wrapper with an updated docstring.
> 
> **`tests/test_vis.py`** adds **`TestBlockTypeAndField`** (nine tests plus **`_FakeBlock`**) to lock in behavior for dict and attribute-based blocks, including missing keys and defaults, before and after the delegation change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdfa4c6af265849739de00a301e84659c008e49e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->