### PR TITLE
refactor: extract per-call-recreated dict/set literals to module constants

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -18,6 +18,42 @@ from navi_bench.base import (
 from navi_bench.dates import initialize_user_metadata
 
 
+# Common US state abbreviations, used by `_is_location_part` to recognize
+# "neighborhood-city-state" URL path segments.
+_STATE_ABBREVIATIONS = frozenset(
+    {
+        "ca", "ny", "tx", "fl", "wa", "il", "pa", "oh", "ga", "nc", "mi", "va", "tn", "in",
+        "az", "ma", "md", "mn", "co", "al", "la", "ky", "or", "ok", "ct", "ia", "ms", "ar",
+        "ut", "nv", "nm", "wv", "ne", "id", "nh", "hi", "ri", "mt", "de", "sd", "nd", "ak",
+        "dc", "vt", "wy", "me", "wi", "mo", "nj", "ks", "sc",
+    }
+)  # fmt: skip
+
+# Apartment amenity keywords recognized by `_normalize_apartment_features` for sorting into
+# a canonical order within a URL path segment.
+_APARTMENT_FEATURES = frozenset(
+    {
+        "air-conditioning",
+        "washer-dryer",
+        "dishwasher",
+        "parking",
+        "fitness-center",
+        "pool",
+        "gated",
+        "garage",
+        "walk-in-closets",
+        "washer_dryer-hookup",
+        "laundry-facilities",
+        "utilities-included",
+    }
+)
+
+# `_APARTMENT_FEATURES` ordered longest-first so `_normalize_apartment_features` extracts
+# multi-word features (e.g. "air-conditioning") before any shorter feature that could be a
+# substring of a longer one.
+_APARTMENT_FEATURES_BY_LENGTH_DESC = sorted(_APARTMENT_FEATURES, key=len, reverse=True)
+
+
 @beartype
 class ApartmentsUrlMatch(BaseMetric):
     IGNORED_PARAMS = ("io", "ss")
@@ -65,37 +101,14 @@ class ApartmentsUrlMatch(BaseMetric):
         if not part or "-" not in part:
             return False
 
-        # Common US state abbreviations
-        state_abbreviations = {
-            "ca", "ny", "tx", "fl", "wa", "il", "pa", "oh", "ga", "nc", "mi", "va", "tn", "in",
-            "az", "ma", "md", "mn", "co", "al", "la", "ky", "or", "ok", "ct", "ia", "ms", "ar",
-            "ut", "nv", "nm", "wv", "ne", "id", "nh", "hi", "ri", "mt", "de", "sd", "nd", "ak",
-            "dc", "vt", "wy", "me", "wi", "mo", "nj", "ks", "sc",
-        }
-
         return (
-            any(part.endswith(f"-{state}") for state in state_abbreviations) or len(part.split("-")[-1]) == 2
+            any(part.endswith(f"-{state}") for state in _STATE_ABBREVIATIONS) or len(part.split("-")[-1]) == 2
         )  # area_city_state format
 
     def _normalize_apartment_features(self, part: str) -> str:
         """Normalize apartment features by sorting them alphabetically."""
-        apartment_features = {
-            "air-conditioning",
-            "washer-dryer",
-            "dishwasher",
-            "parking",
-            "fitness-center",
-            "pool",
-            "gated",
-            "garage",
-            "walk-in-closets",
-            "washer_dryer-hookup",
-            "laundry-facilities",
-            "utilities-included",
-        }
-
         # Check if this part contains any apartment features
-        if not any(feature in part for feature in apartment_features):
+        if not any(feature in part for feature in _APARTMENT_FEATURES):
             return part
 
         # Extract features and non-features
@@ -103,7 +116,7 @@ class ApartmentsUrlMatch(BaseMetric):
         remaining = part
 
         # Extract known features (longest first to avoid partial matches)
-        for feature in sorted(apartment_features, key=len, reverse=True):
+        for feature in _APARTMENT_FEATURES_BY_LENGTH_DESC:
             if feature in remaining:
                 found_features.append(feature)
                 remaining = remaining.replace(feature, "-").replace("--", "-").strip("-")

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -116,6 +116,21 @@ def _time_to_seconds(time_str: str) -> int:
     return hour * 3600 + minute * 60 + second
 
 
+# Human-readable descriptions for the conditional-coverage reason codes that map 1:1 to a
+# fixed string, used by `ResyUrlMatch._describe_conditional_reason`. Reason codes carrying a
+# ":"-delimited suffix (e.g. "neighbors_not_seen:...") are handled separately below since their
+# description embeds that suffix.
+_CONDITIONAL_REASON_DESCRIPTIONS = {
+    "gt_time_in_url": "available slot matched by URL parameter",
+    "gt_time_visible": "available slot visible on page",
+    "neighbor_times_seen": "unavailable slot inferred from visible neighboring times",
+    "boundary_previous_seen_via_next": "unavailable slot inferred before earliest visible availability",
+    "boundary_next_seen_via_prev": "unavailable slot inferred after latest visible availability",
+    "gt_time_outside_available_range": "unavailable slot outside listed availability range",
+    "no_available_slots": "unavailable slot inferred because page lists no availability",
+}
+
+
 @beartype
 class ResyUrlMatch(BaseMetric):
     def __init__(self, queries: list[list[str]]) -> None:
@@ -575,16 +590,7 @@ class ResyUrlMatch(BaseMetric):
         url_time: str | None,
         has_availabilities: bool,
     ) -> str:
-        mapping = {
-            "gt_time_in_url": "available slot matched by URL parameter",
-            "gt_time_visible": "available slot visible on page",
-            "neighbor_times_seen": "unavailable slot inferred from visible neighboring times",
-            "boundary_previous_seen_via_next": "unavailable slot inferred before earliest visible availability",
-            "boundary_next_seen_via_prev": "unavailable slot inferred after latest visible availability",
-            "gt_time_outside_available_range": "unavailable slot outside listed availability range",
-            "no_available_slots": "unavailable slot inferred because page lists no availability",
-        }
-        base = mapping.get(reason)
+        base = _CONDITIONAL_REASON_DESCRIPTIONS.get(reason)
         if base:
             return base
 

--- a/tests/test_apartments_url_match.py
+++ b/tests/test_apartments_url_match.py
@@ -1,0 +1,64 @@
+"""Characterization tests for ApartmentsUrlMatch._normalize_url.
+
+These tests pin the CURRENT behavior of URL normalization (location extraction/merging,
+apartment-feature reordering, and ignored-parameter stripping) before a structural refactor
+moves the ``state_abbreviations`` and ``apartment_features`` literals -- currently rebuilt on
+every call inside ``_is_location_part``/``_normalize_apartment_features`` -- to module-level
+constants. The refactor should not change any of these outputs.
+"""
+
+from navi_bench.apartments.apartments_url_match import ApartmentsUrlMatch
+
+
+def _normalize(url: str) -> str:
+    return ApartmentsUrlMatch(gt_url="https://www.apartments.com/placeholder")._normalize_url(url)
+
+
+class TestNormalizeUrl:
+    def test_single_path_location_with_query_locations_merged_and_sorted(self):
+        url = (
+            "https://www.apartments.com/hudson-yards-new-york-ny/2-to-3-bedrooms-2-bathrooms-under-7300/"
+            "?n=midtown-west_new-york_ny+hell%27s-kitchen_new-york_ny"
+        )
+        result = _normalize(url)
+        assert result == (
+            "apartments.com/hell's-kitchen-new-york-ny/2-to-3-bedrooms-2-bathrooms-under-7300"
+            "?n=hudson-yards-new-york-ny%2Bmidtown-west-new-york-ny"
+        )
+
+    def test_non_location_path_segment_preserved(self):
+        url = (
+            "https://www.apartments.com/apartments/hudson-yards-new-york-ny/2-to-3-bedrooms-2-bathrooms-under-7300/"
+            "?n=midtown-west_new-york_ny"
+        )
+        result = _normalize(url)
+        assert result == (
+            "apartments.com/hudson-yards-new-york-ny/apartments/2-to-3-bedrooms-2-bathrooms-under-7300"
+            "?n=midtown-west-new-york-ny"
+        )
+
+    def test_apartment_features_left_alone_when_only_one_recognized_present_alongside_unknown_words(self):
+        url = "https://www.apartments.com/san-francisco-ca/pet-friendly-air-conditioning-dishwasher/"
+        result = _normalize(url)
+        assert result == "apartments.com/san-francisco-ca/pet-friendly-air-conditioning-dishwasher"
+
+    def test_apartment_features_sorted_alphabetically_when_multiple_present(self):
+        url = "https://www.apartments.com/austin-tx/walk-in-closets-washer_dryer-hookup-laundry-facilities/"
+        result = _normalize(url)
+        assert result == "apartments.com/austin-tx/laundry-facilities-walk-in-closets-washer_dryer-hookup"
+
+    def test_bb_param_ignored_and_io_ss_params_dropped(self):
+        url = "https://www.apartments.com/austin-tx/?bb=1,2,3,4&io=true&ss=1"
+        result = _normalize(url)
+        assert result == "apartments.com/austin-tx"
+
+    def test_off_domain_url_falls_back_to_basic_normalization(self):
+        url = "https://www.example.com/some/path?x=1"
+        result = _normalize(url)
+        assert result == "example.com/some/path?x=1"
+
+    def test_empty_url_returns_empty_string(self):
+        assert _normalize("") == ""
+
+    def test_bare_domain_url(self):
+        assert _normalize("https://www.apartments.com/") == "apartments.com"

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -16,6 +16,8 @@ from datetime import date
 import pytest
 
 from navi_bench.resy.resy_url_match import (
+    ResyQueryState,
+    ResyUrlMatch,
     _render_placeholders_in_queries_all,
     _render_placeholders_in_queries_any,
 )
@@ -107,3 +109,107 @@ class TestRenderPlaceholdersInQueriesAll:
             ["https://resy.com/cities/ny/venues/bar?date=2025-07-15&seats=13"],
             ["https://resy.com/cities/ny/venues/bar?date=2025-07-16&seats=13"],
         ]
+
+
+class TestDescribeConditionalReason:
+    """Characterization tests for ``ResyUrlMatch._describe_conditional_reason``.
+
+    Pins current behavior before a structural refactor moves the ``mapping`` dict literal --
+    currently rebuilt on every call -- to a module-level constant alongside this file's other
+    module-level dicts (``CITY_METADATA``, ``VENUE_SLUG_MAPPING``).
+    """
+
+    def _matcher(self) -> ResyUrlMatch:
+        return ResyUrlMatch(queries=[["https://resy.com/cities/ny/venues/bar"]])
+
+    def _state(self, gt_time: str | None = "1900") -> ResyQueryState:
+        return ResyQueryState(
+            group_index=0,
+            alt_index=0,
+            gt_url="https://resy.com/cities/ny/venues/bar",
+            base_without_time="resy.com/cities/ny/venues/bar",
+            gt_time=gt_time,
+        )
+
+    def test_mapped_reasons(self):
+        matcher = self._matcher()
+        state = self._state()
+        expected = {
+            "gt_time_in_url": "available slot matched by URL parameter",
+            "gt_time_visible": "available slot visible on page",
+            "neighbor_times_seen": "unavailable slot inferred from visible neighboring times",
+            "boundary_previous_seen_via_next": "unavailable slot inferred before earliest visible availability",
+            "boundary_next_seen_via_prev": "unavailable slot inferred after latest visible availability",
+            "gt_time_outside_available_range": "unavailable slot outside listed availability range",
+            "no_available_slots": "unavailable slot inferred because page lists no availability",
+        }
+        for reason, description in expected.items():
+            result = matcher._describe_conditional_reason(
+                reason=reason, state=state, url_time="1930", has_availabilities=True
+            )
+            assert result == description
+
+    def test_gt_time_missing(self):
+        matcher = self._matcher()
+        result = matcher._describe_conditional_reason(
+            reason="gt_time_missing", state=self._state(), url_time="1930", has_availabilities=True
+        )
+        assert result == "ground-truth time missing from configuration"
+
+    def test_gt_time_available_not_seen(self):
+        matcher = self._matcher()
+        result = matcher._describe_conditional_reason(
+            reason="gt_time_available_not_seen", state=self._state(), url_time="1930", has_availabilities=True
+        )
+        assert result == "available slot exists but was not observed"
+
+    def test_no_slots_but_wrong_time(self):
+        matcher = self._matcher()
+        result = matcher._describe_conditional_reason(
+            reason="no_slots_but_wrong_time", state=self._state(), url_time="1930", has_availabilities=False
+        )
+        assert result == "URL time does not match ground truth and no availability data to verify"
+
+    def test_neighbors_not_seen_includes_missing_suffix(self):
+        matcher = self._matcher()
+        result = matcher._describe_conditional_reason(
+            reason="neighbors_not_seen:1830,1930", state=self._state(), url_time="1930", has_availabilities=True
+        )
+        assert result == "unavailable slot needs adjacent times to be visible (missing neighbors: 1830,1930)"
+
+    def test_boundary_previous_not_seen_includes_missing_suffix(self):
+        matcher = self._matcher()
+        result = matcher._describe_conditional_reason(
+            reason="boundary_previous_not_seen:1830", state=self._state(), url_time="1930", has_availabilities=True
+        )
+        assert result == (
+            "unavailable slot earlier than visible range requires earliest time to be visible (missing: 1830)"
+        )
+
+    def test_boundary_next_not_seen_includes_missing_suffix(self):
+        matcher = self._matcher()
+        result = matcher._describe_conditional_reason(
+            reason="boundary_next_not_seen:1930", state=self._state(), url_time="1930", has_availabilities=True
+        )
+        assert result == (
+            "unavailable slot later than visible range requires latest time to be visible (missing: 1930)"
+        )
+
+    def test_unknown_reason_falls_back_to_generic_description_with_availabilities(self):
+        matcher = self._matcher()
+        result = matcher._describe_conditional_reason(
+            reason="some_unknown_reason", state=self._state("1900"), url_time="1930", has_availabilities=True
+        )
+        assert result == (
+            "conditional coverage reason=some_unknown_reason (with availabilities; gt_time=1900; url_time=1930)"
+        )
+
+    def test_unknown_reason_falls_back_to_generic_description_without_availabilities(self):
+        matcher = self._matcher()
+        result = matcher._describe_conditional_reason(
+            reason="some_unknown_reason", state=self._state("1900"), url_time=None, has_availabilities=False
+        )
+        assert result == (
+            "conditional coverage reason=some_unknown_reason "
+            "(with no availabilities listed; gt_time=1900; url_time=None)"
+        )


### PR DESCRIPTION
## Issue

Three helpers rebuilt static lookup data on every call instead of once at import time:

- `ApartmentsUrlMatch._is_location_part` rebuilt a `state_abbreviations` set every call.
- `ApartmentsUrlMatch._normalize_apartment_features` rebuilt an `apartment_features` set (and re-sorted it by length) every call.
- `ResyUrlMatch._describe_conditional_reason` rebuilt its `reason -> description` `mapping` dict every call.

Both `_normalize_url` (apartments) and `_describe_conditional_reason` (resy) run on the per-observation hot path (`update()` is called on every browser navigation during an eval), so this is a small but real bit of wasted allocation, and it obscures that the data is static.

## Fix

Moved all three literals to module-level constants:

- `navi_bench/apartments/apartments_url_match.py`: `_STATE_ABBREVIATIONS`, `_APARTMENT_FEATURES`, and `_APARTMENT_FEATURES_BY_LENGTH_DESC` (the precomputed longest-first ordering used by the extraction loop).
- `navi_bench/resy/resy_url_match.py`: `_CONDITIONAL_REASON_DESCRIPTIONS`, placed next to the class it serves, consistent with this file's existing module-level dict constants (`CITY_METADATA`, `VENUE_SLUG_MAPPING`).

No logic changed — only *where* the literals are defined.

## Safety verification

Neither code path had test coverage before this PR, so per this repo's established convention (see recent PRs #109, #110, #121, etc.), I added characterization tests pinning current behavior *before* refactoring:

- `tests/test_apartments_url_match.py` (new): 8 cases covering path-location extraction, query-param (`n=`) location merging, apartment-feature reordering (including a tie-length case: `washer_dryer-hookup` vs `laundry-facilities`, both 19 chars), ignored params (`bb`, `io`, `ss`), off-domain fallback, and empty/bare-domain URLs.
- `tests/test_resy_url_match.py`: new `TestDescribeConditionalReason` class with 9 cases covering every mapped reason code, the `:`-suffixed reason codes, and the unknown-reason fallback branch (with/without availabilities).

All 171 tests pass after the refactor (154 pre-existing + 17 new). I also independently verified via a `git stash` before/after comparison — running both functions across a broader ad hoc input matrix (12 apartment URLs × the full resy reason/state/url_time/has_availabilities product) and diffing the JSON output — that the refactor produces byte-identical results.

`ruff check` and `ruff format --diff` are clean on all touched files.

## Test plan

- [x] `python -m pytest -q` — 171 passed
- [x] `ruff check` — all checks passed
- [x] `ruff format --diff` — no changes needed
- [x] `git stash` before/after output diff — identical

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_015HsRjN7mhNSJE3LiVhR39K


---
_Generated by [Claude Code](https://claude.ai/code/session_015HsRjN7mhNSJE3LiVhR39K)_