### PR TITLE
refactor(relative_dates): consolidate MONTHS lookup into comprehension form

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -17,15 +17,8 @@ WEEKDAY_SINGULAR = {w: w for w in WEEKDAYS}
 WEEKDAY_SINGULAR.update({w + "s": w for w in WEEKDAYS})
 
 
-MONTHS = {}
-for i, name in enumerate(calendar.month_name):
-    if i == 0:
-        continue
-    MONTHS[name.lower()] = i
-for i, abbr in enumerate(calendar.month_abbr):
-    if i == 0:
-        continue
-    MONTHS[abbr.lower()] = i
+MONTHS = {name.lower(): i for i, name in enumerate(calendar.month_name) if i}
+MONTHS.update({abbr.lower(): i for i, abbr in enumerate(calendar.month_abbr) if i})
 # Allow dotted abbreviations like "Dec."
 MONTHS.update({f"{k}.": v for k, v in list(MONTHS.items()) if len(k) == 3})
 


### PR DESCRIPTION
## What
`MONTHS` in `navi_bench/relative_dates.py` was built with two verbose `for` loops (skip index 0, lowercase-key the name, map to its index) — the exact same "hand-rolled loop building a lookup dict from a `calendar` sequence" shape that `WEEKDAYS`, three lines above it in the same file, already handles with a dict-comprehension + `.update()` idiom. This was simply missed when `WEEKDAYS` got the terse treatment.

Mirrored the same idiom for `MONTHS`:
```python
MONTHS = {name.lower(): i for i, name in enumerate(calendar.month_name) if i}
MONTHS.update({abbr.lower(): i for i, abbr in enumerate(calendar.month_abbr) if i})
```

## Why it's safe — no behavioral change
`enumerate(calendar.month_name)` and `enumerate(calendar.month_abbr)` both always yield `(0, "")` as their first pair (the empty placeholder before "January"/"Jan"), so the comprehension's `if i` (truthy filter) excludes exactly the same index 0 that the original `if i == 0: continue` did — no ambiguity like the Monday=0 case for `WEEKDAYS`.

Verified via a standalone parity script comparing the old two-loop construction against the new comprehension — byte-identical resulting dict (same 24 keys, same integer values 1-12). `tests/test_relative_dates.py` (29 tests, exercises `MONTHS` end-to-end through month-name/abbreviation date parsing like "next Dec. 3rd") passes unchanged.

Touches 1 file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TpUUTAL9XXFq5uaqFxqUcP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor of static lookup initialization with equivalent filtering of calendar index 0; no logic or API changes.
> 
> **Overview**
> **`MONTHS` initialization** in `relative_dates.py` is rewritten to match the **`WEEKDAYS`** pattern: two dict comprehensions over `calendar.month_name` and `calendar.month_abbr`, with `if i` skipping index 0 instead of explicit `continue` loops.
> 
> The follow-up **`.update()`** for dotted month abbreviations (e.g. `Dec.`) is unchanged. This is a **style-only** consolidation; the lookup table contents and all month-based parsing paths should behave the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b3396e9d2acb789925719dc2a0a93c2375334c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->