### PR TITLE
Reuse days_until_next_weekday in the last/previous weekday branch

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -391,8 +391,9 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
             delta = (target_wd - base_wd) % 7
             out = base + timedelta(days=delta)
         else:  # last/previous
-            delta = (base_wd - target_wd) % 7
-            delta = 7 if delta == 0 else delta
+            # Same (target - current) % 7, bump-0-to-7 math as the "next" branch above,
+            # just with the weekday arguments swapped since we're counting backwards.
+            delta = days_until_next_weekday(target_wd, base_wd)
             out = base - timedelta(days=delta)
         return _maybe_iso(out, return_iso)
 

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -153,6 +153,30 @@ class TestMonthDayRangePattern:
         assert parse_relative_dates("Dec 5-3", BASE_DATE) == ["2025-12-03", "2025-12-04", "2025-12-05"]
 
 
+class TestLastWeekdayBranch:
+    """Characterization tests for the "last/previous <weekday>" branch of
+    ``parse_relative_date``. This branch currently hand-rolls the same
+    ``(target - current) % 7``-with-zero-bumped-to-7 math as
+    ``days_until_next_weekday``, just with the two weekday arguments swapped
+    (``(base_wd - target_wd) % 7`` instead of ``(target_wd - base_wd) % 7``),
+    before it is refactored to call the shared helper directly. BASE_DATE
+    (2025-11-06) is a Thursday.
+    """
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("last Monday", "2025-11-03"),
+            ("last Thursday", "2025-10-30"),  # same weekday as base rolls back a full week
+            ("last Sunday", "2025-11-02"),
+            ("last Friday", "2025-10-31"),
+            ("previous Monday", "2025-11-03"),  # "previous" is a synonym for "last"
+        ],
+    )
+    def test_last_weekday(self, text, expected):
+        assert parse_relative_date(text, BASE_DATE) == expected
+
+
 class TestDaysUntilNextWeekday:
     """Direct coverage for ``days_until_next_weekday``, the shared "next strictly-future
     weekday" helper extracted from the duplicated (target - current) % 7, bump-0-to-7 math


### PR DESCRIPTION
## Summary
- `parse_relative_date`'s "last/previous `<weekday>`" branch hand-rolled the same `(target - current) % 7`, bump-0-to-7 math that `days_until_next_weekday` already encapsulates (extracted in #136) — just with the two weekday arguments swapped, since counting backwards to the last occurrence of a weekday is equivalent to `days_until_next_weekday(target_wd, base_wd)`.
- Verified the swapped-argument equivalence exhaustively for all 49 `(base_wd, target_wd)` pairs before making the change.
- Adds characterization tests for this previously-untested branch (`last Monday`, `last Thursday` (same-weekday rollback), `last Sunday`, `last Friday`, `previous Monday`), confirmed passing both before and after the refactor.

## Test plan
- [x] Added `TestLastWeekdayBranch` in `tests/test_relative_dates.py`, confirmed green against the pre-refactor code
- [x] Applied the refactor, reran the same tests — still green
- [x] `pytest tests/` — 203 passed
- [x] `ruff check` / `ruff format --check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012K7VWtwkc7MPwAWnTEBhAD


---
_Generated by [Claude Code](https://claude.ai/code/session_012K7VWtwkc7MPwAWnTEBhAD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in date parsing with new characterization tests; behavior is intended to be equivalent to the prior inline math.
> 
> **Overview**
> **`parse_relative_date`** now routes **last/previous weekday** phrases through **`days_until_next_weekday(target_wd, base_wd)`** instead of inline `(base_wd - target_wd) % 7` with a zero→7 bump, aligning backward counting with the shared helper used for **next/upcoming** weekdays.
> 
> Adds **`TestLastWeekdayBranch`** characterization tests for **`last`/`previous`** weekday inputs (including same-weekday-as-base rolling back a week and **`previous`** as a synonym), locking behavior before and after the refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d752759beac0ba0fe8c65a8bc1e0ee6014f01aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->