### PR TITLE
docs(tests): fix stale "before a refactor" docstring in test_custom_task.py

### DIFF
--- a/tests/test_custom_task.py
+++ b/tests/test_custom_task.py
@@ -1,12 +1,11 @@
 """Characterization tests for ``evaluation.custom_task``.
 
 These pin the current behavior of ``generate_task_config`` -- in particular the
-``eval_config["_target_"]`` string it embeds, which is hand-written as a literal
-(``"evaluation.custom_task.CustomTaskCaptureMetric"``) rather than derived via
-``navi_bench.base.get_import_path`` the way every other domain matcher's
-``generate_task_config``/``build_task_config`` call site does -- before that literal is
-replaced with ``get_import_path(CustomTaskCaptureMetric)``. Also pins
-``CustomTaskCaptureMetric``'s reset/update/compute score semantics.
+``eval_config["_target_"]`` string it embeds, which is derived via
+``navi_bench.base.get_import_path(CustomTaskCaptureMetric)`` the way every other domain
+matcher's ``generate_task_config``/``build_task_config`` call site does, rather than
+hand-written as a literal string that could drift if the class is renamed or moved. Also
+pins ``CustomTaskCaptureMetric``'s reset/update/compute score semantics.
 """
 
 import asyncio


### PR DESCRIPTION
## What

`tests/test_custom_task.py`'s module docstring described `generate_task_config`'s `eval_config["_target_"]` string as "hand-written as a literal ... before that literal is replaced with `get_import_path(CustomTaskCaptureMetric)`" — i.e. it documented the refactor as *not yet done*.

That replacement had already landed in #146, which is the same commit that introduced this test file — so the docstring was stale on arrival. #147 (opened later that same evening) explicitly fixed "five more" instances of this exact pattern elsewhere in the suite, but didn't catch this sixth one, likely because it was introduced by the immediately-preceding commit rather than an older one.

## Why this is an improvement

This is the same class of bug PR #142 and #147 already treated as worth fixing in this repo: a characterization-test docstring that misrepresents current behavior as pending work. Left as-is, it risks misleading a future refactor pass (human or automated) into re-attempting work that's already merged — the exact risk #142/#147 called out in their own descriptions.

A repo-wide grep for the same "ahead of a refactor" / "before it is refactored" / "hand-written as a literal" phrasing turned up no other remaining instances, so this closes out the pattern.

## Why this is safe

- Text-only change to a docstring — no source or test-body changes.
- `uv run pytest tests/` → 233/233 pass, identical before and after.
- `uv run ruff check` / `ruff format --check` → clean.

## Test plan

- [x] `uv run pytest tests/` — 233 passed
- [x] `uv run ruff check tests/test_custom_task.py` — clean
- [x] `uv run ruff format --check tests/test_custom_task.py` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qu7P3FNarUZfDW14NJX6GB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only change in a test file; no runtime or test logic modified.
> 
> **Overview**
> Updates the module docstring in `tests/test_custom_task.py` so it describes **current** behavior: `generate_task_config` sets `eval_config["_target_"]` via `get_import_path(CustomTaskCaptureMetric)`, consistent with other domain matchers.
> 
> It no longer reads as if a literal `_target_` string still needs to be replaced—that refactor already landed in #146. This matches the docstring cleanup done in #142/#147 elsewhere in the suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd561449a510f0cbbba725c6ef575bf1fd2e61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->