### PR TITLE
docs(tests): fix five more stale "before a refactor" docstrings

### DIFF
--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -474,11 +474,11 @@ class TestDateOptions:
 
 
 class TestGetDaysUntilDateUpcomingWeekday:
-    """Pin the "for the upcoming <weekday>" branch of ``get_days_until_date`` ahead of a
-    refactor that delegates its next-occurrence math to the shared
-    ``relative_dates.days_until_next_weekday`` helper (used identically by
-    ``relative_dates.parse_relative_date``'s weekday branch). ``today`` is 2025-11-06, a
-    Thursday, chosen so the Thursday case exercises the "target is today" edge (rolls to 7).
+    """Pin the "for the upcoming <weekday>" branch of ``get_days_until_date``, which delegates
+    its next-occurrence math to the shared ``relative_dates.days_until_next_weekday`` helper
+    (used identically by ``relative_dates.parse_relative_date``'s weekday branch). ``today`` is
+    2025-11-06, a Thursday, chosen so the Thursday case exercises the "target is today" edge
+    (rolls to 7).
     """
 
     _TODAY = datetime(2025, 11, 6, tzinfo=timezone.utc)  # Thursday
@@ -500,11 +500,10 @@ class TestGetDaysUntilDateUpcomingWeekday:
 
 
 class TestGetFirstWeekendOfNextMonthOffsets:
-    """Pin the exact offsets returned by ``get_first_weekend_of_next_month_offsets`` ahead of a
-    refactor that delegates its next-month rollover math to the shared
-    ``relative_dates.add_months`` helper instead of hand-rolling the "month == 12" check.
-    Includes the December -> January year-rollover case, since that is exactly the branch the
-    refactor touches.
+    """Pin the exact offsets returned by ``get_first_weekend_of_next_month_offsets``, which
+    delegates its next-month rollover math to the shared ``relative_dates.add_months`` helper
+    rather than hand-rolling the "month == 12" check. Includes the December -> January
+    year-rollover case, since that is exactly the branch this helper needs to preserve.
     """
 
     def test_regular_month_rollover(self):

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -156,12 +156,11 @@ class TestMonthDayRangePattern:
 class TestWeekdaysInMonthRangeBranch:
     """Characterization tests for the ``parse_relative_dates`` "<weekdays> in <month-ref>
     through <month-ref>" branch (e.g. "Mondays and Fridays in next Jan through Mar"), which
-    hand-rolls a ``if mo == 12: y, mo = y + 1, 1 else: mo += 1`` month-rollover step to walk
-    from the start month to the end month inclusive. Same hand-rolled-rollover pattern as the
-    one already replaced with the shared ``add_months`` helper in
+    walks from the start month to the end month inclusive using the shared ``add_months``
+    helper for its month-rollover step, the same helper already used by
     ``opentable_info_gathering.get_first_weekend_of_next_month_offsets`` (#144); this branch's
     loop crosses a December -> January boundary whenever the requested range spans the turn
-    of the year, exercising the same rollover this helper would need to preserve.
+    of the year, exercising that rollover.
     """
 
     def test_single_month_range(self):
@@ -216,12 +215,11 @@ class TestWeekdaysInMonthRangeBranch:
 
 class TestLastWeekdayBranch:
     """Characterization tests for the "last/previous <weekday>" branch of
-    ``parse_relative_date``. This branch currently hand-rolls the same
-    ``(target - current) % 7``-with-zero-bumped-to-7 math as
-    ``days_until_next_weekday``, just with the two weekday arguments swapped
-    (``(base_wd - target_wd) % 7`` instead of ``(target_wd - base_wd) % 7``),
-    before it is refactored to call the shared helper directly. BASE_DATE
-    (2025-11-06) is a Thursday.
+    ``parse_relative_date``. This branch delegates to the shared
+    ``days_until_next_weekday`` helper (the same ``(target - current) % 7``-with-
+    zero-bumped-to-7 math used elsewhere in this module), just with the two weekday
+    arguments swapped since it's counting backwards. BASE_DATE (2025-11-06) is a
+    Thursday.
     """
 
     @pytest.mark.parametrize(

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,14 +1,13 @@
 """Characterization tests for the per-action "details" strings rendered inside each
 step's action card by ``generate_visualization_html``.
 
-These pin the CURRENT behavior of the inline field-by-field ``details.append(...)``
-chain in ``generate_visualization_html`` (one ``if "<key>" in action: ...`` per
-recognized action field, plus an ``action_type``-specific block for form-recording
-actions) before it is extracted into a standalone ``_build_action_detail_lines``
-helper. They exercise the public entry point end-to-end (rather than a not-yet-existing
-helper) via the OpenAI-style ``tool_calls`` parsing path used in production
+These pin the behavior of ``_build_action_detail_lines`` (one ``if "<key>" in action: ...``
+per recognized action field, plus an ``action_type``-specific block for form-recording
+actions), extracted from what used to be an inline ``details.append(...)`` chain in
+``generate_visualization_html``. They exercise it via the public entry point end-to-end
+using the OpenAI-style ``tool_calls`` parsing path used in production
 (``evaluation/eval_n1.py`` appends ``message.model_dump(...)`` messages in this shape),
-so a refactor of the inline chain can be verified as behavior-preserving.
+so future changes to the shared field-check logic can be verified as behavior-preserving.
 """
 
 import json


### PR DESCRIPTION
## Issue

PR #142 fixed characterization-test docstrings that were written as "pin behavior ahead of a refactor that does X" but where the referenced refactor had already landed — leaving misleading text that could send a future refactor pass chasing work that's already done. That PR's own description called out the risk explicitly.

Auditing the same pattern mechanically across the whole test suite (per this repo's own code-review convention: check every instance of a bug pattern, not just the one you found) turned up five more instances #142 missed, because in each case the *same commit* that performed the refactor also introduced the test with the stale "not yet done" wording — so the docstring was stale on arrival, not from later drift:

- `tests/test_opentable_info_gathering.py::TestGetDaysUntilDateUpcomingWeekday` — said "ahead of a refactor that delegates ... to `days_until_next_weekday`", but PR #136 added this exact delegation in the same commit.
- `tests/test_opentable_info_gathering.py::TestGetFirstWeekendOfNextMonthOffsets` — said "ahead of a refactor that delegates ... to `add_months`", but PR #144 added this exact delegation in the same commit.
- `tests/test_relative_dates.py::TestLastWeekdayBranch` — said "before it is refactored to call the shared helper directly", but PR #139 added this exact delegation in the same commit.
- `tests/test_relative_dates.py::TestWeekdaysInMonthRangeBranch` — said "hand-rolls ... " describing the pre-`add_months` code, but PR #145 added this exact delegation in the same commit.
- `tests/test_vis.py` module docstring — said "before it is extracted into a standalone `_build_action_detail_lines` helper", but PR #120 added that exact extraction in the same commit.

## Fix

Reworded all five docstrings to describe the extracted/shared-helper behavior as already-current (matching the phrasing #142 used for its fixes), with no change to test logic, fixtures, or assertions.

## Safety

- Text-only change (docstrings/comments), no source or test-body edits.
- `pytest tests/` — 227/227 pass, identical to before the change.
- `ruff check` / `ruff format --check` — clean.

🤖 Generated with the yutori-ai automated navi-bench refactor job (Claude Sonnet 5).


---
_Generated by [Claude Code](https://claude.ai/code/session_018E8jeN7Xas5HyZRMHxBiuF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits in test files; no runtime or assertion changes.
> 
> **Overview**
> Follow-up to PR #142: five characterization tests still had docstrings written as if refactors were **future** work, even though the delegations to **`days_until_next_weekday`**, **`add_months`**, and **`_build_action_detail_lines`** were already in place when those tests landed.
> 
> **`tests/test_opentable_info_gathering.py`** — class docstrings for upcoming-weekday and first-weekend-of-next-month tests now say the code **delegates** to the shared helpers (not "ahead of" that change).
> 
> **`tests/test_relative_dates.py`** — weekday-in-month-range and last/previous weekday docstrings now describe **`add_months`** / **`days_until_next_weekday`** as current behavior instead of hand-rolled or not-yet-refactored logic.
> 
> **`tests/test_vis.py`** — module docstring now states tests pin **`_build_action_detail_lines`** after extraction, not before.
> 
> Assertions, fixtures, and production code are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5c8b6141ebaf2cb332678fb2aee6947f37d388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->