### PR TITLE
fix(relative_dates): delegate year-bump date construction to clamp_day

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -206,7 +206,9 @@ def _choose_occurrence(target_this_year: date, base: date, modifier: str) -> dat
     shift = _year_shift_for_modifier(target_this_year, base, modifier)
     if shift == 0:
         return target_this_year
-    return target_this_year.replace(year=target_this_year.year + shift)
+    # clamp_day (not date.replace/date()) so Feb 29 shifted across a non-leap year
+    # (e.g. "next Feb 29") clamps to Feb 28 instead of raising ValueError.
+    return clamp_day(target_this_year.year + shift, target_this_year.month, target_this_year.day)
 
 
 def _shift_for_modifier(mod: str) -> int:
@@ -661,10 +663,12 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
             try:
                 end = parse_relative_date(m.group(3), end_base, return_iso=False)
             except ValueError:
-                # fallback: resolve relative to `base`, and if end < start, bump a year
+                # fallback: resolve relative to `base`, and if end < start, bump a year.
+                # Use clamp_day (not date()) so a Feb 29 end bumped into a non-leap
+                # year clamps to Feb 28 instead of raising ValueError.
                 end = parse_relative_date(m.group(3), base, return_iso=False)
                 if end < start:
-                    end = date(end.year + 1, end.month, end.day)
+                    end = clamp_day(end.year + 1, end.month, end.day)
         except ValueError:
             # maybe there is no weekday filter; treat the entire thing as "from X through Y"
             wds = set()

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -256,3 +256,92 @@ class TestDaysUntilNextWeekday:
     )
     def test_future_weekday_offset(self, current_weekday, target_weekday, expected):
         assert days_until_next_weekday(current_weekday, target_weekday) == expected
+
+
+class TestFeb29YearBump:
+    """``_choose_occurrence`` (used by every modifier'd month+day/holiday branch of
+    ``parse_relative_date``) and the "from <A> through <B>" branch of
+    ``parse_relative_dates`` both bump a resolved date into a neighboring year. Both used
+    to do so with raw ``date.replace(year=...)``/``date(y + 1, m, d)`` construction, which
+    raises ``ValueError`` whenever a Feb 29 occurrence lands on a non-leap year -- the same
+    "hand-rolled year/month rollover instead of delegating to the module's own
+    clamp_day/add_months helpers" bug pattern already fixed for December -> January
+    rollover in #144/#145. Both now go through ``clamp_day`` (already used for this exact
+    "bump year, clamp day" idiom at this module's "in N years" branch), matching every
+    other date shifted into a shorter month.
+    """
+
+    def test_next_feb_29_shifted_into_non_leap_year_clamps_to_feb_28(self):
+        # target_this_year (Feb 29, 2028, a leap year) is already in the past relative to
+        # base, so the "next" modifier must shift it forward into 2029, a non-leap year.
+        assert parse_relative_date("next Feb 29", date(2028, 3, 1)) == "2029-02-28"
+
+    def test_last_feb_29_shifted_into_non_leap_year_clamps_to_feb_28(self):
+        # Mirror of the "next" case above: target_this_year (Feb 29, 2028) hasn't happened
+        # yet relative to base, so "last" must shift back into 2027, a non-leap year.
+        assert parse_relative_date("last Feb 29", date(2028, 1, 15)) == "2027-02-28"
+
+    def test_from_through_span_with_feb_29_end_bumped_past_non_leap_year(self):
+        # Resolving "Feb 29" relative to `start` (2028-03-15, after Feb 29 that year) forces
+        # a "next occurrence" shift into 2029 (non-leap), which used to raise ValueError
+        # inside the branch's inner try; the outer except then fell back to resolving "Feb
+        # 29" relative to `base` (2028-01-15, before Feb 29 that year, so no shift/crash),
+        # got 2028-02-29, saw it was < start, and bumped the year again -- which used to
+        # raise the same ValueError a second time, escaping to the wrong outer except
+        # branch entirely and silently misparsing the whole expression as a literal
+        # start/end pair (producing a nonsensical span that runs *backwards* from
+        # 2028-01-22 to 2028-03-15). The fix makes both bumps clamp Feb 29 -> Feb 28
+        # instead of raising, so the span correctly runs forward from the resolved start
+        # (Saturdays only) through the clamped end.
+        assert parse_relative_dates("Sat from March 15 through Feb 29", date(2028, 1, 15)) == [
+            "2028-03-18",
+            "2028-03-25",
+            "2028-04-01",
+            "2028-04-08",
+            "2028-04-15",
+            "2028-04-22",
+            "2028-04-29",
+            "2028-05-06",
+            "2028-05-13",
+            "2028-05-20",
+            "2028-05-27",
+            "2028-06-03",
+            "2028-06-10",
+            "2028-06-17",
+            "2028-06-24",
+            "2028-07-01",
+            "2028-07-08",
+            "2028-07-15",
+            "2028-07-22",
+            "2028-07-29",
+            "2028-08-05",
+            "2028-08-12",
+            "2028-08-19",
+            "2028-08-26",
+            "2028-09-02",
+            "2028-09-09",
+            "2028-09-16",
+            "2028-09-23",
+            "2028-09-30",
+            "2028-10-07",
+            "2028-10-14",
+            "2028-10-21",
+            "2028-10-28",
+            "2028-11-04",
+            "2028-11-11",
+            "2028-11-18",
+            "2028-11-25",
+            "2028-12-02",
+            "2028-12-09",
+            "2028-12-16",
+            "2028-12-23",
+            "2028-12-30",
+            "2029-01-06",
+            "2029-01-13",
+            "2029-01-20",
+            "2029-01-27",
+            "2029-02-03",
+            "2029-02-10",
+            "2029-02-17",
+            "2029-02-24",
+        ]


### PR DESCRIPTION
## What

Two places in `navi_bench/relative_dates.py` bump a resolved date into a neighboring year using raw construction instead of this module's own `clamp_day` helper:

1. `_choose_occurrence` (used by every modifier'd month+day and holiday branch of `parse_relative_date`): `target_this_year.replace(year=target_this_year.year + shift)`
2. The `"<X> from <A> through <B>"` branch of `parse_relative_dates`: `date(end.year + 1, end.month, end.day)`

Both now go through `clamp_day(y, m, d)` — the exact same "bump year, clamp day" idiom this module already uses correctly at its `"in N years"` branch (`clamp_day(base.year + n, base.month, base.day)`).

## Why

Both raise `ValueError` whenever the bumped-to occurrence is Feb 29 landing on a non-leap year (e.g. `"next Feb 29"` resolved from a base in a leap year, shifting forward to a non-leap year). This is the same **hand-rolled year/month-rollover-instead-of-delegating-to-this-module's-own-helpers** bug pattern already fixed for the December → January rollover in #144 and #145 — just the year-bump sibling of that month-bump fix, in the same file.

It's worse than a bare crash in the `from`/`through` case: the `ValueError` from case (1) is what's caught by that branch's own inner `except ValueError:` (triggering its base-relative fallback), but the *fallback's own* year-bump can hit the exact same bug a second time. That second crash isn't caught by the inner handler — it escapes to the *outer* `except ValueError:`, which silently reinterprets the whole expression as a literal, un-modifiered `"from X through Y"` and returns a nonsensical **backwards** date span instead of raising or resolving correctly. See `TestFeb29YearBump.test_from_through_span_with_feb_29_end_bumped_past_non_leap_year` for the exact repro.

## Safety / verification

- **Parity check**: ran a grid search over `date.replace(year=...)` vs `clamp_day(...)` across 54,790 `(year, month, day, shift)` combinations spanning 2000–2029. Results are byte-identical in every case *except* the 32 cases where the target day is Feb 29 and the shifted year is non-leap — exactly the case this PR fixes (old: raises; new: clamps to Feb 28).
- **Before/after repro via `git stash`**: confirmed `next Feb 29` / `last Feb 29` crash with `ValueError('day is out of range for month')` pre-fix and correctly resolve to Feb 28 post-fix; confirmed the `"Sat from March 15 through Feb 29"` case produces a nonsensical backwards span pre-fix and the correct forward span post-fix.
- **Characterization tests added** (`tests/test_relative_dates.py::TestFeb29YearBump`, 3 new tests) pin both the single-date fix and the from/through-span fix, following this repo's established convention of adding characterization tests alongside structural fixes to previously-undercovered code.
- `pytest tests/`: 233 → 236 passed (no regressions, count only grew).
- `ruff check` / `ruff format --check`: clean on both changed files.

Diff is 2 files (`navi_bench/relative_dates.py`, `tests/test_relative_dates.py`), no behavior change for any non-Feb-29-crossing-a-non-leap-year input.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJrMNx7f4eXAt3jTHzyBBS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bugfix aligned with existing `clamp_day` usage; behavior changes only when Feb 29 crosses into a non-leap year, with new tests and no reported regressions.
> 
> **Overview**
> Year shifts when resolving modifier phrases (e.g. **next/last Feb 29**) and when the **from … through …** span bumps an end date into the next year no longer use `date.replace` / `date(y+1, m, d)`. Both paths now call **`clamp_day`**, so Feb 29 moved into a non-leap year becomes **Feb 28** instead of raising `ValueError`.
> 
> That change also fixes a **from/through** edge case where a second failed year-bump could fall through exception handling and return a **backwards** date span. Three characterization tests in `TestFeb29YearBump` lock in single-date and span behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def3b6bc1617c25d390856564f7d353db5e7142a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->