### PR TITLE
refactor(custom_task): derive eval_config target via get_import_path

### DIFF
--- a/evaluation/custom_task.py
+++ b/evaluation/custom_task.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata
+from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
 
 
 class CustomTaskResult(BaseModel):
@@ -38,6 +38,6 @@ def generate_task_config(
         task=task,
         url=url,
         user_metadata=UserMetadata.model_validate(user_metadata or {}),
-        eval_config={"_target_": "evaluation.custom_task.CustomTaskCaptureMetric"},
+        eval_config={"_target_": get_import_path(CustomTaskCaptureMetric)},
         use_cdp=use_cdp,
     )

--- a/tests/test_custom_task.py
+++ b/tests/test_custom_task.py
@@ -1,0 +1,83 @@
+"""Characterization tests for ``evaluation.custom_task``.
+
+These pin the current behavior of ``generate_task_config`` -- in particular the
+``eval_config["_target_"]`` string it embeds, which is hand-written as a literal
+(``"evaluation.custom_task.CustomTaskCaptureMetric"``) rather than derived via
+``navi_bench.base.get_import_path`` the way every other domain matcher's
+``generate_task_config``/``build_task_config`` call site does -- before that literal is
+replaced with ``get_import_path(CustomTaskCaptureMetric)``. Also pins
+``CustomTaskCaptureMetric``'s reset/update/compute score semantics.
+"""
+
+import asyncio
+
+from evaluation.custom_task import CustomTaskCaptureMetric, CustomTaskResult, generate_task_config
+from navi_bench.base import UserMetadata
+
+
+class TestGenerateTaskConfig:
+    def test_eval_config_target_points_at_capture_metric(self):
+        config = generate_task_config(task="do a thing", url="https://example.com")
+
+        assert config.eval_config == {"_target_": "evaluation.custom_task.CustomTaskCaptureMetric"}
+
+    def test_basic_fields_passed_through(self):
+        config = generate_task_config(task="do a thing", url="https://example.com", use_cdp=True)
+
+        assert config.task == "do a thing"
+        assert config.url == "https://example.com"
+        assert config.use_cdp is True
+
+    def test_default_use_cdp_is_false(self):
+        config = generate_task_config(task="do a thing", url="https://example.com")
+
+        assert config.use_cdp is False
+
+    def test_missing_user_metadata_defaults(self):
+        config = generate_task_config(task="do a thing", url="https://example.com")
+
+        assert config.user_metadata == UserMetadata()
+
+    def test_user_metadata_dict_is_validated(self):
+        config = generate_task_config(
+            task="do a thing",
+            url="https://example.com",
+            user_metadata={"location": "New York, NY, United States", "timezone": "America/New_York"},
+        )
+
+        assert config.user_metadata.location == "New York, NY, United States"
+        assert config.user_metadata.timezone == "America/New_York"
+
+
+class TestCustomTaskCaptureMetric:
+    def test_no_answer_message_scores_zero(self):
+        metric = CustomTaskCaptureMetric()
+
+        result = asyncio.run(metric.compute())
+
+        assert result == CustomTaskResult(score=0.0, final_answer=None)
+
+    def test_answer_message_scores_one(self):
+        metric = CustomTaskCaptureMetric()
+        asyncio.run(metric.update(answer_message="the final answer"))
+
+        result = asyncio.run(metric.compute())
+
+        assert result == CustomTaskResult(score=1.0, final_answer="the final answer")
+
+    def test_update_without_answer_message_kwarg_is_a_noop(self):
+        metric = CustomTaskCaptureMetric()
+        asyncio.run(metric.update(other_kwarg="ignored"))
+
+        result = asyncio.run(metric.compute())
+
+        assert result == CustomTaskResult(score=0.0, final_answer=None)
+
+    def test_reset_clears_previously_captured_answer(self):
+        metric = CustomTaskCaptureMetric()
+        asyncio.run(metric.update(answer_message="first"))
+        asyncio.run(metric.reset())
+
+        result = asyncio.run(metric.compute())
+
+        assert result == CustomTaskResult(score=0.0, final_answer=None)


### PR DESCRIPTION
## Issue

`evaluation/custom_task.py`'s `generate_task_config()` hand-wrote the `eval_config["_target_"]` value as a literal string:

```python
eval_config={"_target_": "evaluation.custom_task.CustomTaskCaptureMetric"},
```

Every other domain matcher's `generate_task_config`/`build_task_config` call site (apartments, craigslist, resy, opentable, google_flights) derives this same kind of string via `navi_bench.base.get_import_path(eval_class)` instead of hand-writing it — see `build_task_config` in `navi_bench/base.py`:

```python
eval_config = {"_target_": get_import_path(eval_class), **eval_kwargs}
```

`custom_task.py` doesn't use `build_task_config` directly (it returns a `CustomTaskConfig` subclass with an extra `use_cdp` field, and takes no `eval_kwargs`), so it had drifted into duplicating the import path as a literal instead of reusing the existing helper. That literal can silently go stale if `CustomTaskCaptureMetric` is ever renamed or moved, since nothing would catch the mismatch until instantiation.

## Fix

Swap the literal for `get_import_path(CustomTaskCaptureMetric)`, which resolves to the exact same string (`"evaluation.custom_task.CustomTaskCaptureMetric"`) today, but can no longer drift from the class.

## Why it's safe

- `custom_task.py` had **zero** test coverage before this change. Added `tests/test_custom_task.py` with characterization tests that pin the pre-refactor `eval_config` target string and `CustomTaskCaptureMetric`'s reset/update/compute semantics, written and run against the *original* code first.
- The change is a single-line, one-file swap with no behavior change: `get_import_path` returns `f"{obj.__module__}.{obj.__qualname__}"`, which for `CustomTaskCaptureMetric` is byte-for-byte the same string that was previously hardcoded.
- Full suite: **218 passed** before this change, **227 passed** after (9 new characterization tests added, 0 removed, 0 modified in existing files).
- `ruff check` and `ruff format --check` both clean on the touched files.

No other files reference `evaluation.custom_task`, so the blast radius is contained to this module.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RX5q34ikcpUyxqNawCQ3ND)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line refactor with no intended behavior change; new tests lock existing semantics.
> 
> **Overview**
> **`generate_task_config`** in `evaluation/custom_task.py` now sets `eval_config["_target_"]` with **`get_import_path(CustomTaskCaptureMetric)`** instead of a hardcoded import string, matching how other matchers use **`build_task_config`**.
> 
> Adds **`tests/test_custom_task.py`** with characterization tests for that target string, config field pass-through, and **`CustomTaskCaptureMetric`** reset/update/compute scoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad18438b247d863cd6ef92b659fcf8b8717947a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->