### PR TITLE
Reuse _get_booking_window_limit in generate_task_config_random

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -977,8 +977,9 @@ def generate_task_config_random(
     # Look up restaurant metadata from CSV to get constraints
     csv_metadata = RESTAURANT_METADATA.get((city.lower(), restaurant_name.lower()), {})
 
-    # Cap days_ahead with CSV value (CSV is the max booking window)
-    days_ahead = min(days_ahead, csv_metadata["days_ahead"]) if csv_metadata.get("days_ahead") else days_ahead
+    # Cap days_ahead with CSV value (CSV is the max booking window), reusing the same
+    # explicit-vs-CSV capping `_get_booking_window_limit` applies for the deterministic path.
+    days_ahead = _get_booking_window_limit(city, restaurant_name, days_ahead)
 
     # Get optional fields from CSV
     open_time = csv_metadata.get("open_time")

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -14,14 +14,17 @@ from datetime import date
 
 import pytest
 
+from navi_bench.resy import resy_url_match
 from navi_bench.resy.resy_url_match import (
     RESTAURANT_METADATA,
     ResyQueryState,
     ResyUrlMatch,
     _BOUNDARY_REASON_MESSAGE_TEMPLATES,
+    _get_booking_window_limit,
     _parse_optional_int,
     _render_placeholders_in_queries_all,
     _render_placeholders_in_queries_any,
+    generate_task_config_random,
     parse_time_to_hour,
 )
 
@@ -290,3 +293,98 @@ class TestLoadRestaurantMetadata:
         assert entry["guests_max"] == 15
         assert entry["days_ahead"] == 28
         assert isinstance(entry["guests_min"], int)
+
+
+class TestGetBookingWindowLimit:
+    """Characterization tests for ``_get_booking_window_limit``, which combines an explicit
+    booking-window override with the CSV-configured ``days_ahead`` for a restaurant, taking
+    the smaller of the two when both are present.
+    """
+
+    def test_no_restaurant_returns_explicit_limit_unchanged(self):
+        assert _get_booking_window_limit(None, None, 45) == 45
+
+    def test_no_csv_entry_returns_explicit_limit_unchanged(self):
+        assert _get_booking_window_limit("nowhere", "nonexistent restaurant xyz", 45) == 45
+
+    def test_csv_entry_caps_larger_explicit_limit(self):
+        # Carbone (new york) has days_ahead=28 in the bundled CSV.
+        assert _get_booking_window_limit("new york", "Carbone", 100) == 28
+
+    def test_csv_entry_does_not_raise_smaller_explicit_limit(self):
+        assert _get_booking_window_limit("new york", "Carbone", 10) == 10
+
+    def test_no_explicit_limit_uses_csv_value(self):
+        assert _get_booking_window_limit("new york", "Carbone", None) == 28
+
+    def test_no_explicit_limit_and_no_csv_entry_returns_none(self):
+        assert _get_booking_window_limit("nowhere", "nonexistent restaurant xyz", None) is None
+
+    def test_lookup_is_case_insensitive(self):
+        assert _get_booking_window_limit("NEW YORK", "CARBONE", 100) == 28
+
+
+class TestGenerateTaskConfigRandomDaysAheadCapping:
+    """Pins that ``generate_task_config_random`` caps a restaurant dict's explicit
+    ``days_ahead`` by the CSV metadata's ``days_ahead`` for the same restaurant -- the same
+    "smaller of explicit vs. CSV" capping ``_get_booking_window_limit`` centralizes for the
+    deterministic (any/all) task-config path via ``generate_task_config_deterministic``.
+    """
+
+    def _capture_date_range(self, monkeypatch):
+        captured = {}
+
+        def fake_select_valid_date(base_date, date_range, closed_days):
+            captured["date_range"] = date_range
+            return base_date
+
+        monkeypatch.setattr(resy_url_match, "select_valid_date", fake_select_valid_date)
+        return captured
+
+    def test_explicit_days_ahead_larger_than_csv_gets_capped(self, monkeypatch):
+        captured = self._capture_date_range(monkeypatch)
+
+        generate_task_config_random(
+            restaurant={
+                "city": "new york",
+                "name": "Carbone",
+                "guests_min": 1,
+                "guests_max": 4,
+                "days_ahead": 1000,  # far larger than Carbone's CSV cap of 28
+            },
+            seed=1,
+        )
+
+        assert captured["date_range"] == (1, 28)
+
+    def test_explicit_days_ahead_smaller_than_csv_is_unaffected(self, monkeypatch):
+        captured = self._capture_date_range(monkeypatch)
+
+        generate_task_config_random(
+            restaurant={
+                "city": "new york",
+                "name": "Carbone",
+                "guests_min": 1,
+                "guests_max": 4,
+                "days_ahead": 5,  # smaller than Carbone's CSV cap of 28
+            },
+            seed=1,
+        )
+
+        assert captured["date_range"] == (1, 5)
+
+    def test_restaurant_without_csv_entry_uses_explicit_days_ahead(self, monkeypatch):
+        captured = self._capture_date_range(monkeypatch)
+
+        generate_task_config_random(
+            restaurant={
+                "city": "nowhere",
+                "name": "nonexistent restaurant xyz",
+                "guests_min": 1,
+                "guests_max": 4,
+                "days_ahead": 14,
+            },
+            seed=1,
+        )
+
+        assert captured["date_range"] == (1, 14)


### PR DESCRIPTION
## Issue

`navi_bench/resy/resy_url_match.py`'s `generate_task_config_random` re-implemented the exact same "cap an explicit `days_ahead` value by the CSV-configured `days_ahead`, taking the smaller of the two when both are present" logic that `_get_booking_window_limit` already centralizes for the deterministic (`any`/`all`) task-config path (`generate_task_config_deterministic`):

```python
# generate_task_config_random (before)
csv_metadata = RESTAURANT_METADATA.get((city.lower(), restaurant_name.lower()), {})
days_ahead = min(days_ahead, csv_metadata["days_ahead"]) if csv_metadata.get("days_ahead") else days_ahead
```

```python
# _get_booking_window_limit (already existed, only used by the deterministic path)
def _get_booking_window_limit(restaurant_city, restaurant_name, explicit_limit=None):
    limit = explicit_limit
    if restaurant_city and restaurant_name:
        metadata = RESTAURANT_METADATA.get((restaurant_city.lower(), restaurant_name.lower()))
        csv_limit = metadata.get("days_ahead") if metadata else None
        if csv_limit:
            limit = min(limit, csv_limit) if limit is not None else csv_limit
    return limit
```

Both implement identical semantics (same lookup key, same truthy-check on the CSV value, same min-combination), just with the random path re-deriving it inline instead of calling the existing helper a few dozen lines above it.

## Fix

`generate_task_config_random` now calls `_get_booking_window_limit(city, restaurant_name, days_ahead)` instead of duplicating the capping logic inline. No behavior change — verified via new characterization tests (see below) run against the code both before and after the change.

## Why this is safe

- Single file touched for the source change (`navi_bench/resy/resy_url_match.py`), plus test additions.
- `_get_booking_window_limit` had zero direct test coverage before this PR (only exercised indirectly via the deterministic path) — added `TestGetBookingWindowLimit` (7 tests) covering: no restaurant, no CSV entry, CSV caps a larger explicit limit, CSV doesn't raise a smaller explicit limit, no explicit limit falls back to CSV, no explicit limit + no CSV entry returns `None`, and case-insensitive lookup.
- Added `TestGenerateTaskConfigRandomDaysAheadCapping` (3 tests) that monkeypatch `select_valid_date` to capture the `date_range` it's called with, confirming `generate_task_config_random` still caps `days_ahead` identically after the refactor (explicit larger than CSV gets capped, explicit smaller than CSV is unaffected, restaurant with no CSV entry uses the explicit value unchanged).
- All 10 new tests were run and confirmed passing against the pre-refactor code first, then re-run after the change with identical results.
- Full suite: 272/272 tests pass (262 pre-existing + 10 new). `ruff check`/`ruff format --check` clean on both touched files.

## Test plan

- [x] `pytest tests/` — 272/272 passing
- [x] `ruff check navi_bench/resy/resy_url_match.py tests/test_resy_url_match.py` — clean
- [x] `ruff format --check navi_bench/resy/resy_url_match.py tests/test_resy_url_match.py` — clean
- [x] New tests confirmed passing against pre-refactor code before applying the change (characterization-test-first convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4kmiaFrae9AB2gScgTcEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4kmiaFrae9AB2gScgTcEp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with characterization tests confirming unchanged date-range behavior; no auth or data-path changes.
> 
> **Overview**
> **`generate_task_config_random`** no longer inlines CSV vs. explicit **`days_ahead`** capping; it delegates to **`_get_booking_window_limit`**, matching the deterministic task-config path.
> 
> **Tests** add **`TestGetBookingWindowLimit`** (explicit/CSV/min, missing metadata, case-insensitive lookup) and **`TestGenerateTaskConfigRandomDaysAheadCapping`** (monkeypatched **`select_valid_date`** asserts the **`date_range`** passed in after capping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 716dba81c4ce3198e14ee2bcfd52f2cf3ef292aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->