### PR TITLE
refactor(vis): extract shared _render_stop_action_card helper for stop-action cards

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -262,6 +262,24 @@ def _render_section(title: str, text: str, *, collapsed: bool = False) -> str:
 """
 
 
+def _render_stop_action_card(step_num: int, label: str, answer: str) -> str:
+    """Render the ``.action-item.stop-action`` card shown for a step's terminal answer.
+
+    Shared by the implicit "no tool calls" final-answer branch (fixed label "Final Answer
+    (No Tool Call)") and the explicit Finished/CallUser stop-action branch (``label`` is
+    that action's own ``action_type``) in ``generate_visualization_html``, which built
+    identical card markup differing only in the label and the source of ``answer``.
+    """
+    answer_preview = _truncate_preview(answer)
+    return f"""
+            <div class="action-item stop-action" onclick="openAnswerModal({step_num})">
+                <div class="action-type">✅ {label}</div>
+                <div class="action-details">{_escape_html(answer_preview)}</div>
+                <div class="click-to-expand">Click to view full answer</div>
+            </div>
+"""
+
+
 def _render_response_section(label: str, content_html: str, *, collapsed: bool = False) -> str:
     """Render a per-step collapsible ``.response-section`` block (Actions / Text Observations / Raw Response)."""
     collapsed_class = " collapsed" if collapsed else ""
@@ -1343,31 +1361,17 @@ def generate_visualization_html(
 
         # Handle final answer case (no tool calls = implicit stop)
         if is_final_answer and final_answer_content:
-            answer_preview = _truncate_preview(final_answer_content)
             step["stop_answer"] = final_answer_content
-            actions_html = f"""
-            <div class="action-item stop-action" onclick="openAnswerModal({step_num})">
-                <div class="action-type">✅ Final Answer (No Tool Call)</div>
-                <div class="action-details">{_escape_html(answer_preview)}</div>
-                <div class="click-to-expand">Click to view full answer</div>
-            </div>
-"""
+            actions_html = _render_stop_action_card(step_num, "Final Answer (No Tool Call)", final_answer_content)
         else:
             # Check if any action is a stop action (Finished/CallUser)
             stop_actions = [a for a in actions if a.get("action_type") in _STOP_ACTION_TYPES]
             if stop_actions:
                 stop_text = stop_actions[0].get("text", "")
                 if stop_text:
-                    answer_preview = _truncate_preview(stop_text)
                     step["stop_answer"] = stop_text
                     stop_label = stop_actions[0].get("action_type", "Finished")
-                    actions_html = f"""
-            <div class="action-item stop-action" onclick="openAnswerModal({step_num})">
-                <div class="action-type">✅ {stop_label}</div>
-                <div class="action-details">{_escape_html(answer_preview)}</div>
-                <div class="click-to-expand">Click to view full answer</div>
-            </div>
-"""
+                    actions_html = _render_stop_action_card(step_num, stop_label, stop_text)
 
             for i, action in enumerate(actions):
                 action_type = action.get("action_type", "unknown")

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -361,6 +361,118 @@ class TestRenderResponseSection:
         assert "<span>▼</span> Raw Response" in html
 
 
+def _messages_with_final_answer(text: str | None) -> list[dict]:
+    """Assistant message with no tool_calls, i.e. an implicit "final answer" stop."""
+    return [
+        {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+        {"role": "assistant", "content": text},
+    ]
+
+
+def _messages_with_stop_tool_call(action_type: str, text: str | None) -> list[dict]:
+    """Assistant message with a single Finished/CallUser-style tool call."""
+    arguments = {"text": text} if text is not None else {}
+    return [
+        {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "t1",
+                    "type": "function",
+                    "function": {"name": action_type, "arguments": json.dumps(arguments)},
+                }
+            ],
+        },
+    ]
+
+
+_STOP_CARD_RE = re.compile(
+    r'<div class="action-item stop-action" onclick="openAnswerModal\((\d+)\)">\s*'
+    r'<div class="action-type">([^<]*)</div>\s*'
+    r'<div class="action-details">(.*?)</div>\s*'
+    r'<div class="click-to-expand">Click to view full answer</div>\s*'
+    r"</div>",
+    re.S,
+)
+
+
+class TestStopActionCard:
+    """Characterization tests for the ``.action-item.stop-action`` card rendered for a
+    step's terminal answer in ``generate_visualization_html``. Two branches build this
+    card: the implicit "no tool calls" final-answer branch (fixed label "Final Answer
+    (No Tool Call)") and the explicit Finished/CallUser tool-call branch (label is the
+    action's own ``action_type``). Both produce byte-identical markup apart from the
+    label and the source of the answer text, before being extracted into a shared
+    ``_render_stop_action_card`` helper. Also pins that the full (untruncated) answer is
+    what ends up in the ``stopAnswers`` JS object, while only the *card* shows a
+    ``_truncate_preview``'d version.
+    """
+
+    def _render(self, messages: list[dict]) -> str:
+        return generate_visualization_html("task1", messages, None)
+
+    def _stop_answers(self, html: str) -> dict:
+        match = re.search(r"const stopAnswers = (\{.*?\});", html)
+        assert match is not None, html
+        return json.loads(match.group(1))
+
+    def test_final_answer_card_label_and_content(self):
+        html = self._render(_messages_with_final_answer("The result is 42."))
+        match = _STOP_CARD_RE.search(html)
+        assert match is not None, html
+        step_num, label, details = match.groups()
+        assert step_num == "1"
+        assert label == "✅ Final Answer (No Tool Call)"
+        assert details == "The result is 42."
+        assert self._stop_answers(html) == {"1": "The result is 42."}
+
+    def test_final_answer_empty_content_renders_no_actions_placeholder(self):
+        html = self._render(_messages_with_final_answer(""))
+        assert _STOP_CARD_RE.search(html) is None
+        assert "No actions" in html
+
+    def test_finished_tool_call_card_label_and_content(self):
+        html = self._render(_messages_with_stop_tool_call("Finished", "All done."))
+        match = _STOP_CARD_RE.search(html)
+        assert match is not None, html
+        _, label, details = match.groups()
+        assert label == "✅ Finished"
+        assert details == "All done."
+
+    def test_call_user_tool_call_uses_its_own_action_type_as_label(self):
+        html = self._render(_messages_with_stop_tool_call("CallUser", "Need help."))
+        match = _STOP_CARD_RE.search(html)
+        assert match is not None, html
+        _, label, details = match.groups()
+        assert label == "✅ CallUser"
+        assert details == "Need help."
+
+    def test_lowercase_stop_action_type_aliases_also_covered(self):
+        html = self._render(_messages_with_stop_tool_call("call_user", "hi"))
+        match = _STOP_CARD_RE.search(html)
+        assert match is not None, html
+        _, label, _ = match.groups()
+        assert label == "✅ call_user"
+
+    def test_stop_tool_call_with_no_text_renders_no_actions_placeholder(self):
+        # `stop_actions` is found but `stop_text` is empty, so no card is rendered and the
+        # per-action loop also skips it (it's still a recognized stop action type).
+        html = self._render(_messages_with_stop_tool_call("Finished", None))
+        assert _STOP_CARD_RE.search(html) is None
+        assert "No actions" in html
+
+    def test_long_answer_is_truncated_in_card_but_not_in_stop_answers_json(self):
+        long_text = "x" * 200
+        html = self._render(_messages_with_final_answer(long_text))
+        match = _STOP_CARD_RE.search(html)
+        assert match is not None, html
+        _, _, details = match.groups()
+        assert details == "x" * 150 + "..."
+        assert self._stop_answers(html) == {"1": long_text}
+
+
 class TestTopLevelSectionsEndToEnd:
     """Confirms ``generate_visualization_html`` wires ``_render_section`` for the System
     Prompt (collapsed by default), User Query, and Evaluation Result sections in the


### PR DESCRIPTION
## Issue

`generate_visualization_html()` in `evaluation/vis.py` built the `.action-item.stop-action`
card HTML twice:

1. The implicit "no tool calls" final-answer branch, with a fixed label `"Final Answer (No
   Tool Call)"`.
2. The explicit Finished/CallUser stop-action branch, with a dynamic label (that action's
   own `action_type`).

Both branches produced byte-identical markup — same `onclick="openAnswerModal(...)"`,
same `.action-details` div, same "Click to view full answer" footer — differing only in
the label text and the source of the answer string. Same duplicated-HTML-template pattern
already fixed elsewhere in this file (form-action cards in #111, collapsible sections in
#122, coordinate-fallback lookup in #123).

## Improvement

This code path had **zero prior test coverage**, so per this repo's established
convention (see `.claude/REFACTOR.md` in `yutori-ai/yutori`), I added characterization
tests *first*, pinning current behavior, before touching the implementation:

- `TestStopActionCard` in `tests/test_vis.py` (7 tests): both branches' label/content,
  the "empty content" and "empty stop-action text" no-op cases (card omitted, "No
  actions" placeholder shown instead), and the truncated-card-vs-untruncated-`stopAnswers`-JSON
  distinction (the card shows `_truncate_preview`'d text, but the JS `stopAnswers` object
  used by the answer modal gets the full untruncated text).

Then extracted `_render_stop_action_card(step_num, label, answer)`; both call sites now
delegate to it.

## Safety

- Debug/visualization output only — not on any production request path.
- 154/154 tests pass unchanged after the refactor (7 new + 147 pre-existing).
- `ruff check` and `ruff format --check` clean on the changed files.
- Diff is 2 files (`evaluation/vis.py`, `tests/test_vis.py`), purely a template
  extraction — no change to which branch fires or what text ends up where.

## Test plan

- [x] Added `TestStopActionCard` characterization tests against the pre-refactor code;
      confirmed they pass.
- [x] Extracted `_render_stop_action_card`; re-ran the full suite unchanged — 154/154 pass.
- [x] `ruff check .` — all checks passed.
- [x] `ruff format --check evaluation/vis.py tests/test_vis.py` — already formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RUqs7xYGuXJ8ExW7Bbwrfv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only HTML generation in evaluation/vis.py; refactor is template extraction with tests pinning existing output.
> 
> **Overview**
> **Deduplicates** the green `.action-item.stop-action` HTML in eval visualization by introducing `_render_stop_action_card(step_num, label, answer)` and routing both call sites through it: implicit final answers (no tool calls, fixed **Final Answer (No Tool Call)** label) and explicit **Finished** / **CallUser** stop tool calls (dynamic label).
> 
> Adds **`TestStopActionCard`** (7 tests) that lock in labels, empty-answer / missing-text **No actions** behavior, and that the card preview uses `_truncate_preview` while `stopAnswers` in the page script keeps the full answer for the modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657326d9ada81c9fb2b904cafdc70a925e24ed3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->