### PR TITLE
refactor(vis): extract shared _collapsed_class helper

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -1602,7 +1602,7 @@ def generate_visualization_html(
                     .replace(/</g, '&lt;')
                     .replace(/>/g, '&gt;')
                     .replace(/"/g, '&quot;')
-                    .replace(/\n/g, '<br>');
+                    .replace(/\\n/g, '<br>');
             }}
 
             // Try using marked.js if available
@@ -1610,7 +1610,7 @@ def generate_visualization_html(
                 try {{
                     // Configure marked for safe rendering
                     marked.setOptions({{
-                        breaks: true,  // Convert \n to <br>
+                        breaks: true,  // Convert \\n to <br>
                         gfm: true      // GitHub Flavored Markdown
                     }});
                     return marked.parse(text);

--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -246,9 +246,14 @@ def _get_action_marker_style(
     return result
 
 
+def _collapsed_class(collapsed: bool) -> str:
+    """Return the ` collapsed` CSS class suffix to toggle a section's initial collapsed state."""
+    return " collapsed" if collapsed else ""
+
+
 def _render_section(title: str, text: str, *, collapsed: bool = False) -> str:
     """Render a top-level collapsible ``.section`` block (System Prompt / User Query / Result)."""
-    collapsed_class = " collapsed" if collapsed else ""
+    collapsed_class = _collapsed_class(collapsed)
     return f"""
         <div class="section{collapsed_class}">
             <div class="section-header" onclick="this.parentElement.classList.toggle('collapsed')">
@@ -282,7 +287,7 @@ def _render_stop_action_card(step_num: int, label: str, answer: str) -> str:
 
 def _render_response_section(label: str, content_html: str, *, collapsed: bool = False) -> str:
     """Render a per-step collapsible ``.response-section`` block (Actions / Text Observations / Raw Response)."""
-    collapsed_class = " collapsed" if collapsed else ""
+    collapsed_class = _collapsed_class(collapsed)
     return f"""<div class="response-section{collapsed_class}">
                         <div class="response-section-header" onclick="this.parentElement.classList.toggle('collapsed')">
                             <span>▼</span> {label}
@@ -1597,7 +1602,7 @@ def generate_visualization_html(
                     .replace(/</g, '&lt;')
                     .replace(/>/g, '&gt;')
                     .replace(/"/g, '&quot;')
-                    .replace(/\\n/g, '<br>');
+                    .replace(/\n/g, '<br>');
             }}
 
             // Try using marked.js if available
@@ -1605,7 +1610,7 @@ def generate_visualization_html(
                 try {{
                     // Configure marked for safe rendering
                     marked.setOptions({{
-                        breaks: true,  // Convert \\n to <br>
+                        breaks: true,  // Convert \n to <br>
                         gfm: true      // GitHub Flavored Markdown
                     }});
                     return marked.parse(text);


### PR DESCRIPTION
## What

Extracts `_collapsed_class(collapsed: bool) -> str` in `evaluation/vis.py` and has `_render_section` and `_render_response_section` delegate to it instead of each computing `" collapsed" if collapsed else ""` independently.

## Why (the day-over-day pattern)

Today's PRs #131, #129, #128, and #126 all extracted shared helpers within this same visualization module (`_render_stop_action_card`, `_block_type`/`_block_field`, `repr_with_attr`, `_ACTION_COLOR_CLASSES`) — the exact "same shape, minor field difference" pattern this one-line duplication also fits, just not caught because each of those PRs was scoped to a different specific duplication.

## Verification

Zero behavior change — same string returned for both call sites, same signature shape. This is a pure one-line extraction.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpMUo1FrrD5S5f1kzDwd4T)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor in eval HTML generation with no logic or output change.
> 
> **Overview**
> Adds **`_collapsed_class(collapsed)`** in `evaluation/vis.py` so the `" collapsed"` CSS suffix for initial collapsed state lives in one place.
> 
> **`_render_section`** and **`_render_response_section`** now call that helper instead of each inlining `" collapsed" if collapsed else ""`. Generated HTML and toggle behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98e419be640e5c79b70e9afeae3586792a53e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->