### PR TITLE
refactor(opentable): extract shared _iter_uncovered_queries helper

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -3,7 +3,7 @@ import functools
 import itertools
 import random
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
@@ -99,6 +99,21 @@ class OpenTableInfoGathering(BaseMetric):
     def js_script(self) -> str:
         return read_sidecar(__file__, "opentable_info_gathering.js")
 
+    def _iter_uncovered_queries(self) -> Iterator[tuple[int, list[MultiCandidateQuery]]]:
+        """Yield ``(i, alternative_conditions)`` for each query in ``self.queries`` not yet
+        marked covered in ``self._is_query_covered``.
+
+        Centralizes the ``for i, alternative_conditions in enumerate(self.queries): if
+        self._is_query_covered[i]: continue`` guard that ``update``, ``compute``, and
+        ``_mark_uncovered_queries_with_unconditional_evidence`` each repeated verbatim before
+        their own domain-specific body. Lazily re-checks coverage at yield time, so it stays
+        behavior-identical to the inline guard even though each of those bodies may itself set
+        ``self._is_query_covered[i] = True`` for the *current* index while iterating.
+        """
+        for i, alternative_conditions in enumerate(self.queries):
+            if not self._is_query_covered[i]:
+                yield i, alternative_conditions
+
     async def reset(self) -> None:
         self._all_infos = []
         self._is_query_covered = [False] * len(self.queries)
@@ -123,10 +138,7 @@ class OpenTableInfoGathering(BaseMetric):
             if "your party is too large" in info["info"].lower():
                 self._handle_party_too_small_or_too_large(info, issue="too large")
 
-        for i, alternative_conditions in enumerate(self.queries):
-            if self._is_query_covered[i]:
-                continue
-
+        for i, alternative_conditions in self._iter_uncovered_queries():
             for info in infos:
                 if self._check_alternative_conditions(i, alternative_conditions, info):
                     logger.info(
@@ -171,9 +183,7 @@ class OpenTableInfoGathering(BaseMetric):
         which share this iteration shape and only differ in the value predicate
         and the log line.
         """
-        for i, alternative_conditions in enumerate(self.queries):
-            if self._is_query_covered[i]:
-                continue
+        for i, alternative_conditions in self._iter_uncovered_queries():
             for alternative_condition in alternative_conditions:
                 if not self._condition_matches_restaurant(alternative_condition, restaurant):
                     continue
@@ -239,9 +249,7 @@ class OpenTableInfoGathering(BaseMetric):
 
     async def compute(self) -> FinalResult:
         # At the end, for each uncovered query, check if we have exhausted searching for all the alternative conditions
-        for i, alternative_conditions in enumerate(self.queries):
-            if self._is_query_covered[i]:
-                continue
+        for i, alternative_conditions in self._iter_uncovered_queries():
             for j, alternative_condition in enumerate(alternative_conditions):
                 if not self._is_exhausted(alternative_condition, self._unavailable_evidences[i][j]):
                     break

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -9,6 +9,7 @@ refactor of the shared branch logic can be verified as behavior-preserving witho
 hand-tracing every case from scratch.
 """
 
+import asyncio
 from datetime import datetime, timezone
 
 import pytest
@@ -22,6 +23,18 @@ from navi_bench.opentable.opentable_info_gathering import (
     SingleCandidateQuery,
     get_days_until_date,
 )
+
+
+class _FakePage:
+    """Minimal stand-in for playwright's ``Page``, returning canned JS-evaluate results
+    so ``OpenTableInfoGathering.update`` can be exercised without a real browser.
+    """
+
+    def __init__(self, infos: list[InfoDict]) -> None:
+        self._infos = infos
+
+    async def evaluate(self, _js_script: str) -> list[InfoDict]:
+        return self._infos
 
 
 def _info(**kwargs) -> InfoDict:
@@ -220,6 +233,76 @@ class TestIsExhausted:
     def test_multi_candidate_not_exhausted_with_no_evidence(self):
         query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["19:00:00"]}
         assert OpenTableInfoGathering._is_exhausted(query, []) is False
+
+
+class TestSkipsAlreadyCoveredQueries:
+    """Pin the "skip queries already marked covered" guard shared -- as an identical,
+    verbatim ``for i, alternative_conditions in enumerate(self.queries): if
+    self._is_query_covered[i]: continue`` idiom -- by ``update``, ``compute``, and
+    ``_mark_uncovered_queries_with_unconditional_evidence``, ahead of a refactor that
+    extracts it into a single ``_iter_uncovered_queries`` generator reused by all three.
+    """
+
+    def test_update_does_not_reprocess_an_already_covered_query(self):
+        queries: list[list[MultiCandidateQuery]] = [
+            [{"dates": ["2025-07-10"], "times": ["19:00:00"]}],
+            [{"dates": ["2025-07-10"], "times": ["19:00:00"]}],
+        ]
+        gathering = OpenTableInfoGathering(queries=queries)
+        gathering._is_query_covered[0] = True  # simulate already covered by a prior update()
+
+        info = _info(info=_PLAIN_UNAVAILABLE_INFO, date="2025-07-10", time="19:00:00")
+        asyncio.run(gathering.update(page=_FakePage([info])))
+
+        # Query 0 was skipped entirely: no evidence recorded despite matching date/time.
+        assert gathering._unavailable_evidences[0][0] == []
+        # Query 1 was processed: the "unavailable" info is recorded as evidence, not a match.
+        assert gathering._unavailable_evidences[1][0] == [info]
+        assert gathering._is_query_covered == [True, False]
+
+    def test_compute_leaves_already_covered_query_untouched_and_marks_exhausted_query_covered(self):
+        queries: list[list[MultiCandidateQuery]] = [
+            [{"dates": ["2025-07-10"], "times": ["19:00:00"]}],
+            [{"dates": ["2025-07-10"], "times": ["19:00:00"]}],
+        ]
+        gathering = OpenTableInfoGathering(queries=queries)
+        gathering._is_query_covered[0] = True
+        gathering._unavailable_evidences[1][0] = [
+            _info(date="2025-07-10", time="19:00:00", info=_PLAIN_UNAVAILABLE_INFO)
+        ]
+
+        result = asyncio.run(gathering.compute())
+
+        assert gathering._is_query_covered == [True, True]
+        assert result.n_covered == 2
+        assert result.n_queries == 2
+        assert result.score == 1.0
+
+    def test_handle_too_far_in_advance_marks_matching_uncovered_query(self):
+        queries: list[list[MultiCandidateQuery]] = [
+            [{"restaurant_names": ["chez tj"], "dates": ["2025-07-10"]}],
+            [{"restaurant_names": ["chez tj"], "dates": ["2025-06-01"]}],
+        ]
+        gathering = OpenTableInfoGathering(queries=queries)
+
+        gathering._handle_too_far_in_advance(_info(restaurantName="Chez TJ", date="2025-07-01"))
+
+        # Query 0's only date (07-10) is >= the "too far in advance" date (07-01): covered.
+        # Query 1's only date (06-01) is < 07-01: left uncovered.
+        assert gathering._is_query_covered == [True, False]
+
+    def test_handle_party_too_small_marks_matching_uncovered_query(self):
+        queries: list[list[MultiCandidateQuery]] = [
+            [{"restaurant_names": ["chez tj"], "party_sizes": [6]}],
+            [{"restaurant_names": ["chez tj"], "party_sizes": [2]}],
+        ]
+        gathering = OpenTableInfoGathering(queries=queries)
+
+        gathering._handle_party_too_small_or_too_large(_info(restaurantName="Chez TJ", partySize=4), issue="too small")
+
+        # Query 0's party size (6) is > 4 (i.e. NOT <= 4): left uncovered.
+        # Query 1's party size (2) is <= 4: covered.
+        assert gathering._is_query_covered == [False, True]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- `OpenTableInfoGathering.update()`, `.compute()`, and `._mark_uncovered_queries_with_unconditional_evidence()` each repeated the identical `for i, alternative_conditions in enumerate(self.queries): if self._is_query_covered[i]: continue` guard verbatim before their own domain-specific body.
- Extracted a single `_iter_uncovered_queries()` generator (lazily re-checks coverage at yield time, so it stays behavior-identical to the inline guard even though each body may set `self._is_query_covered[i] = True` for the *current* index mid-iteration); all three call sites now delegate to it.
- Per this repo's established convention, added characterization tests **first** for the previously-untested `update()`/`compute()` skip-already-covered behavior (via a synthetic `Page` stand-in + `asyncio.run`, since these are async methods with no existing async test infra) and the two `_handle_too_far_in_advance`/`_handle_party_too_small_or_too_large` helpers, before making the change.

## Why it's safe
- 139/139 tests pass (135 before this PR + 4 new characterization tests, all passing identically before and after the refactor).
- `ruff check` / `ruff format --check` clean on both touched files.
- The two pre-existing `ruff format` deviations in `evaluation/eval_n1.py`/`navi_bench/dates.py` surfaced by a repo-wide format check are unrelated to this change (confirmed present on `main` via `git stash`) and untouched here.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_vis.py` (139 passed; `test_vis.py` requires the private `yutori` package, excluded per existing repo convention)
- [x] `ruff check` / `ruff format --check` on changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01XiDYpTyaesUu3qs9scqXpn)_