### PR TITLE
Type build_dataset/build_browser config params with Protocols

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -3,11 +3,21 @@ import functools
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Protocol, runtime_checkable
 
 from loguru import logger
 from playwright.async_api import Browser, BrowserContext, Error as PlaywrightError, Page, Playwright
 
 from navi_bench.base import BaseTaskConfig, read_sidecar
+
+
+@runtime_checkable
+class BrowserBuildConfig(Protocol):
+    """Protocol for the config fields build_browser() reads."""
+
+    browser_headless: bool
+    browser_viewport_width: int
+    browser_viewport_height: int
 
 
 LOCATION_COORDS = {
@@ -70,12 +80,9 @@ async def _safe_close(resource, label: str) -> None:
 
 @asynccontextmanager
 async def build_browser(
-    config, task_config: BaseTaskConfig, playwright: Playwright
+    config: BrowserBuildConfig, task_config: BaseTaskConfig, playwright: Playwright
 ) -> AsyncIterator[tuple[Browser, BrowserContext, Page]]:
-    """Create a browser, context, and page for evaluation.
-
-    Config must have: browser_headless, browser_viewport_width, browser_viewport_height.
-    """
+    """Create a browser, context, and page for evaluation."""
     browser = None
     context = None
 

--- a/evaluation/dataset.py
+++ b/evaluation/dataset.py
@@ -1,11 +1,26 @@
 import json
 
 from collections import defaultdict
+from typing import Protocol, runtime_checkable
 
 from datasets import concatenate_datasets, disable_caching, load_dataset
 from loguru import logger
 
 from navi_bench.base import DatasetItem
+
+
+@runtime_checkable
+class DatasetBuildConfig(Protocol):
+    """Protocol for the config fields build_dataset() reads."""
+
+    dataset_item_json: str | None
+    dataset_name: str
+    dataset_splits: list[str]
+    dataset_revision: str | None
+    dataset_include_domains: list[str] | None
+    dataset_include_task_ids: list[str] | None
+    dataset_max_samples_per_domain: int | None
+    dataset_max_samples: int | None
 
 
 def load_dataset_item_json(dataset_item_json: str) -> DatasetItem:
@@ -18,13 +33,8 @@ def load_dataset_item_json(dataset_item_json: str) -> DatasetItem:
     return DatasetItem.model_validate(item)
 
 
-async def build_dataset(config) -> list[DatasetItem]:
-    """Build and filter the dataset based on config.
-
-    Config must have: dataset_name, dataset_splits, dataset_revision,
-    dataset_include_domains, dataset_include_task_ids,
-    dataset_max_samples_per_domain, dataset_max_samples.
-    """
+async def build_dataset(config: DatasetBuildConfig) -> list[DatasetItem]:
+    """Build and filter the dataset based on config."""
     disable_caching()
 
     if config.dataset_item_json:


### PR DESCRIPTION
## What

`evaluation/dataset.py::build_dataset` and `evaluation/browser.py::build_browser` both took an untyped `config` parameter, documenting the required shape only in a prose docstring ("Config must have: ..."). That contract had already drifted: `dataset.py`'s docstring omitted `dataset_item_json`, which the function body reads at the top (`if config.dataset_item_json:`).

Replaced both docstring contracts with `runtime_checkable` `Protocol` classes (`DatasetBuildConfig`, `BrowserBuildConfig`), mirroring the existing `PageLike` Protocol convention already used in `navi_bench/resy/resy_url_match.py`.

## Why this is safe

- **Pure type-hint addition** — Protocols aren't `isinstance`-checked anywhere in these call paths, so this is zero-runtime-cost and behaviorally identical.
- Verified directly that `evaluation/eval_n1.py::Config` (the only caller) structurally satisfies both new protocols via `isinstance()`.
- `213/213` tests pass locally after the change.
- Only 2 files touched, no call-site changes needed.

---
🤖 Generated with automated refactor cronjob

Claude-Session: https://claude.ai/code/session_01B2jEj2sEcy15pBafcj5QGx

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2jEj2sEcy15pBafcj5QGx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-hint-only change in evaluation helpers with no behavioral or call-site edits; low risk unless future code relies on incomplete config objects that type checkers no longer flag.
> 
> **Overview**
> Replaces untyped `config` parameters on **`build_browser`** and **`build_dataset`** with **`BrowserBuildConfig`** and **`DatasetBuildConfig`** — `@runtime_checkable` `Protocol` classes that spell out the attributes each helper reads. The old “Config must have: …” docstrings are dropped in favor of those protocols.
> 
> **`DatasetBuildConfig`** explicitly includes **`dataset_item_json`**, which the function already used but the previous docstring did not document. No call-site or runtime logic changes; this is static typing and contract clarity only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3269b460bb5faa93fd4db627e572c34040835d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->