### PR TITLE
refactor(opentable): reuse add_months for next-month rollover

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -29,7 +29,7 @@ from navi_bench.dates import (
     render_task_statement,
     resolve_city_now,
 )
-from navi_bench.relative_dates import WEEKDAYS, days_until_next_weekday, nth_weekday_of_month
+from navi_bench.relative_dates import WEEKDAYS, add_months, days_until_next_weekday, nth_weekday_of_month
 
 
 class SingleCandidateQuery(TypedDict, total=False):
@@ -302,7 +302,7 @@ class OpenTableInfoGathering(BaseMetric):
         ``query_dates``/``query_times``, which cares which branch matched in order to decide
         whether to record ``info`` as unavailability evidence) and
         ``_check_single_candidate_query`` (its scalar date/time wrapped into singleton lists,
-        which only cares about ``matched`` — see that method for why the branch is irrelevant
+        which only cares about ``matched`` -- see that method for why the branch is irrelevant
         there).
         """
         available_info = info["info"].lower()
@@ -580,11 +580,9 @@ def get_first_weekend_of_next_month_offsets(today: datetime) -> list[int]:
     # Normalize to date only (remove time component)
     today_date = datetime(today.year, today.month, today.day, tzinfo=today.tzinfo)
 
-    # Get the first day of the next calendar month
-    if today.month == 12:
-        first_of_next_month = datetime(today.year + 1, 1, 1, tzinfo=today.tzinfo)
-    else:
-        first_of_next_month = datetime(today.year, today.month + 1, 1, tzinfo=today.tzinfo)
+    # First day of the next calendar month, via the shared month-rollover helper (which
+    # already handles the December -> January year rollover).
+    first_of_next_month = add_months(datetime(today.year, today.month, 1, tzinfo=today.tzinfo), 1)
 
     # First Saturday of the next calendar month
     first_saturday_date = nth_weekday_of_month(

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -22,14 +22,15 @@ from navi_bench.opentable.opentable_info_gathering import (
     OpenTableInfoGathering,
     SingleCandidateQuery,
     get_days_until_date,
+    get_first_weekend_of_next_month_offsets,
 )
 
 
 class TestSingletonChoices:
     """Characterization tests for `_singleton_choices`, extracted from the four
     `restaurant_names`/`party_sizes`/`dates`/`times` "default to [None]" blocks in
-    `_is_exhausted` that each previously repeated `value = query.get(key); if not value:
-    value = [None]` inline.
+    `_is_exhausted` that each previously repeated `value = query.get(key); if not
+    value: value = [None]` inline.
     """
 
     def test_missing_key_defaults_to_none_singleton(self):
@@ -496,3 +497,27 @@ class TestGetDaysUntilDateUpcomingWeekday:
     )
     def test_upcoming_weekday_offset(self, weekday_name, expected_days):
         assert get_days_until_date(f"for the upcoming {weekday_name}", self._TODAY) == [expected_days]
+
+
+class TestGetFirstWeekendOfNextMonthOffsets:
+    """Pin the exact offsets returned by ``get_first_weekend_of_next_month_offsets`` ahead of a
+    refactor that delegates its next-month rollover math to the shared
+    ``relative_dates.add_months`` helper instead of hand-rolling the "month == 12" check.
+    Includes the December -> January year-rollover case, since that is exactly the branch the
+    refactor touches.
+    """
+
+    def test_regular_month_rollover(self):
+        # 2025-11-06 is a Thursday; December 2025's first Saturday/Sunday are the 6th/7th.
+        today = datetime(2025, 11, 6, tzinfo=timezone.utc)
+        assert get_first_weekend_of_next_month_offsets(today) == [30, 31]
+
+    def test_december_to_january_year_rollover(self):
+        # 2025-12-15 is a Monday; January 2026's first Saturday/Sunday are the 3rd/4th.
+        today = datetime(2025, 12, 15, tzinfo=timezone.utc)
+        assert get_first_weekend_of_next_month_offsets(today) == [19, 20]
+
+    def test_from_first_of_december(self):
+        # 2025-12-01 is a Monday itself; still rolls over into January 2026.
+        today = datetime(2025, 12, 1, tzinfo=timezone.utc)
+        assert get_first_weekend_of_next_month_offsets(today) == [33, 34]


### PR DESCRIPTION
## What

`get_first_weekend_of_next_month_offsets` in `navi_bench/opentable/opentable_info_gathering.py` hand-rolled the December → January year-rollover with:

```python
if today.month == 12:
    first_of_next_month = datetime(today.year + 1, 1, 1, tzinfo=today.tzinfo)
else:
    first_of_next_month = datetime(today.year, today.month + 1, 1, tzinfo=today.tzinfo)
```

This duplicates exactly the month/year rollover math that `navi_bench/relative_dates.py`'s `add_months` helper already centralizes (and that other call sites in this codebase already reuse, e.g. `nth_weekday_of_month`/`days_until_next_weekday` a few lines below in the same file). Replaced it with:

```python
first_of_next_month = add_months(datetime(today.year, today.month, 1, tzinfo=today.tzinfo), 1)
```

Since the input day is always `1`, `add_months`'s day-clamping never kicks in, so this is a drop-in behavioral no-op — just one fewer hand-rolled rollover branch in the codebase.

## Why safe

- `get_first_weekend_of_next_month_offsets` had no direct test coverage before this PR, so I added characterization tests first (`TestGetFirstWeekendOfNextMonthOffsets` in `tests/test_opentable_info_gathering.py`), including the December → January rollover case that the refactor actually touches, and confirmed they pass against the pre-refactor code.
- Full test suite: **213 passed → 216 passed** (213 baseline + 3 new characterization tests), no regressions.
- `ruff check` and `ruff format --check` clean on both touched files.
- Scope: 2 files (`navi_bench/opentable/opentable_info_gathering.py`, `tests/test_opentable_info_gathering.py`).
- Note: `get_next_weekend_offsets` (a few lines above) was previously investigated and confirmed to diverge numerically from `relative_dates.days_until_next_weekday` on Saturday, so it's intentionally left untouched — this PR only touches the separate `get_first_weekend_of_next_month_offsets` function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EgBAmzV1vgPkx422q2b5YZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in date-offset helper for bench task generation, with new tests covering the year-rollover path; no auth, security, or production runtime impact.
> 
> **Overview**
> **`get_first_weekend_of_next_month_offsets`** no longer inlines the December→January month/year rollover; it computes the first day of the next calendar month with shared **`add_months`** (import added from **`relative_dates`**). Intended as a behavioral no-op when the anchor day is always the 1st.
> 
> Adds **`TestGetFirstWeekendOfNextMonthOffsets`** with three fixed-offset cases (normal month advance, December→January, and from Dec 1) to lock behavior before/after the refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f3ca6bea0986ef932efa8bfc52a5f838d579681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->