### PR TITLE
fix(opentable): delegate weekend-rollover math to days_until_next_weekday

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -564,11 +564,12 @@ def get_next_weekend_offsets(today: datetime) -> list[int]:
     """
     current_day = today.weekday()  # 0=Monday, 6=Sunday
 
-    # Calculate days until next Saturday
-    if current_day < 5:  # Monday-Friday
-        days_to_sat = 5 - current_day
-    else:  # Saturday (5) or Sunday (6)
-        days_to_sat = 6 if current_day == 5 else 5  # Skip to next weekend
+    # Delegate to the shared weekday-rollover helper (used identically by
+    # relative_dates.parse_relative_date's weekday branch) rather than hand-rolling the
+    # Saturday/Sunday special case. The previous hand-rolled version special-cased
+    # current_day in (5, 6) but computed 6/5 instead of the correct 7/6 days-to-Saturday,
+    # landing the "Saturday" offset on a Friday whenever today was itself a Saturday or Sunday.
+    days_to_sat = days_until_next_weekday(current_day, WEEKDAYS["saturday"])
 
     return [days_to_sat, days_to_sat + 1]  # [Saturday, Sunday]
 

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -23,6 +23,7 @@ from navi_bench.opentable.opentable_info_gathering import (
     SingleCandidateQuery,
     get_days_until_date,
     get_first_weekend_of_next_month_offsets,
+    get_next_weekend_offsets,
 )
 
 
@@ -497,6 +498,33 @@ class TestGetDaysUntilDateUpcomingWeekday:
     )
     def test_upcoming_weekday_offset(self, weekday_name, expected_days):
         assert get_days_until_date(f"for the upcoming {weekday_name}", self._TODAY) == [expected_days]
+
+
+class TestGetNextWeekendOffsets:
+    """Pin the exact offsets returned by ``get_next_weekend_offsets``, which delegates its
+    Saturday-rollover math to the shared ``relative_dates.days_until_next_weekday`` helper
+    rather than hand-rolling the "current_day in (5, 6)" special case. That hand-rolled version
+    computed 6/5 days-to-Saturday for a Saturday/Sunday ``today`` instead of the correct 7/6,
+    landing the "Saturday" offset on a Friday -- exactly the class of hand-rolled
+    date-rollover bug already fixed in ``get_first_weekend_of_next_month_offsets`` below, so
+    both Saturday and Sunday "today" cases are pinned here alongside a weekday case.
+    """
+
+    def test_weekday_today(self):
+        # 2025-11-06 is a Thursday; the next Saturday/Sunday are the 8th/9th.
+        today = datetime(2025, 11, 6, tzinfo=timezone.utc)
+        assert get_next_weekend_offsets(today) == [2, 3]
+
+    def test_saturday_today_rolls_to_next_weekend(self):
+        # 2025-11-08 is a Saturday; must roll to the following Saturday/Sunday (15th/16th),
+        # not land on a Friday.
+        today = datetime(2025, 11, 8, tzinfo=timezone.utc)
+        assert get_next_weekend_offsets(today) == [7, 8]
+
+    def test_sunday_today_rolls_to_next_weekend(self):
+        # 2025-11-09 is a Sunday; must roll to the following Saturday/Sunday (15th/16th).
+        today = datetime(2025, 11, 9, tzinfo=timezone.utc)
+        assert get_next_weekend_offsets(today) == [6, 7]
 
 
 class TestGetFirstWeekendOfNextMonthOffsets:


### PR DESCRIPTION
## Summary

- `get_next_weekend_offsets()` in `navi_bench/opentable/opentable_info_gathering.py` hand-rolled a Saturday/Sunday special case for computing "days until next Saturday". That special case computed `6`/`5` days-to-Saturday for a Saturday/Sunday `today`, when the correct values are `7`/`6`. As a result, whenever "today" was itself a Saturday or Sunday, `get_days_until_date("upcoming weekend", ...)` (and the "the following weekend" / "the next two weekends" labels built on top of it) resolved to a Friday/Saturday instead of the intended Saturday/Sunday.
- Fixed by delegating to the already-imported `relative_dates.days_until_next_weekday` helper, matching the identical fix already applied to `get_first_weekend_of_next_month_offsets` in this same file (see its docstring/tests: "delegates its next-month rollover math to the shared `relative_dates.add_months` helper rather than hand-rolling the month == 12 check").
- This repo has had several prior PRs fixing this exact class of hand-rolled date/weekday-rollover bug (e.g. #151, #145, #144); this instance in `get_next_weekend_offsets` had been missed.

## Test plan

- [x] Added `TestGetNextWeekendOffsets` in `tests/test_opentable_info_gathering.py` pinning a regular weekday case plus the two previously-broken Saturday/Sunday "today" cases.
- [x] `python3 -m pytest tests/ -q` — 249 passed (246 existing + 3 new).
- [x] `ruff check` / `ruff format --check` pass on both changed files.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01UL7MiUbp6TDaw99k7pwLWd


---
_Generated by [Claude Code](https://claude.ai/code/session_01UL7MiUbp6TDaw99k7pwLWd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized date-offset fix in OpenTable task generation with characterization tests; no auth, persistence, or API surface changes.
> 
> **Overview**
> Fixes incorrect **“upcoming weekend”** (and related) date resolution when **today is Saturday or Sunday**: `get_next_weekend_offsets` no longer hand-rolls Saturday rollover with wrong **6/5** day offsets (which pointed at **Friday/Saturday** instead of the next **Saturday/Sunday**).
> 
> It now uses the shared **`days_until_next_weekday`** helper—the same pattern already used for upcoming weekdays and first-weekend-of-next-month in this module.
> 
> Adds **`TestGetNextWeekendOffsets`** to lock weekday, Saturday-today, and Sunday-today offsets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874544c1f055cd883fd1df3501e52ff20bfb3eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->