### PR TITLE
refactor(resy): extract _BOUNDARY_REASON_MESSAGE_TEMPLATES in _describe_conditional_reason

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -131,6 +131,19 @@ _CONDITIONAL_REASON_DESCRIPTIONS = {
     "no_available_slots": "unavailable slot inferred because page lists no availability",
 }
 
+# Message templates for the reason-code prefixes that carry a ":"-delimited suffix (the
+# missing time or times), checked via `reason.startswith(prefix)` in
+# `ResyUrlMatch._describe_conditional_reason`. `{}` is filled in with the suffix.
+_BOUNDARY_REASON_MESSAGE_TEMPLATES = {
+    "neighbors_not_seen": "unavailable slot needs adjacent times to be visible (missing neighbors: {})",
+    "boundary_previous_not_seen": (
+        "unavailable slot earlier than visible range requires earliest time to be visible (missing: {})"
+    ),
+    "boundary_next_not_seen": (
+        "unavailable slot later than visible range requires latest time to be visible (missing: {})"
+    ),
+}
+
 
 @beartype
 class ResyUrlMatch(BaseMetric):
@@ -604,18 +617,10 @@ class ResyUrlMatch(BaseMetric):
             return "available slot exists but was not observed"
         if reason == "no_slots_but_wrong_time":
             return "URL time does not match ground truth and no availability data to verify"
-        if reason.startswith("neighbors_not_seen"):
-            return (
-                f"unavailable slot needs adjacent times to be visible (missing neighbors: {reason.split(':', 1)[-1]})"
-            )
-        if reason.startswith("boundary_previous_not_seen"):
-            missing = reason.split(":", 1)[-1]
-            return (
-                f"unavailable slot earlier than visible range requires earliest time to be visible (missing: {missing})"
-            )
-        if reason.startswith("boundary_next_not_seen"):
-            missing = reason.split(":", 1)[-1]
-            return f"unavailable slot later than visible range requires latest time to be visible (missing: {missing})"
+
+        for prefix, template in _BOUNDARY_REASON_MESSAGE_TEMPLATES.items():
+            if reason.startswith(prefix):
+                return template.format(reason.split(":", 1)[-1])
 
         availability_status = "with availabilities" if has_availabilities else "with no availabilities listed"
         return (

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -18,6 +18,7 @@ from navi_bench.resy.resy_url_match import (
     RESTAURANT_METADATA,
     ResyQueryState,
     ResyUrlMatch,
+    _BOUNDARY_REASON_MESSAGE_TEMPLATES,
     _parse_optional_int,
     _render_placeholders_in_queries_all,
     _render_placeholders_in_queries_any,
@@ -215,6 +216,24 @@ class TestDescribeConditionalReason:
             "conditional coverage reason=some_unknown_reason "
             "(with no availabilities listed; gt_time=1900; url_time=None)"
         )
+
+
+class TestBoundaryReasonMessageTemplates:
+    """Direct tests for ``_BOUNDARY_REASON_MESSAGE_TEMPLATES``, extracted from the three
+    near-identical ``if reason.startswith(prefix): ... reason.split(':', 1)[-1] ...`` blocks
+    that used to live inline in ``_describe_conditional_reason``.
+    """
+
+    def test_template_keys_match_previously_hardcoded_prefixes(self):
+        assert set(_BOUNDARY_REASON_MESSAGE_TEMPLATES) == {
+            "neighbors_not_seen",
+            "boundary_previous_not_seen",
+            "boundary_next_not_seen",
+        }
+
+    def test_each_template_has_exactly_one_format_placeholder(self):
+        for template in _BOUNDARY_REASON_MESSAGE_TEMPLATES.values():
+            assert template.format("X").count("X") == 1
 
 
 class TestParseTimeToHour:


### PR DESCRIPTION
## Issue

`ResyUrlMatch._describe_conditional_reason` (in `navi_bench/resy/resy_url_match.py`) repeated the same shape three times for the `neighbors_not_seen`/`boundary_previous_not_seen`/`boundary_next_not_seen` reason codes:

```python
if reason.startswith("neighbors_not_seen"):
    return f"unavailable slot needs adjacent times to be visible (missing neighbors: {reason.split(':', 1)[-1]})"
if reason.startswith("boundary_previous_not_seen"):
    missing = reason.split(":", 1)[-1]
    return f"unavailable slot earlier than visible range requires earliest time to be visible (missing: {missing})"
if reason.startswith("boundary_next_not_seen"):
    missing = reason.split(":", 1)[-1]
    return f"unavailable slot later than visible range requires latest time to be visible (missing: {missing})"
```

Each does `reason.split(':', 1)[-1]` to pull the suffix out of a `:`-delimited reason code and embed it in an otherwise-fixed message.

## Why this is an improvement

Same "duplicated small block → module-level dict" pattern this file already uses for `_CONDITIONAL_REASON_DESCRIPTIONS` (the fixed-string reason codes just above this one). Extracted `_BOUNDARY_REASON_MESSAGE_TEMPLATES` and replaced the three `if` blocks with a single loop over `.items()`.

## Why it's safe

- `_describe_conditional_reason` already has full characterization-test coverage in `tests/test_resy_url_match.py::TestDescribeConditionalReason`, including one test per branch (`test_neighbors_not_seen_includes_missing_suffix`, `test_boundary_previous_not_seen_includes_missing_suffix`, `test_boundary_next_not_seen_includes_missing_suffix`) plus the fallback path — so this refactor was mechanically verifiable without adding new characterization tests first.
- Added a small direct test class (`TestBoundaryReasonMessageTemplates`) for the new constant.
- Full test suite: **233 → 235 passing** (2 new tests), no regressions. `ruff check` / `ruff format --check` clean.
- Change is contained to 2 files: `navi_bench/resy/resy_url_match.py` and `tests/test_resy_url_match.py`.

Note: an earlier PR #141 on this same branch name (`_singleton_choices` in `opentable_info_gathering.py`) was already merged in a prior run — this PR is unrelated, new work.

🤖 Generated as part of the hourly automated refactor job.

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01HCLMtR3AFfLpnQvjvoafkL)_