### PR TITLE
refactor(relative_dates): reuse add_months for month-range rollover

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -640,11 +640,9 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
             for d in _iter_month_days(y, mo):
                 if d.weekday() in wds:
                     out.append(d)
-            # next month
-            if mo == 12:
-                y, mo = y + 1, 1
-            else:
-                mo += 1
+            # next month (day=1 never triggers clamp_day's end-of-month clamping)
+            next_month = add_months(date(y, mo, 1), 1)
+            y, mo = next_month.year, next_month.month
         out.sort()
         return _maybe_iso_list(out, return_iso)
 

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -153,6 +153,67 @@ class TestMonthDayRangePattern:
         assert parse_relative_dates("Dec 5-3", BASE_DATE) == ["2025-12-03", "2025-12-04", "2025-12-05"]
 
 
+class TestWeekdaysInMonthRangeBranch:
+    """Characterization tests for the ``parse_relative_dates`` "<weekdays> in <month-ref>
+    through <month-ref>" branch (e.g. "Mondays and Fridays in next Jan through Mar"), which
+    hand-rolls a ``if mo == 12: y, mo = y + 1, 1 else: mo += 1`` month-rollover step to walk
+    from the start month to the end month inclusive. Same hand-rolled-rollover pattern as the
+    one already replaced with the shared ``add_months`` helper in
+    ``opentable_info_gathering.get_first_weekend_of_next_month_offsets`` (#144); this branch's
+    loop crosses a December -> January boundary whenever the requested range spans the turn
+    of the year, exercising the same rollover this helper would need to preserve.
+    """
+
+    def test_single_month_range(self):
+        assert parse_relative_dates("Mondays and Fridays in next Jan through Mar", BASE_DATE) == [
+            "2026-01-02",
+            "2026-01-05",
+            "2026-01-09",
+            "2026-01-12",
+            "2026-01-16",
+            "2026-01-19",
+            "2026-01-23",
+            "2026-01-26",
+            "2026-01-30",
+            "2026-02-02",
+            "2026-02-06",
+            "2026-02-09",
+            "2026-02-13",
+            "2026-02-16",
+            "2026-02-20",
+            "2026-02-23",
+            "2026-02-27",
+            "2026-03-02",
+            "2026-03-06",
+            "2026-03-09",
+            "2026-03-13",
+            "2026-03-16",
+            "2026-03-20",
+            "2026-03-23",
+            "2026-03-27",
+            "2026-03-30",
+        ]
+
+    def test_range_crossing_december_into_january(self):
+        # "this month" (Nov) through "next Jan" walks Nov -> Dec -> Jan, exercising the
+        # mo == 12 rollover branch mid-loop.
+        assert parse_relative_dates("Mondays in this month through next Jan", BASE_DATE) == [
+            "2025-11-03",
+            "2025-11-10",
+            "2025-11-17",
+            "2025-11-24",
+            "2025-12-01",
+            "2025-12-08",
+            "2025-12-15",
+            "2025-12-22",
+            "2025-12-29",
+            "2026-01-05",
+            "2026-01-12",
+            "2026-01-19",
+            "2026-01-26",
+        ]
+
+
 class TestLastWeekdayBranch:
     """Characterization tests for the "last/previous <weekday>" branch of
     ``parse_relative_date``. This branch currently hand-rolls the same


### PR DESCRIPTION
## Issue

`parse_relative_dates`'s "`<weekdays>` in `<month-ref>` through `<month-ref>`" branch (e.g. `"Mondays and Fridays in next Jan through Mar"`) hand-rolled a December→January month rollover to walk from the start month to the end month inclusive:

```python
if mo == 12:
    y, mo = y + 1, 1
else:
    mo += 1
```

This is the exact same hand-rolled-rollover pattern that #144 just replaced with the shared `add_months` helper in `opentable_info_gathering.py`'s `get_first_weekend_of_next_month_offsets` — a sibling instance the CLAUDE.md code-review convention calls out to sweep for mechanically (same bug-pattern class, different call site).

## Improvement

Replaced the `if`/`else` with `add_months(date(y, mo, 1), 1)`, using the module's own already-defined helper. `day=1` never triggers `clamp_day`'s end-of-month clamping, so this is behavior-preserving for every `(year, month)` pair.

## Safety

- This branch had **zero** direct test coverage. Added `TestWeekdaysInMonthRangeBranch` characterization tests first, pinning the existing `__main__`-documented example plus a new case (`"Mondays in this month through next Jan"`) that specifically crosses the Dec→Jan boundary to exercise the rollover.
- Numerically verified old vs. new rollover logic produce identical `(year, month)` output across 10 years × 12 months before touching the source.
- Test count: 216 → 218 passing (both new tests pass against the pre-refactor code, then again after the refactor).
- `ruff check` / `ruff format --check` clean on both touched files.

🤖 Generated as part of the hourly automated refactor job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01McQhyyroFKNAcv14WCsiVd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-preserving refactor in date parsing with new tests pinning multi-month and year-boundary output; low blast radius.
> 
> **Overview**
> In **`parse_relative_dates`**, the **"<weekdays> in `<month>` through `<month>`"** loop no longer hand-rolls December→January rollover (`mo == 12` / `mo += 1`). It advances with **`add_months(date(y, mo, 1), 1)`** and reads **`year`/`month`** from the result—the same helper used elsewhere in the module.
> 
> Adds **`TestWeekdaysInMonthRangeBranch`** with two characterization tests: a multi-month weekday span (`next Jan through Mar`) and a range that crosses **Dec→Jan** (`this month through next Jan`), covering the previously untested branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c4aef750ef88b2eb4bab305c93827463d32495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->