### PR TITLE
Replace hand-rolled 12-hour time parsing with datetime.strptime

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -741,27 +741,12 @@ def parse_time_to_hour(time_str: str | None) -> float | None:
     if not time_str or not time_str.strip():
         return None
 
-    time_str = time_str.strip()
-    # Split into time and period (AM/PM)
-    parts = time_str.split()
-    if len(parts) != 2:
+    try:
+        parsed = datetime.strptime(time_str.strip().upper(), "%I:%M %p")
+    except ValueError:
         return None
 
-    time_part, period = parts
-    time_components = time_part.split(":")
-    if len(time_components) != 2:
-        return None
-
-    hour = int(time_components[0])
-    minute = int(time_components[1])
-
-    # Convert to 24-hour format
-    if period.upper() == "PM" and hour != 12:
-        hour += 12
-    elif period.upper() == "AM" and hour == 12:
-        hour = 0
-
-    return hour + (minute / 60.0)
+    return parsed.hour + (parsed.minute / 60.0)
 
 
 def generate_time_slots(open_time: str | None = None, close_time: str | None = None) -> list[str]:

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -20,6 +20,7 @@ from navi_bench.resy.resy_url_match import (
     ResyUrlMatch,
     _render_placeholders_in_queries_all,
     _render_placeholders_in_queries_any,
+    parse_time_to_hour,
 )
 
 
@@ -213,3 +214,28 @@ class TestDescribeConditionalReason:
             "conditional coverage reason=some_unknown_reason "
             "(with no availabilities listed; gt_time=1900; url_time=None)"
         )
+
+
+class TestParseTimeToHour:
+    """Characterization tests for ``parse_time_to_hour``, which was refactored from a
+    hand-rolled AM/PM split to ``datetime.strptime(..., "%I:%M %p")``.
+    """
+
+    @pytest.mark.parametrize(
+        ("time_str", "expected"),
+        [
+            ("6:00 AM", 6.0),
+            ("11:30 PM", 23.5),
+            ("12:00 PM", 12.0),
+            ("12:00 AM", 0.0),
+            ("2:00 AM", 2.0),
+            ("9:30 PM", 21.5),
+            ("  6:00 am  ", 6.0),
+            (None, None),
+            ("", None),
+            ("   ", None),
+            ("not a time", None),
+        ],
+    )
+    def test_parses_expected_values(self, time_str, expected):
+        assert parse_time_to_hour(time_str) == expected


### PR DESCRIPTION
## What

`navi_bench/resy/resy_url_match.py`'s `parse_time_to_hour()` manually parsed 12-hour time strings like `"6:00 AM"` (split on whitespace, split on `:`, hand-rolled AM/PM-to-24h arithmetic) — exactly what `datetime.strptime(..., "%I:%M %p")` does natively.

Replaced the manual parsing with `datetime.strptime`.

## Why it's safe

- Touches one file (plus a new test file addition), one ~15-line function.
- Verified old and new implementations produce identical output for every distinct `Open Time`/`Close Time` value that actually appears in `resy_restaurant.csv` (the sole data source feeding this function), plus `None`/empty/whitespace-only inputs.
- The only behavioral divergence is on malformed input the code path never receives in practice (e.g. `"13:00 PM"`, an invalid 12-hour value) — old code silently produced a wrong out-of-range value (25.0), new code correctly returns `None`. No such value exists in the actual dataset.
- Added `TestParseTimeToHour` characterization tests pinning current behavior, matching this repo's convention of test coverage alongside such refactors.
- `ruff check` / `ruff format --check` pass; all 30 tests in `tests/test_resy_url_match.py` pass.

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] `pytest tests/test_resy_url_match.py` — 30 passed
- [x] Manually diffed old vs. new implementation output across every real Open/Close Time value in `resy_restaurant.csv`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmaCEXWafSguqE7vYDFD7q

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmaCEXWafSguqE7vYDFD7q)_