### PR TITLE
Extract shared days_until_next_weekday helper for opentable/relative_dates

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -29,7 +29,7 @@ from navi_bench.dates import (
     render_task_statement,
     resolve_city_now,
 )
-from navi_bench.relative_dates import WEEKDAYS, nth_weekday_of_month
+from navi_bench.relative_dates import WEEKDAYS, days_until_next_weekday, nth_weekday_of_month
 
 
 class SingleCandidateQuery(TypedDict, total=False):
@@ -630,11 +630,7 @@ def get_days_until_date(date_label: str, today: datetime) -> list[int]:
 
         # Calculate days until next occurrence of this weekday
         current_day = today.weekday()  # 0=Monday, 6=Sunday
-        days_ahead = (target_day - current_day) % 7
-
-        # If the target day is today, we want next week's occurrence
-        if days_ahead == 0:
-            days_ahead = 7
+        days_ahead = days_until_next_weekday(current_day, target_day)
 
         return [days_ahead]
     else:

--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -73,6 +73,16 @@ def nth_weekday_of_month(year: int, month: int, weekday: int, n: int) -> date:
     return date(year, month, day)
 
 
+def days_until_next_weekday(current_weekday: int, target_weekday: int) -> int:
+    """Days until the next strictly-future occurrence of ``target_weekday`` (0=Mon..6=Sun).
+
+    Never returns 0: if ``target_weekday`` is today's weekday, the result rolls to 7
+    (i.e. next week's occurrence), matching "next"/"upcoming"/bare-weekday semantics.
+    """
+    delta = (target_weekday - current_weekday) % 7
+    return 7 if delta == 0 else delta
+
+
 def last_weekday_of_month(year: int, month: int, weekday: int) -> date:
     last_day = _days_in_month(year, month)
     last = date(year, month, last_day)
@@ -375,8 +385,7 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         target_wd = WEEKDAYS[m.group(2)]
         base_wd = base.weekday()
         if modifier in ("next", "coming", ""):  # treat bare weekday as upcoming (future strictly)
-            delta = (target_wd - base_wd) % 7
-            delta = 7 if delta == 0 else delta
+            delta = days_until_next_weekday(base_wd, target_wd)
             out = base + timedelta(days=delta)
         elif modifier == "this":  # same-week, can be today
             delta = (target_wd - base_wd) % 7

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -9,6 +9,8 @@ refactor of the shared branch logic can be verified as behavior-preserving witho
 hand-tracing every case from scratch.
 """
 
+from datetime import datetime, timezone
+
 import pytest
 
 from navi_bench.opentable.opentable_info_gathering import (
@@ -18,6 +20,7 @@ from navi_bench.opentable.opentable_info_gathering import (
     MultiCandidateQuery,
     OpenTableInfoGathering,
     SingleCandidateQuery,
+    get_days_until_date,
 )
 
 
@@ -342,3 +345,29 @@ class TestDateOptions:
             "the next two weekends",
             "the first weekend of the next calendar month",
         ]
+
+
+class TestGetDaysUntilDateUpcomingWeekday:
+    """Pin the "for the upcoming <weekday>" branch of ``get_days_until_date`` ahead of a
+    refactor that delegates its next-occurrence math to the shared
+    ``relative_dates.days_until_next_weekday`` helper (used identically by
+    ``relative_dates.parse_relative_date``'s weekday branch). ``today`` is 2025-11-06, a
+    Thursday, chosen so the Thursday case exercises the "target is today" edge (rolls to 7).
+    """
+
+    _TODAY = datetime(2025, 11, 6, tzinfo=timezone.utc)  # Thursday
+
+    @pytest.mark.parametrize(
+        "weekday_name,expected_days",
+        [
+            ("Monday", 4),
+            ("Tuesday", 5),
+            ("Wednesday", 6),
+            ("Thursday", 7),  # today's own weekday rolls to next week
+            ("Friday", 1),
+            ("Saturday", 2),
+            ("Sunday", 3),
+        ],
+    )
+    def test_upcoming_weekday_offset(self, weekday_name, expected_days):
+        assert get_days_until_date(f"for the upcoming {weekday_name}", self._TODAY) == [expected_days]

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -14,7 +14,7 @@ from datetime import date
 
 import pytest
 
-from navi_bench.relative_dates import parse_relative_date, parse_relative_dates
+from navi_bench.relative_dates import days_until_next_weekday, parse_relative_date, parse_relative_dates
 
 
 BASE_DATE = date(2025, 11, 6)  # a Thursday
@@ -151,3 +151,25 @@ class TestMonthDayRangePattern:
 
     def test_single_range_fallback_reversed_range_is_normalized(self):
         assert parse_relative_dates("Dec 5-3", BASE_DATE) == ["2025-12-03", "2025-12-04", "2025-12-05"]
+
+
+class TestDaysUntilNextWeekday:
+    """Direct coverage for ``days_until_next_weekday``, the shared "next strictly-future
+    weekday" helper extracted from the duplicated (target - current) % 7, bump-0-to-7 math
+    in this module's weekday branch and in
+    ``opentable_info_gathering.get_days_until_date``'s "for the upcoming <weekday>" branch."""
+
+    def test_same_weekday_rolls_to_next_week(self):
+        assert days_until_next_weekday(3, 3) == 7
+
+    @pytest.mark.parametrize(
+        "current_weekday,target_weekday,expected",
+        [
+            (3, 4, 1),  # Thu -> Fri
+            (3, 0, 4),  # Thu -> Mon (wraps past week boundary)
+            (0, 6, 6),  # Mon -> Sun
+            (6, 0, 1),  # Sun -> Mon (wraps forward)
+        ],
+    )
+    def test_future_weekday_offset(self, current_weekday, target_weekday, expected):
+        assert days_until_next_weekday(current_weekday, target_weekday) == expected


### PR DESCRIPTION
## Issue

`navi_bench/relative_dates.py`'s `parse_relative_date` (weekday branch, `"next"`/`"coming"`/bare-weekday case) and `navi_bench/opentable/opentable_info_gathering.py`'s `get_days_until_date` (the `"for the upcoming <weekday>"` branch) independently computed the identical "days until the next strictly-future weekday" formula:

```python
delta = (target_weekday - current_weekday) % 7
delta = 7 if delta == 0 else delta  # bump 0 -> 7 so today's own weekday rolls to next week
```

This is the same shape of cross-module date-math duplication already addressed in #127 (`nth_weekday_of_month` reuse for opentable's first-Saturday calc) — `opentable_info_gathering.py` already imports `WEEKDAYS`/`nth_weekday_of_month` from `relative_dates.py`, so this extends that existing shared surface with one more small helper.

## Improvement

Extracted `days_until_next_weekday(current_weekday, target_weekday) -> int` into `navi_bench/relative_dates.py`, next to `nth_weekday_of_month`/`last_weekday_of_month`. Both call sites now delegate to it — no logic change, just hoisting the identical math into one place.

## Safety

- Pure arithmetic extraction; the formula is unchanged, only moved into a named function.
- `get_days_until_date`'s weekday branch had **zero prior test coverage**, so per this repo's established convention (characterization tests before/alongside structural refactors of untested code), I added `TestGetDaysUntilDateUpcomingWeekday` in `tests/test_opentable_info_gathering.py` — parametrized over all 7 weekdays from a fixed Thursday `today`, including the "target is today" edge case that rolls to 7.
- Also added `TestDaysUntilNextWeekday` in `tests/test_relative_dates.py` for direct coverage of the new helper (same-weekday-rolls-to-7, plus forward/wrap-around cases).
- `ruff format --check` / `ruff check` clean on all touched files.
- **Tests: 182 → 194 passing** (12 new characterization tests added, 0 removed, 0 changed in the pre-existing suite).

🤖 Generated as part of an automated hourly refactor job.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9VNWbc95DSpSLg349RmiP)_