### PR TITLE
refactor(opentable): extract shared _singleton_choices helper in _is_exhausted

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -404,24 +404,25 @@ class OpenTableInfoGathering(BaseMetric):
         )
         return matched
 
+    @staticmethod
+    def _singleton_choices(query: MultiCandidateQuery, key: str) -> list:
+        """Return ``query[key]`` if it's a non-empty list, else ``[None]``.
+
+        Shared by the four ``restaurant_names``/``party_sizes``/``dates``/``times`` lookups in
+        ``_is_exhausted``, which each previously repeated ``value = query.get(key); if not
+        value: value = [None]`` to turn an absent-or-empty-list "no constraint on this axis"
+        into a single placeholder choice for the ``itertools.product`` exhaustion loop below.
+        """
+        value = query.get(key)
+        return value if value else [None]
+
     @classmethod
     def _is_exhausted(cls, query: MultiCandidateQuery, evidences: list[InfoDict]) -> bool:
         """If the query is unavailable, check if we have exhausted searching for its choices"""
-        query_names = query.get("restaurant_names")
-        if not query_names:
-            query_names = [None]
-
-        query_party_sizes = query.get("party_sizes")
-        if not query_party_sizes:
-            query_party_sizes = [None]
-
-        query_dates = query.get("dates")
-        if not query_dates:
-            query_dates = [None]
-
-        query_times = query.get("times")
-        if not query_times:
-            query_times = [None]
+        query_names = cls._singleton_choices(query, "restaurant_names")
+        query_party_sizes = cls._singleton_choices(query, "party_sizes")
+        query_dates = cls._singleton_choices(query, "dates")
+        query_times = cls._singleton_choices(query, "times")
 
         for query_name, query_party_size, query_date, query_time in itertools.product(
             query_names, query_party_sizes, query_dates, query_times

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -25,6 +25,24 @@ from navi_bench.opentable.opentable_info_gathering import (
 )
 
 
+class TestSingletonChoices:
+    """Characterization tests for `_singleton_choices`, extracted from the four
+    `restaurant_names`/`party_sizes`/`dates`/`times` "default to [None]" blocks in
+    `_is_exhausted` that each previously repeated `value = query.get(key); if not value:
+    value = [None]` inline.
+    """
+
+    def test_missing_key_defaults_to_none_singleton(self):
+        assert OpenTableInfoGathering._singleton_choices({}, "dates") == [None]
+
+    def test_explicitly_empty_list_defaults_to_none_singleton(self):
+        assert OpenTableInfoGathering._singleton_choices({"dates": []}, "dates") == [None]
+
+    def test_non_empty_list_returned_as_is(self):
+        query: MultiCandidateQuery = {"dates": ["2025-07-10", "2025-07-11"]}
+        assert OpenTableInfoGathering._singleton_choices(query, "dates") == ["2025-07-10", "2025-07-11"]
+
+
 class _FakePage:
     """Minimal stand-in for playwright's ``Page``, returning canned JS-evaluate results
     so ``OpenTableInfoGathering.update`` can be exercised without a real browser.
@@ -233,6 +251,32 @@ class TestIsExhausted:
     def test_multi_candidate_not_exhausted_with_no_evidence(self):
         query: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["19:00:00"]}
         assert OpenTableInfoGathering._is_exhausted(query, []) is False
+
+    def test_explicitly_empty_list_treated_same_as_missing_key(self):
+        # `restaurant_names: []` (explicitly present but empty) must collapse to the same
+        # single "no constraint on this axis" choice as an altogether-missing key -- this is
+        # the falsy-check `_is_exhausted` performs (as opposed to a `dict.get(key, [None])`
+        # default, which only fires when the key is absent).
+        query_explicit_empty: MultiCandidateQuery = {
+            "restaurant_names": [],
+            "dates": ["2025-07-10"],
+            "times": ["19:00:00"],
+        }
+        query_missing_key: MultiCandidateQuery = {"dates": ["2025-07-10"], "times": ["19:00:00"]}
+        info = _info(date="2025-07-10", time="19:00:00", info=_PLAIN_UNAVAILABLE_INFO)
+
+        assert OpenTableInfoGathering._is_exhausted(query_explicit_empty, [info]) == (
+            OpenTableInfoGathering._is_exhausted(query_missing_key, [info])
+        )
+        assert OpenTableInfoGathering._is_exhausted(query_explicit_empty, [info]) is True
+
+    def test_fully_unconstrained_query_exhausted_by_single_matching_evidence(self):
+        # None of the four candidate-list keys set: the itertools.product loop degenerates to
+        # a single (None, None, None, None) combination, so one matching evidence item exhausts it.
+        query: MultiCandidateQuery = {}
+        info = _info(info=_PLAIN_UNAVAILABLE_INFO)
+
+        assert OpenTableInfoGathering._is_exhausted(query, [info]) is True
 
 
 class TestSkipsAlreadyCoveredQueries:


### PR DESCRIPTION
## Issue

`OpenTableInfoGathering._is_exhausted` (in `navi_bench/opentable/opentable_info_gathering.py`) repeated the identical block four times, once each for `restaurant_names`, `party_sizes`, `dates`, and `times`:

```python
query_names = query.get("restaurant_names")
if not query_names:
    query_names = [None]
```

Each turns an absent-or-empty-list "no constraint on this axis" into a single placeholder choice consumed by the `itertools.product` exhaustion loop right below.

## Why this is an improvement

Same "duplicated small block → shared helper" pattern this repo has applied repeatedly (e.g. #123 `_first_present`, #125 `unwrap_optional_type`, #140 `_parse_optional_int`). Extracted a `_singleton_choices(query, key)` static helper; `_is_exhausted` now calls it four times instead of hand-rolling the same two-line guard.

## Why it's safe

- **Characterization tests added first**, per this repo's established convention for touching logic without dedicated direct-unit coverage: pinned (a) that an explicitly-empty list (`"restaurant_names": []`) collapses to the same behavior as a missing key — the subtlety that distinguishes this from a naive `dict.get(key, [None])` default, which only fires on a missing key — and (b) a fully-unconstrained query (`{}`) is exhausted by a single matching evidence item.
- Extracted the helper, then added direct unit tests for `_singleton_choices` itself.
- Full test suite: **208 → 213 passing** (5 new tests), no regressions. `ruff check` / `ruff format --check` clean on both touched files.
- Change is contained to 2 files: `navi_bench/opentable/opentable_info_gathering.py` and `tests/test_opentable_info_gathering.py`.

🤖 Generated as part of the hourly automated refactor job.

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01HCLMtR3AFfLpnQvjvoafkL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication inside OpenTable query exhaustion logic, guarded by new characterization tests; no API or eval wiring changes.
> 
> **Overview**
> **`_is_exhausted`** no longer repeats the same “absent or empty list → `[None]`” logic for **`restaurant_names`**, **`party_sizes`**, **`dates`**, and **`times`**. That normalization now lives in a new **`_singleton_choices`** static helper, which **`_is_exhausted`** calls four times before the **`itertools.product`** exhaustion loop.
> 
> Tests add direct coverage for **`_singleton_choices`** (missing key, empty list, non-empty list) and two **`_is_exhausted`** characterization cases: explicit **`[]`** on an axis behaves like a missing key, and a fully unconstrained query **`{}`** is exhausted by one matching unavailable evidence item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baea37db558b8f740ec4ffe6e645fe15c1ae3336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->