### PR TITLE
refactor: extract shared safe_update helper for evaluator.update try/except

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -17,7 +17,7 @@ from typing import Any
 from datasets import load_dataset
 from playwright.async_api import Page, async_playwright
 
-from navi_bench.base import DatasetItem, instantiate
+from navi_bench.base import DatasetItem, instantiate, safe_update
 
 
 HF_DATASET = "yutori-ai/navi-bench"
@@ -35,10 +35,12 @@ def load_task(task_id: str) -> dict[str, Any]:
 
 
 async def _safe_evaluator_update(evaluator, page: Page, *, label: str = "") -> None:
-    try:
-        await evaluator.update(url=page.url, page=page)
-    except Exception as e:
-        print(f"[WARN] {label}evaluator.update(url={page.url!r}, page={page}) failed: {e}")
+    await safe_update(
+        evaluator,
+        url=page.url,
+        page=page,
+        log_fn=lambda exc: print(f"[WARN] {label}evaluator.update(url={page.url!r}, page={page}) failed: {exc}"),
+    )
 
 
 async def attach_human_agent_loop(page: Page, evaluator) -> None:

--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -63,7 +63,7 @@ from evaluation.cli import cli
 from evaluation.dataset import build_dataset
 from evaluation.recorder import Recorder, log_formatter
 from evaluation.stats import BaseTokenUsage, Crashed, TimingStats, log_section_header, show_results, show_timing_summary
-from navi_bench.base import BaseMetric, BaseTaskConfig, DatasetItem, instantiate
+from navi_bench.base import BaseMetric, BaseTaskConfig, DatasetItem, instantiate, safe_update
 from navi_bench.dates import user_metadata_datetime
 from yutori import AsyncYutoriClient
 from yutori.auth import resolve_api_key
@@ -254,10 +254,15 @@ Today is: {dt.strftime("%A")}"""
                 raise RuntimeError(f"Unknown action type: {name}")
 
     async def _safe_update_evaluator() -> None:
-        try:
-            await evaluator.update(url=page.url, page=page, answer_message=answer_message)
-        except Exception:
-            logger.opt(exception=True).warning(f"[{step_idx}] Failed to update evaluator: {page.url}")
+        await safe_update(
+            evaluator,
+            url=page.url,
+            page=page,
+            answer_message=answer_message,
+            log_fn=lambda exc: logger.opt(exception=True).warning(
+                f"[{step_idx}] Failed to update evaluator: {page.url}"
+            ),
+        )
 
     async def _fail(
         reason: str,

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -51,6 +51,27 @@ async def safe_evaluate(
     return value
 
 
+async def safe_update(
+    evaluator: Any,
+    *,
+    log_fn: Callable[[Exception], None],
+    **kwargs: Any,
+) -> None:
+    """Call ``evaluator.update(**kwargs)``, logging via ``log_fn`` instead of raising.
+
+    A live page can navigate away or throw mid-update while a task verifier polls it;
+    callers (a human-agent-loop step and an N1 eval step, previously each hand-rolling
+    this try/except) should degrade gracefully instead of crashing the whole loop.
+    ``log_fn`` receives the caught exception so callers can format their own message
+    (and, e.g., call ``logger.opt(exception=True)`` from within the still-live except
+    context).
+    """
+    try:
+        await evaluator.update(**kwargs)
+    except Exception as exc:
+        log_fn(exc)
+
+
 def strip_url_scheme(url: str) -> str:
     """Strip http(s):// scheme and a leading www. prefix for URL normalization.
 

--- a/tests/test_safe_update.py
+++ b/tests/test_safe_update.py
@@ -1,0 +1,51 @@
+"""Tests for ``safe_update``, extracted from the ``try: await evaluator.update(...) except
+Exception: log + continue`` pattern that ``demo.py``'s human-agent-loop and
+``evaluation/eval_n1.py``'s N1 eval step each hand-rolled against a live page that can
+navigate away or throw mid-update.
+"""
+
+import pytest
+
+from navi_bench.base import safe_update
+
+
+class _FakeEvaluator:
+    def __init__(self, error: Exception | None = None):
+        self._error = error
+        self.calls: list[dict] = []
+
+    async def update(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._error is not None:
+            raise self._error
+
+
+@pytest.mark.asyncio
+async def test_safe_update_forwards_kwargs_on_success():
+    evaluator = _FakeEvaluator()
+
+    await safe_update(
+        evaluator, url="https://example.com", page="page-obj", log_fn=lambda exc: pytest.fail("unexpected")
+    )
+
+    assert evaluator.calls == [{"url": "https://example.com", "page": "page-obj"}]
+
+
+@pytest.mark.asyncio
+async def test_safe_update_logs_and_swallows_on_failure():
+    evaluator = _FakeEvaluator(error=RuntimeError("boom"))
+    logged: list[Exception] = []
+
+    await safe_update(evaluator, url="https://example.com", log_fn=logged.append)
+
+    assert len(logged) == 1
+    assert str(logged[0]) == "boom"
+
+
+@pytest.mark.asyncio
+async def test_safe_update_passes_arbitrary_kwargs_through():
+    evaluator = _FakeEvaluator()
+
+    await safe_update(evaluator, url="u", page="p", answer_message="done", log_fn=lambda exc: pytest.fail("unexpected"))
+
+    assert evaluator.calls == [{"url": "u", "page": "p", "answer_message": "done"}]


### PR DESCRIPTION
## Summary

- `demo.py`'s human-agent-loop (`_safe_evaluator_update`) and `evaluation/eval_n1.py`'s N1 eval step (`_safe_update_evaluator`) each hand-rolled the identical `try: await evaluator.update(...) except Exception: log-and-continue` scaffolding. Both exist for the same reason: a live page can navigate away or throw mid-update while a task verifier is polling it, so callers need to degrade gracefully instead of crashing the whole agent loop.
- This is the same shape as the already-extracted `navi_bench.base.safe_evaluate` helper (added in #148 for the analogous `page.evaluate` try/except pattern), just one level up at the `evaluator.update` call.
- Added `navi_bench.base.safe_update(evaluator, *, log_fn, **kwargs)`, mirroring `safe_evaluate`'s `log_fn` callback design: `log_fn` receives the caught exception, so each call site keeps its exact current logging behavior — `demo.py` still `print`s a `[WARN]`-prefixed message with its optional `label`, and `eval_n1.py` still calls `logger.opt(exception=True).warning(...)` with the step index (this still works correctly since `log_fn` is invoked synchronously from within `safe_update`'s own `except` block, so `sys.exc_info()` is still live).
- No behavior change: same exceptions caught (bare `Exception`), same kwargs forwarded to `evaluator.update(...)`, same log output at both call sites.

## Test plan

- [x] Added `tests/test_safe_update.py` (mirroring the existing `tests/test_safe_evaluate.py` style) covering: kwargs forwarded on success, exception caught and passed to `log_fn` on failure, and arbitrary kwargs (e.g. `answer_message`) passed through.
- [x] `pytest tests/` — 249 passed (246 existing + 3 new).
- [x] `ruff check` clean on all changed files.
- [x] `ruff format --check` clean on all changed files (one pre-existing, unrelated formatting diff in `evaluation/eval_n1.py` predates this change and was left untouched to keep the diff minimal).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017NbaZAfH8Woxi8tTT9Cw82


---
_Generated by [Claude Code](https://claude.ai/code/session_017NbaZAfH8Woxi8tTT9Cw82)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with tests; same Exception catch, kwargs, and log behavior at both call sites.
> 
> **Overview**
> Introduces **`navi_bench.base.safe_update`**, which wraps `evaluator.update(**kwargs)` in a try/except, forwards kwargs unchanged, and delegates failure logging to a caller-supplied `log_fn` instead of raising.
> 
> **`demo.py`** and **`evaluation/eval_n1.py`** drop their duplicated `try/except` around `evaluator.update` and call `safe_update` instead, preserving each site’s logging (`[WARN]` print vs `logger.opt(exception=True).warning` with step index and optional `answer_message`).
> 
> Adds **`tests/test_safe_update.py`** (same style as `test_safe_evaluate`) for success forwarding, swallowed failures, and arbitrary kwargs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edec288879d36284ca3a9408c54baf00a188039e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->