### PR TITLE
refactor(resy): extract _parse_optional_int helper for CSV int parsing

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -683,6 +683,16 @@ class RestaurantDict(TypedDict):
     days_ahead: int
 
 
+def _parse_optional_int(value: str) -> int | None:
+    """Parse a CSV cell as ``int``, or ``None`` when the cell is empty.
+
+    Shared by the ``Guests Min``/``Guests Max``/``Days Ahead`` columns in
+    :func:`load_restaurant_metadata`, which each previously repeated this
+    ``int(value) if value else None`` conversion inline.
+    """
+    return int(value) if value else None
+
+
 def load_restaurant_metadata() -> dict:
     """
     Load restaurant metadata from CSV file.
@@ -699,9 +709,9 @@ def load_restaurant_metadata() -> dict:
                 restaurant = row["Restaurant"].strip()
 
                 # Parse numeric values
-                guests_min = int(row["Guests Min"]) if row["Guests Min"] else None
-                guests_max = int(row["Guests Max"]) if row["Guests Max"] else None
-                days_ahead = int(row["Days Ahead"]) if row["Days Ahead"] else None
+                guests_min = _parse_optional_int(row["Guests Min"])
+                guests_max = _parse_optional_int(row["Guests Max"])
+                days_ahead = _parse_optional_int(row["Days Ahead"])
 
                 # Parse time strings (may be empty)
                 open_time = row["Open Time"].strip() or None

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -16,8 +16,10 @@ from datetime import date
 import pytest
 
 from navi_bench.resy.resy_url_match import (
+    RESTAURANT_METADATA,
     ResyQueryState,
     ResyUrlMatch,
+    _parse_optional_int,
     _render_placeholders_in_queries_all,
     _render_placeholders_in_queries_any,
     parse_time_to_hour,
@@ -239,3 +241,34 @@ class TestParseTimeToHour:
     )
     def test_parses_expected_values(self, time_str, expected):
         assert parse_time_to_hour(time_str) == expected
+
+
+class TestParseOptionalInt:
+    """Characterization tests for ``_parse_optional_int``, extracted from the ``Guests
+    Min``/``Guests Max``/``Days Ahead`` columns in ``load_restaurant_metadata``, which each
+    previously repeated ``int(value) if value else None`` inline.
+    """
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("1", 1),
+            ("28", 28),
+            ("0", 0),
+            ("", None),
+        ],
+    )
+    def test_parses_expected_values(self, value, expected):
+        assert _parse_optional_int(value) == expected
+
+
+class TestLoadRestaurantMetadata:
+    """Sanity check that the bundled ``resy_restaurant.csv`` is still parsed with the
+    expected int types after routing through ``_parse_optional_int``."""
+
+    def test_known_row_has_correct_types(self):
+        entry = RESTAURANT_METADATA[("new york", "carbone")]
+        assert entry["guests_min"] == 1
+        assert entry["guests_max"] == 15
+        assert entry["days_ahead"] == 28
+        assert isinstance(entry["guests_min"], int)


### PR DESCRIPTION
## What

`load_restaurant_metadata()` in `navi_bench/resy/resy_url_match.py` parsed three CSV
columns (`Guests Min`, `Guests Max`, `Days Ahead`) with the identical expression
repeated verbatim:

```python
guests_min = int(row["Guests Min"]) if row["Guests Min"] else None
guests_max = int(row["Guests Max"]) if row["Guests Max"] else None
days_ahead = int(row["Days Ahead"]) if row["Days Ahead"] else None
```

This PR extracts the shared pattern into a small helper:

```python
def _parse_optional_int(value: str) -> int | None:
    return int(value) if value else None
```

and updates all three call sites to use it.

## Why this is safe

- Purely mechanical extraction — the helper body is byte-identical to the expression
  it replaces, so behavior (including the empty-string -> `None` case and the `"0"` ->
  `0` truthy-string edge case) is unchanged.
- Single file touched for the source change (`navi_bench/resy/resy_url_match.py`), plus
  the corresponding test file.
- Added characterization tests (`tests/test_resy_url_match.py::TestParseOptionalInt`)
  pinning both branches of `_parse_optional_int`, plus a sanity check
  (`TestLoadRestaurantMetadata::test_known_row_has_correct_types`) that the bundled
  `resy_restaurant.csv` still parses to the same `int` values via the real
  `RESTAURANT_METADATA` module-level load.
- Full suite passes: 208/208 tests (`pytest tests/`), including the 5 new tests.
- `ruff check` and `ruff format --check` are clean on both touched files.

This follows the same "duplicated literal/expression -> module helper" pattern used by
several prior merged refactors in this repo (e.g. #112, #125, #134).

## Test plan

- [x] `ruff check navi_bench/resy/resy_url_match.py tests/test_resy_url_match.py`
- [x] `ruff format --check navi_bench/resy/resy_url_match.py tests/test_resy_url_match.py`
- [x] `pytest tests/` — 208 passed

🤖 Generated as part of an automated hourly refactor scan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYDGFPT6Cg6GyNN46WEqot)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with identical parsing logic; only Resy CSV metadata loading and tests are touched.
> 
> **Overview**
> Deduplicates optional integer parsing when loading **`resy_restaurant.csv`** by introducing **`_parse_optional_int`** and wiring **`Guests Min`**, **`Guests Max`**, and **`Days Ahead`** in **`load_restaurant_metadata`** through it instead of repeating **`int(value) if value else None`**.
> 
> Tests add parametrized coverage for the helper (including **`"0"`** → **`0`** and empty → **`None`**) and assert a known **Carbone** row in module-level **`RESTAURANT_METADATA`** still has the expected **`int`** fields after the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcca7ed130fd6b17fbb9e6a53996ae87a32e72e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->