### PR TITLE
fix(opentable): correct get_next_weekend_offsets on Saturday/Sunday "today"

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -563,13 +563,7 @@ def get_next_weekend_offsets(today: datetime) -> list[int]:
         List of two integers: [days_to_saturday, days_to_sunday]
     """
     current_day = today.weekday()  # 0=Monday, 6=Sunday
-
-    # Calculate days until next Saturday
-    if current_day < 5:  # Monday-Friday
-        days_to_sat = 5 - current_day
-    else:  # Saturday (5) or Sunday (6)
-        days_to_sat = 6 if current_day == 5 else 5  # Skip to next weekend
-
+    days_to_sat = days_until_next_weekday(current_day, WEEKDAYS["saturday"])
     return [days_to_sat, days_to_sat + 1]  # [Saturday, Sunday]
 
 

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -23,6 +23,7 @@ from navi_bench.opentable.opentable_info_gathering import (
     SingleCandidateQuery,
     get_days_until_date,
     get_first_weekend_of_next_month_offsets,
+    get_next_weekend_offsets,
 )
 
 
@@ -520,3 +521,29 @@ class TestGetFirstWeekendOfNextMonthOffsets:
         # 2025-12-01 is a Monday itself; still rolls over into January 2026.
         today = datetime(2025, 12, 1, tzinfo=timezone.utc)
         assert get_first_weekend_of_next_month_offsets(today) == [33, 34]
+
+
+class TestGetNextWeekendOffsets:
+    """Pin ``get_next_weekend_offsets`` for all 7 starting weekdays, including the Saturday/Sunday
+    "today" cases. These previously hand-rolled the days-to-Saturday math instead of delegating to
+    the shared ``relative_dates.days_until_next_weekday`` helper, and were wrong on Sat/Sun starts:
+    a Saturday "today" returned offset 6 (landing on the *prior* Friday) instead of rolling to the
+    following weekend, and a Sunday "today" returned offset 5 (also Friday) for the same reason.
+    """
+
+    @pytest.mark.parametrize(
+        "weekday_name,today_day,expected_offsets",
+        [
+            ("Monday", 3, [5, 6]),  # 2025-11-03 is a Monday
+            ("Tuesday", 4, [4, 5]),
+            ("Wednesday", 5, [3, 4]),
+            ("Thursday", 6, [2, 3]),
+            ("Friday", 7, [1, 2]),
+            ("Saturday", 8, [7, 8]),  # today is itself Saturday -> rolls to the *following* weekend
+            ("Sunday", 9, [6, 7]),  # today is itself Sunday -> rolls to the *following* weekend
+        ],
+    )
+    def test_offsets_for_each_starting_weekday(self, weekday_name, today_day, expected_offsets):
+        today = datetime(2025, 11, today_day, tzinfo=timezone.utc)
+        assert today.strftime("%A") == weekday_name
+        assert get_next_weekend_offsets(today) == expected_offsets


### PR DESCRIPTION
## What

`get_next_weekend_offsets()` hand-rolled its days-to-Saturday math instead of delegating to the already-shared `relative_dates.days_until_next_weekday()` helper, which is imported into this same file and used two functions below for the "for the upcoming `<weekday>`" branch.

## Why this is a bug, not just duplication

The hand-rolled version is wrong on the two "today is itself a weekend day" cases its own docstring claims to handle ("If today is Saturday or Sunday, returns the following weekend"):

- Saturday "today" → old code returned offset `6`, landing on the *prior* Friday instead of the following weekend.
- Sunday "today" → old code returned offset `5`, also landing on Friday.

Delegating to `days_until_next_weekday` (which never returns 0 — it rolls to 7 when the target weekday is today's own weekday) fixes both cases and removes the duplicated arithmetic in one line.

## Safety

- Pure delegation to an existing, already-unit-tested helper (`tests/test_relative_dates.py`), used identically elsewhere in this file.
- Added a parametrized `TestGetNextWeekendOffsets` covering all 7 starting weekdays (following the existing style of `TestGetDaysUntilDateUpcomingWeekday`), including the two previously-untested Sat/Sun cases — which is exactly why this bug survived undetected.
- Full test suite passes: 191 passed (excluding `tests/test_vis.py`, which fails to collect on `main` in this sandbox due to an unrelated missing `yutori` package dependency, not touched by this change).
- `ruff check` and `ruff format --diff` both clean on the touched files.

Only the two previously-incorrect Sat/Sun cases change behavior; all 5 weekday cases are unchanged.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01TUSZn3cwQcPNgfEWG1sF7g)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized date-offset bugfix in OpenTable task generation; weekday-only behavior is unchanged and logic reuses an existing tested helper.
> 
> **Overview**
> **`get_next_weekend_offsets`** no longer hand-rolls days until Saturday; it uses the shared **`days_until_next_weekday`** helper (same pattern as the “for the upcoming \<weekday\>” path in this file).
> 
> When **today is Saturday or Sunday**, the old logic produced wrong offsets (effectively landing on the prior Friday instead of the **following** weekend, contrary to the docstring). Only those two cases change behavior; Mon–Fri offsets stay the same. Labels like **“upcoming weekend”**, **“the following weekend”**, and **“the next two weekends”** all flow through this helper via **`get_days_until_date`**.
> 
> Adds **`TestGetNextWeekendOffsets`** with parametrized expectations for all seven starting weekdays, including the previously untested Sat/Sun cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb46e74e60ada49b97ec85211777a42a61398714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->