### PR TITLE
refactor(tests): dedupe stop-tool-call message builder in test_vis.py

### DIFF
--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -370,22 +370,14 @@ def _messages_with_final_answer(text: str | None) -> list[dict]:
 
 
 def _messages_with_stop_tool_call(action_type: str, text: str | None) -> list[dict]:
-    """Assistant message with a single Finished/CallUser-style tool call."""
+    """Assistant message with a single Finished/CallUser-style tool call.
+
+    Same message shape as ``_messages_with_action``, just deriving ``action_args`` from
+    ``text`` first (an empty dict when ``text`` is ``None``, matching how a real Finished/
+    CallUser tool call with no text argument is represented).
+    """
     arguments = {"text": text} if text is not None else {}
-    return [
-        {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {
-                    "id": "t1",
-                    "type": "function",
-                    "function": {"name": action_type, "arguments": json.dumps(arguments)},
-                }
-            ],
-        },
-    ]
+    return _messages_with_action(arguments, name=action_type)
 
 
 _STOP_CARD_RE = re.compile(


### PR DESCRIPTION
## Issue

`tests/test_vis.py`'s `_messages_with_stop_tool_call(action_type, text)` helper reconstructed the exact same `user` + `assistant`/`tool_calls` message list already built by `_messages_with_action(action_args, name)`, differing only in how the `arguments` dict is derived from `text` (`{"text": text}` if not `None`, else `{}`).

## Improvement

`_messages_with_stop_tool_call` now computes `arguments` and delegates to `_messages_with_action(arguments, name=action_type)` instead of re-building the message list inline. Test-scaffolding only — no production code touched, same class of fix as the previously-merged #134 (duplicated literals extracted from test scaffolding).

## Safety net

- Verified programmatically that the old inline construction and the new delegating call produce byte-identical output for every `(action_type, text)` combination exercised by the test file's own `TestStopActionCard` cases (`Finished`/`All done.`, `CallUser`/`Need help.`, `call_user`/`hi`, `Finished`/`None`).
- Full suite: 198/198 tests pass, identical before and after the change.
- `ruff check` / `ruff format --check` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zcec8DYF7kMT9CPwtGeE1

---
_Generated by [Claude Code](https://claude.ai/code/session_011zcec8DYF7kMT9CPwtGeE1)_