### PR TITLE
refactor: extract safe_evaluate helper, fix uncaught OpenTable evaluate crash

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -1,7 +1,7 @@
 import importlib
 import json
 import types
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
@@ -10,6 +10,7 @@ from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value
 from loguru import logger
+from playwright.async_api import Error as PlaywrightError
 from pydantic import BaseModel, Field
 
 
@@ -21,6 +22,33 @@ def get_import_path(obj: Any) -> str:
 def read_sidecar(module_file: str, filename: str) -> str:
     """Read a sidecar file located next to ``module_file`` (typically ``__file__``)."""
     return (Path(module_file).parent / filename).read_text()
+
+
+async def safe_evaluate(
+    page: Any,
+    script: str,
+    *,
+    default: Any,
+    log_message: str,
+    log_fn: Callable[[str], None] = logger.warning,
+    on_success: Callable[[Any], None] | None = None,
+) -> Any:
+    """Run ``page.evaluate(script)``, returning ``default`` and logging on failure.
+
+    A live page can navigate away or throw a JS error mid-evaluation while a task
+    verifier is polling it; callers should degrade gracefully instead of crashing the
+    whole verification step. ``on_success`` (if given) is invoked with the evaluated
+    value only when evaluation succeeds, matching call sites that previously logged
+    only on the happy path.
+    """
+    try:
+        value = await page.evaluate(script)
+    except PlaywrightError as exc:
+        log_fn(f"{log_message}: {exc}")
+        return default
+    if on_success is not None:
+        on_success(value)
+    return value
 
 
 def strip_url_scheme(url: str) -> str:

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -21,6 +21,7 @@ from navi_bench.base import (
     hour_to_12h_period,
     read_sidecar,
     repr_with_attr,
+    safe_evaluate,
 )
 from navi_bench.dates import (
     ensure_resolved_dates,
@@ -122,7 +123,12 @@ class OpenTableInfoGathering(BaseMetric):
     async def update(self, **kwargs) -> None:
         inputs: InputDict = kwargs
         page = inputs["page"]
-        infos: list[InfoDict] = await page.evaluate(self.js_script)
+        infos: list[InfoDict] = await safe_evaluate(
+            page,
+            self.js_script,
+            default=[],
+            log_message="OpenTableInfoGathering.update: Could not gather intermediate infos",
+        )
         logger.info(f"OpenTableInfoGathering.update gathered {len(infos)} intermediate infos: {infos}")
 
         self._all_infos.append(infos)

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlparse
 
 from beartype import beartype
 from loguru import logger
-from playwright.async_api import Error as PlaywrightError, Page
+from playwright.async_api import Page
 
 from navi_bench.base import (
     BaseMetric,
@@ -21,6 +21,7 @@ from navi_bench.base import (
     hour_to_12h_period,
     read_sidecar,
     repr_with_attr,
+    safe_evaluate,
 )
 from navi_bench.dates import (
     ensure_resolved_dates,
@@ -192,12 +193,13 @@ class ResyUrlMatch(BaseMetric):
         page = inputs["page"]
 
         # Check if the page has "no availability" message (default behavior)
-        try:
-            has_no_availability = await page.evaluate(self.js_script)
-            logger.info(f"ResyUrlMatch.update: no_availability={has_no_availability} for URL: {url}")
-        except PlaywrightError as e:
-            logger.warning(f"ResyUrlMatch.update: Could not check no_availability: {e}")
-            has_no_availability = False
+        has_no_availability = await safe_evaluate(
+            page,
+            self.js_script,
+            default=False,
+            log_message="ResyUrlMatch.update: Could not check no_availability",
+            on_success=lambda value: logger.info(f"ResyUrlMatch.update: no_availability={value} for URL: {url}"),
+        )
 
         availabilities = await self._extract_availabilities(page)
         normalized_url = self._normalize_url(url, ignore_seats_time=has_no_availability)
@@ -409,11 +411,13 @@ class ResyUrlMatch(BaseMetric):
         return self._normalize_url(url, ignore_seats_time=False, include_time=False)
 
     async def _extract_availabilities(self, page: PageLike) -> list[AvailabilitySlot]:
-        try:
-            raw_availabilities = await page.evaluate(self.availability_script)
-        except PlaywrightError as exc:
-            logger.debug(f"ResyUrlMatch.update: Could not extract availabilities: {exc}")
-            return []
+        raw_availabilities = await safe_evaluate(
+            page,
+            self.availability_script,
+            default=[],
+            log_message="ResyUrlMatch.update: Could not extract availabilities",
+            log_fn=logger.debug,
+        )
 
         if not isinstance(raw_availabilities, list):
             logger.debug("ResyUrlMatch.update: availability extractor returned non-list")

--- a/tests/test_safe_evaluate.py
+++ b/tests/test_safe_evaluate.py
@@ -1,0 +1,86 @@
+"""Tests for ``safe_evaluate``, extracted from the ``try: await page.evaluate(...) except
+PlaywrightError: log + return default`` pattern that ``ResyUrlMatch.update``,
+``ResyUrlMatch._extract_availabilities``, and (previously uncaught, now fixed)
+``OpenTableInfoGathering.update`` each needed against a live page that can navigate away or
+throw a JS error mid-evaluation.
+"""
+
+import pytest
+from playwright.async_api import Error as PlaywrightError
+
+from navi_bench.base import safe_evaluate
+
+
+class _FakePage:
+    def __init__(self, result=None, error: Exception | None = None):
+        self._result = result
+        self._error = error
+        self.scripts: list[str] = []
+
+    async def evaluate(self, script: str):
+        self.scripts.append(script)
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_safe_evaluate_returns_evaluated_value_on_success():
+    page = _FakePage(result=["a", "b"])
+
+    value = await safe_evaluate(page, "script", default=[], log_message="failed")
+
+    assert value == ["a", "b"]
+    assert page.scripts == ["script"]
+
+
+@pytest.mark.asyncio
+async def test_safe_evaluate_returns_default_on_playwright_error(caplog):
+    page = _FakePage(error=PlaywrightError("boom"))
+
+    value = await safe_evaluate(page, "script", default=[], log_message="Could not evaluate")
+
+    assert value == []
+
+
+@pytest.mark.asyncio
+async def test_safe_evaluate_logs_with_custom_log_fn():
+    page = _FakePage(error=PlaywrightError("boom"))
+    logged: list[str] = []
+
+    value = await safe_evaluate(page, "script", default=None, log_message="Could not evaluate", log_fn=logged.append)
+
+    assert value is None
+    assert len(logged) == 1
+    assert "Could not evaluate" in logged[0]
+    assert "boom" in logged[0]
+
+
+@pytest.mark.asyncio
+async def test_safe_evaluate_invokes_on_success_only_when_evaluate_succeeds():
+    page = _FakePage(result=True)
+    seen: list[bool] = []
+
+    value = await safe_evaluate(page, "script", default=False, log_message="failed", on_success=seen.append)
+
+    assert value is True
+    assert seen == [True]
+
+
+@pytest.mark.asyncio
+async def test_safe_evaluate_does_not_invoke_on_success_when_evaluate_fails():
+    page = _FakePage(error=PlaywrightError("boom"))
+    seen: list[bool] = []
+
+    value = await safe_evaluate(page, "script", default=False, log_message="failed", on_success=seen.append)
+
+    assert value is False
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_safe_evaluate_lets_unrelated_exceptions_propagate():
+    page = _FakePage(error=ValueError("not a playwright error"))
+
+    with pytest.raises(ValueError):
+        await safe_evaluate(page, "script", default=None, log_message="failed")


### PR DESCRIPTION
## What

`ResyUrlMatch.update` and `ResyUrlMatch._extract_availabilities` each defensively wrap a live-page `page.evaluate(...)` call in `try/except PlaywrightError`, logging and falling back to a safe default — the page can navigate, close, or throw a JS error mid-evaluation while the task verifier is polling it. `OpenTableInfoGathering.update` makes the same kind of `page.evaluate(...)` call in its own `update()` polling loop but had **no try/except at all**. If the page navigates away or its DOM shape changes mid-eval, the whole verification step crashes instead of degrading gracefully like its siblings — and no test exercised this gap (the fake `Page.evaluate` in `tests/test_opentable_info_gathering.py` never raises).

This PR extracts `navi_bench.base.safe_evaluate(page, script, *, default, log_message, log_fn=logger.warning, on_success=None)` and has all three call sites use it.

## Why it's safe

- **The two Resy call sites: no behavioral change.** Same exception type (`PlaywrightError`), same log messages, same log levels (`on_success` preserves `update`'s existing "log the resolved value only on success" behavior exactly; `log_fn=logger.debug` preserves `_extract_availabilities`' existing debug-vs-warning level), same fallback defaults.
- **The OpenTable call site is the intended fix, not a refactor:** an uncaught crash becomes graceful degradation (empty `infos` list + a warning log), matching the pattern already used by the other 2 of 3 call sites in this file family.
- Unrelated exceptions still propagate uncaught in all three cases.
- Touches 3 production files (`navi_bench/base.py`, `navi_bench/resy/resy_url_match.py`, `navi_bench/opentable/opentable_info_gathering.py`) plus 1 new test file.

## Verification

- Added `tests/test_safe_evaluate.py` covering: success passthrough, `PlaywrightError` → default, custom `log_fn`, `on_success` firing only when evaluate succeeds (not on failure), and unrelated exceptions still propagating.
- `python3 -m pytest tests/test_safe_evaluate.py tests/test_opentable_info_gathering.py tests/test_resy_url_match.py` — 89 passed.
- `ruff check` / `ruff format --check` clean on all changed files.

(Note: the full `tests/` suite has two unrelated pre-existing collection errors in this sandbox from missing `google.protobuf`/`yutori` packages, in `test_base.py`/`test_vis.py` — unrelated to this change, confirmed by inspecting the failing import chains.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeEUJNYneT6wNwZfnfa77c)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with preserved Resy behavior and a targeted OpenTable resilience fix; covered by new unit tests and low blast radius.
> 
> **Overview**
> Introduces **`safe_evaluate`** in `navi_bench.base` to wrap `page.evaluate` with **`PlaywrightError`** handling: log, return a caller-chosen default, optional **`on_success`** callback, and configurable **`log_fn`**. Non-Playwright errors still propagate.
> 
> **Resy** `ResyUrlMatch.update` and `_extract_availabilities` switch to the helper with the same defaults, log levels, and success-only logging as before. **OpenTable** `OpenTableInfoGathering.update` is the behavior change: a failed evaluate now returns an empty info list and logs a warning instead of aborting verification.
> 
> Adds **`tests/test_safe_evaluate.py`** for success, Playwright failure, custom logging, `on_success` gating, and unrelated exception propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078d6e70865bfc73933846198e72ea4b95245918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->