### PR TITLE
docs(tests): fix stale "before a refactor" docstrings across test suite

### DIFF
--- a/tests/test_apartments_url_match.py
+++ b/tests/test_apartments_url_match.py
@@ -1,10 +1,9 @@
 """Characterization tests for ApartmentsUrlMatch._normalize_url.
 
-These tests pin the CURRENT behavior of URL normalization (location extraction/merging,
-apartment-feature reordering, and ignored-parameter stripping) before a structural refactor
-moves the ``state_abbreviations`` and ``apartment_features`` literals -- currently rebuilt on
-every call inside ``_is_location_part``/``_normalize_apartment_features`` -- to module-level
-constants. The refactor should not change any of these outputs.
+These tests pin the behavior of URL normalization (location extraction/merging,
+apartment-feature reordering, and ignored-parameter stripping), including the
+``_STATE_ABBREVIATIONS``/``_APARTMENT_FEATURES`` module-level constants that
+``_is_location_part``/``_normalize_apartment_features`` read from.
 """
 
 from navi_bench.apartments.apartments_url_match import ApartmentsUrlMatch

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,9 +1,9 @@
 """Characterization test for ``evaluation.browser.get_prepare_page_js``.
 
-Pins the pre-refactor behavior (reading ``prepare_page.js`` from the same directory as
-``evaluation/browser.py``, open-coded via ``os.path``) before switching the implementation to
-delegate to ``navi_bench.base.read_sidecar`` -- the same sidecar-file-read helper already used by
-``navi_bench/resy/resy_url_match.py`` and ``navi_bench/opentable/opentable_info_gathering.py``.
+Pins its behavior of reading ``prepare_page.js`` from the same directory as
+``evaluation/browser.py`` via ``navi_bench.base.read_sidecar`` -- the same sidecar-file-read
+helper used by ``navi_bench/resy/resy_url_match.py`` and
+``navi_bench/opentable/opentable_info_gathering.py``.
 """
 
 from pathlib import Path

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -1,12 +1,12 @@
 """Characterization tests for OpenTableInfoGathering's query-matching logic.
 
-These tests pin the CURRENT behavior of ``_check_multi_candidate_query`` and
-``_check_single_candidate_query`` (and, transitively, ``_is_exhausted``) before a
-structural refactor extracts their shared four-way branch (``"no online availability"``
-/ time-range ``"unavailable"`` / plain ``"unavailable"``-or-``"unfortunately"`` /
-available). They are not meant to exhaustively spec the domain; they exist so a
-refactor of the shared branch logic can be verified as behavior-preserving without
-hand-tracing every case from scratch.
+These tests pin the behavior of ``_check_multi_candidate_query`` and
+``_check_single_candidate_query`` (and, transitively, ``_is_exhausted``), including their
+shared four-way branch (``"no online availability"`` / time-range ``"unavailable"`` / plain
+``"unavailable"``-or-``"unfortunately"`` / available) extracted into ``_match_query_window``.
+They are not meant to exhaustively spec the domain; they exist so future changes to the
+shared branch logic can be verified as behavior-preserving without hand-tracing every case
+from scratch.
 """
 
 import asyncio
@@ -280,11 +280,9 @@ class TestIsExhausted:
 
 
 class TestSkipsAlreadyCoveredQueries:
-    """Pin the "skip queries already marked covered" guard shared -- as an identical,
-    verbatim ``for i, alternative_conditions in enumerate(self.queries): if
-    self._is_query_covered[i]: continue`` idiom -- by ``update``, ``compute``, and
-    ``_mark_uncovered_queries_with_unconditional_evidence``, ahead of a refactor that
-    extracts it into a single ``_iter_uncovered_queries`` generator reused by all three.
+    """Pin the "skip queries already marked covered" guard shared by ``update``, ``compute``,
+    and ``_mark_uncovered_queries_with_unconditional_evidence`` via the single
+    ``_iter_uncovered_queries`` generator all three delegate to.
     """
 
     def test_update_does_not_reprocess_an_already_covered_query(self):

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -1,14 +1,13 @@
 """Characterization tests for ResyUrlMatch's placeholder-rendering helpers.
 
-These tests pin the CURRENT behavior of ``_render_placeholders_in_queries_any`` and
-``_render_placeholders_in_queries_all`` before a structural refactor extracts their shared
-per-placeholder validation preamble (build the ``{key}`` template string, reject empty
-resolved dates via ``ensure_resolved_dates``, reject dates beyond the booking window via
-``_ensure_within_booking_window``). ``_any`` additionally requires exactly one resolved date,
-checked *between* the other two validations in the original code — a couple of these tests
-exist specifically to pin that ordering (which error wins when a placeholder is both
-multi-valued and out of the booking window) so the refactor can be verified as
-behavior-preserving without hand-tracing every case from scratch.
+These tests pin the behavior of ``_render_placeholders_in_queries_any`` and
+``_render_placeholders_in_queries_all``, including their shared per-placeholder validation
+preamble (build the ``{key}`` template string, reject empty resolved dates via
+``ensure_resolved_dates``, reject dates beyond the booking window via
+``_ensure_within_booking_window``) extracted into ``_validate_placeholder_dates_and_get_template_string``.
+``_any`` additionally requires exactly one resolved date, checked *between* the other two
+validations — a couple of these tests exist specifically to pin that ordering (which error
+wins when a placeholder is both multi-valued and out of the booking window).
 """
 
 from datetime import date
@@ -117,8 +116,8 @@ class TestRenderPlaceholdersInQueriesAll:
 class TestDescribeConditionalReason:
     """Characterization tests for ``ResyUrlMatch._describe_conditional_reason``.
 
-    Pins current behavior before a structural refactor moves the ``mapping`` dict literal --
-    currently rebuilt on every call -- to a module-level constant alongside this file's other
+    Pins current behavior, including the reason->description lookup extracted to the
+    module-level ``_CONDITIONAL_REASON_DESCRIPTIONS`` constant alongside this file's other
     module-level dicts (``CITY_METADATA``, ``VENUE_SLUG_MAPPING``).
     """
 


### PR DESCRIPTION
## Issue

This repo has had ~37+ structural-refactor PRs land, and several of the "characterization tests written first" docstrings established by that convention were never updated after their corresponding refactor merged. They still read as "these tests pin the CURRENT behavior **before** a structural refactor extracts/moves X" — but X has already landed in `main`:

| File | Docstring claimed pending | Actually already in source |
|---|---|---|
| `tests/test_apartments_url_match.py` (module) | move `state_abbreviations`/`apartment_features` literals to module constants | `_STATE_ABBREVIATIONS`/`_APARTMENT_FEATURES` are already module-level frozensets in `apartments_url_match.py` |
| `tests/test_resy_url_match.py` (module) | extract shared per-placeholder validation preamble | `_validate_placeholder_dates_and_get_template_string` already exists and is used by both `_render_placeholders_in_queries_any`/`_all` (PR #109) |
| `tests/test_resy_url_match.py` (`TestDescribeConditionalReason`) | move the reason->description `mapping` dict to a module constant | `_CONDITIONAL_REASON_DESCRIPTIONS` is already a module-level dict, already used by `_describe_conditional_reason` |
| `tests/test_opentable_info_gathering.py` (module) | extract the shared four-way branch | `_match_query_window` classmethod is already extracted and shared by `_check_multi_candidate_query`/`_check_single_candidate_query` (PR #107/#108) |
| `tests/test_opentable_info_gathering.py` (`TestSkipsAlreadyCoveredQueries`) | extract `_iter_uncovered_queries` generator | `_iter_uncovered_queries` already exists and is used by `update`/`compute`/`_mark_uncovered_queries_with_unconditional_evidence` (PR #137, the most recent structural refactor) |
| `tests/test_browser.py` (module) | switch `get_prepare_page_js` to delegate to `read_sidecar` | `get_prepare_page_js` already calls `navi_bench.base.read_sidecar` |

Left uncorrected, these stale docstrings risk misleading a future refactor pass into re-attempting work that's already done (or spending time re-verifying it's already done, as this run did).

## Improvement

Rewrote each stale docstring to describe the **current** (already-refactored) state in accurate, present-tense language, removing the "before a structural refactor..." framing. No source/behavior files were touched — this is purely test-docstring text.

## Safety

- **Zero behavior change**: only docstrings/comments were edited, no test logic, assertions, or source code changed.
- Full suite: **213/213 tests pass, identical before and after** (verified via local baseline run prior to editing).
- `ruff check` and `ruff format --check` both clean on all four touched files.
- I did a repo-wide audit for this exact pattern (`grep` for "before a"/"ahead of a" + refactor/extract/delegate/move language across `tests/*.py`) and cross-checked each hit against the actual current source to confirm the referenced refactor had landed, rather than guessing from the docstring text alone.

This run's broader search (base.py, dates.py, relative_dates.py, all 5 domain matchers, `evaluation/*.py`, `demo.py`) did not surface a new safe source-level structural refactor — the codebase is already heavily swept (37+ prior PRs). One candidate (replacing `resy_url_match.py`'s hand-rolled `_normalize_time_value` with `datetime.strptime`, mirroring PR #135's precedent) was investigated and **rejected**: `strptime`'s flexible-width digit parsing silently accepts inputs the current implementation correctly rejects (e.g. `"18"` -> hour=1/minute=8 via `%H%M`, vs. the original's `None` for any digit-only string whose length isn't exactly 4 or 6), so it is not behavior-preserving.

Claude-Session: https://claude.ai/code/session_01PUbvcYCaquGTvzDVZvktr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUbvcYCaquGTvzDVZvktr9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits in test files; no runtime or test logic changes.
> 
> **Overview**
> Updates **module and class docstrings** in four test files so they describe the **already-landed** refactors instead of framing tests as guarding behavior **before** upcoming extractions.
> 
> **`test_apartments_url_match.py`** now references module-level **`_STATE_ABBREVIATIONS`** / **`_APARTMENT_FEATURES`**. **`test_browser.py`** documents **`get_prepare_page_js`** using **`read_sidecar`**. **`test_resy_url_match.py`** names **`_validate_placeholder_dates_and_get_template_string`** and **`_CONDITIONAL_REASON_DESCRIPTIONS`**. **`test_opentable_info_gathering.py`** names **`_match_query_window`** and **`_iter_uncovered_queries`**.
> 
> No test assertions or production code were modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a580cb51b9e6a5537ae3b82dedb9e9194db64f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->