### PR TITLE
test(dates): add characterization tests for resolve_placeholder_values and render_task_statement

### DIFF
--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -33,8 +33,10 @@ every year-spanning or backward ("last") case.
 
 from datetime import date, datetime, timezone
 
+import pytest
+
 from navi_bench.base import UserMetadata
-from navi_bench.dates import initialize_placeholder_map
+from navi_bench.dates import initialize_placeholder_map, render_task_statement, resolve_placeholder_values
 
 
 def _user_metadata(base_date: date) -> UserMetadata:
@@ -133,3 +135,114 @@ class TestInitializePlaceholderMapUnaffectedForwardBumpStillWorks:
         desc, iso_dates = placeholder_map["date"]
         assert iso_dates == ["2025-12-03"]
         assert desc == "the 3rd of December"
+
+
+class TestResolvePlaceholderValuesDynamicOffset:
+    """``resolve_placeholder_values`` had zero direct test coverage: ``initialize_placeholder_map``
+    only exercises its string-parsed fallback branch (via ``parse_relative_dates``), never the
+    ``{now() + timedelta(start, end)}`` dynamic-offset branch that resy/opentable/google_flights
+    placeholder configs can also use. Per ``_DYNAMIC_OFFSET_PATTERN``, the ``|option=value`` options
+    string comes *after* the closing ``}``, not inside it -- easy to get wrong, which is exactly why
+    this branch needs its own direct tests rather than relying on indirect exercise."""
+
+    BASE = date(2026, 3, 10)
+
+    def test_single_day_offset_has_no_prefix(self):
+        assert resolve_placeholder_values("{now() + timedelta(0)}", self.BASE) == (
+            "Mar 10th",
+            ["2026-03-10"],
+            True,
+        )
+
+    def test_future_single_day_offset_gets_next_prefix(self):
+        assert resolve_placeholder_values("{now() + timedelta(1)}", self.BASE) == (
+            "next Mar 11th",
+            ["2026-03-11"],
+            True,
+        )
+
+    def test_range_offset_defaults_to_all_dates(self):
+        assert resolve_placeholder_values("{now() + timedelta(1, 3)}", self.BASE) == (
+            "next Mar 11th-13th",
+            ["2026-03-11", "2026-03-12", "2026-03-13"],
+            True,
+        )
+
+    def test_range_mode_endpoints_only_returns_start_and_end_dates(self):
+        assert resolve_placeholder_values("{now() + timedelta(1, 3)}|range=endpoints", self.BASE) == (
+            "next Mar 11th-13th",
+            ["2026-03-11", "2026-03-13"],
+            True,
+        )
+
+    def test_month_style_long(self):
+        assert resolve_placeholder_values("{now() + timedelta(1, 3)}|month=long", self.BASE) == (
+            "next March 11th-13th",
+            ["2026-03-11", "2026-03-12", "2026-03-13"],
+            True,
+        )
+
+    def test_year_style_set_appends_year_after_range(self):
+        assert resolve_placeholder_values("{now() + timedelta(1, 3)}|year=set", self.BASE) == (
+            "next Mar 11th-13th, 2026",
+            ["2026-03-11", "2026-03-12", "2026-03-13"],
+            True,
+        )
+
+    def test_prefix_none_suppresses_next_prefix(self):
+        assert resolve_placeholder_values("{now() + timedelta(1, 3)}|prefix=none", self.BASE) == (
+            "Mar 11th-13th",
+            ["2026-03-11", "2026-03-12", "2026-03-13"],
+            True,
+        )
+
+    def test_prefix_auto_adds_next_when_start_offset_is_at_least_one(self):
+        assert resolve_placeholder_values("{now() + timedelta(30, 32)}|prefix=auto", self.BASE) == (
+            "next Apr 9th-11th",
+            ["2026-04-09", "2026-04-10", "2026-04-11"],
+            True,
+        )
+
+    def test_prefix_auto_omits_next_when_start_offset_is_negative(self):
+        assert resolve_placeholder_values("{now() + timedelta(-2, 0)}|prefix=auto", self.BASE) == (
+            "Mar 8th-10th",
+            ["2026-03-08", "2026-03-09", "2026-03-10"],
+            True,
+        )
+
+    def test_end_offset_smaller_than_start_offset_raises(self):
+        with pytest.raises(ValueError, match="timedelta end offset cannot be smaller than the start offset"):
+            resolve_placeholder_values("{now() + timedelta(3, 1)}", self.BASE)
+
+    def test_invalid_option_value_raises(self):
+        with pytest.raises(ValueError, match="month style must be one of"):
+            resolve_placeholder_values("{now() + timedelta(1)}|month=bogus", self.BASE)
+
+    def test_non_dynamic_text_falls_back_to_string_parsing(self):
+        description, iso_dates, is_dynamic = resolve_placeholder_values("the 3rd of December", self.BASE)
+        assert description == "the 3rd of December"
+        assert iso_dates == ["2026-12-03"]
+        assert is_dynamic is False
+
+
+class TestRenderTaskStatement:
+    """``render_task_statement`` had zero test coverage despite being the shared placeholder
+    substitution step used by resy, opentable, and google_flights task generation."""
+
+    def test_substitutes_multiple_placeholders(self):
+        rendered = render_task_statement(
+            "Book a table for {partySize} on {date}",
+            {"partySize": ("4", []), "date": ("March 10th", [])},
+        )
+        assert rendered == "Book a table for 4 on March 10th"
+
+    def test_missing_placeholder_raises(self):
+        with pytest.raises(ValueError, match="Placeholder 'missing' not found in resolved_placeholders"):
+            render_task_statement("Book for {missing}", {})
+
+    def test_repeated_placeholder_is_substituted_at_every_occurrence(self):
+        rendered = render_task_statement("{x} and {x} again", {"x": ("foo", [])})
+        assert rendered == "foo and foo again"
+
+    def test_statement_without_placeholders_is_returned_unchanged(self):
+        assert render_task_statement("no placeholders here", {}) == "no placeholders here"


### PR DESCRIPTION
## What

Adds direct characterization tests for two functions in `navi_bench/dates.py` that had zero direct test coverage: `resolve_placeholder_values` and `render_task_statement`.

## Why

Both feed placeholder resolution/rendering shared by resy, opentable, and google_flights task generation. `initialize_placeholder_map`'s existing tests only exercise `resolve_placeholder_values`'s string-parsed fallback branch (via `parse_relative_dates`) — the `"{now() + timedelta(start, end)}"` dynamic-offset branch, including all of its `month`/`range`/`year`/`prefix` options, had never been exercised by any test. `render_task_statement` had no coverage at all, direct or indirect.

This follows up on the note left in the #152 fix ("no dedicated test file... `resolve_placeholder_values` and `render_task_statement` have zero test coverage").

New tests cover:
- `resolve_placeholder_values`: single-day and ranged dynamic offsets, each option (`range=endpoints`, `month=long`, `year=set`, `prefix=none`/`auto` in both directions), the two documented `ValueError` paths (end offset < start offset; invalid option value), and the non-dynamic string-parsing fallback.
- `render_task_statement`: multi-placeholder substitution, missing-placeholder `ValueError`, repeated-placeholder substitution, and the no-placeholder passthrough.

## Safety

Test-only change — `navi_bench/dates.py` itself is untouched, so there is no behavior change to production code. All expected values were derived by first running the target functions directly and recording their actual output, then asserting on that (true characterization, not guessed values).

- `pytest tests/`: 246 → 262 passing (all new tests pass; no existing test touched or broken)
- `ruff check` / `ruff format --check`: clean
- Diff: 1 file (`tests/test_dates.py`), +114/-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CTpMSoC7f7kXGpgzBfFLL5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no modifications to production code.
> 
> **Overview**
> Adds **direct characterization tests** in `tests/test_dates.py` for `resolve_placeholder_values` and `render_task_statement` from `navi_bench/dates.py`. Production date logic is unchanged.
> 
> **`resolve_placeholder_values`:** Covers the `{now() + timedelta(...)}` path and `|option=value` modifiers (`range`, `month`, `year`, `prefix`), including `ValueError` cases and the non-dynamic string fallback. Existing `initialize_placeholder_map` tests only hit the string-parsed branch.
> 
> **`render_task_statement`:** Covers multi-placeholder substitution, repeated placeholders, missing-placeholder errors, and statements with no placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0af0ecf17e33aa7243b72b056457ace5695aa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->