### PR TITLE
refactor(stats): extract shared _metrics_row helper in show_results

### DIFF
--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -163,6 +163,15 @@ def show_results(dataset: list[DatasetItem], results: list[BaseModel | Crashed])
             _fmt(_avg_score(entries, crashed_score=1.0)),
         )
 
+    def _metrics_row(label: str, entries: list[tuple[float, bool]]) -> list:
+        """Build a ``table_rows`` entry: ``[label, n_finished, n_crashed, lower, excluding, upper]``.
+
+        Shared by the per-domain, per-difficulty, and overall row builders below, which each
+        previously repeated the same "destructure ``_compute_metrics(entries)``, then prepend
+        a label" pattern.
+        """
+        return [label, *_compute_metrics(entries)]
+
     log_section_header("Summary (Lower Bound: crashed=0.0, Upper Bound: crashed=1.0, Excluding: no crashed)", width=90)
 
     table_rows = []
@@ -178,20 +187,15 @@ def show_results(dataset: list[DatasetItem], results: list[BaseModel | Crashed])
                 domain_entries.extend(difficulty_data[diff])
 
         all_entries.extend(domain_entries)
-        n_finished, n_crashed, lower, excluding, upper = _compute_metrics(domain_entries)
-
-        table_rows.append([domain, n_finished, n_crashed, lower, excluding, upper])
+        table_rows.append(_metrics_row(domain, domain_entries))
 
         for diff in difficulties_order:
             if diff in difficulty_data:
-                diff_entries = difficulty_data[diff]
-                d_n_finished, d_n_crashed, d_lower, d_excluding, d_upper = _compute_metrics(diff_entries)
-                table_rows.append([f"  └─ {diff}", d_n_finished, d_n_crashed, d_lower, d_excluding, d_upper])
+                table_rows.append(_metrics_row(f"  └─ {diff}", difficulty_data[diff]))
 
         table_rows.append(SEPARATING_LINE)
 
-    total_n_finished, total_n_crashed, total_lower, total_excluding, total_upper = _compute_metrics(all_entries)
-    table_rows.append(["Overall", total_n_finished, total_n_crashed, total_lower, total_excluding, total_upper])
+    table_rows.append(_metrics_row("Overall", all_entries))
 
     headers = ["Domain", "n_finished", "n_crashed", "Lower Bound", "Excl. Crashed", "Upper Bound"]
     table_str = tabulate(

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,73 @@
+"""Characterization tests for ``evaluation.stats.show_results``.
+
+``show_results`` had zero prior test coverage (unlike most of the rest of this repo).
+These pin its current printed summary table -- per-domain rows, per-difficulty sub-rows,
+and the final "Overall" row -- across a small synthetic dataset mixing two domains,
+multiple difficulties, and one crashed result, ahead of extracting the repeated
+``n_finished, n_crashed, lower, excluding, upper = _compute_metrics(entries); table_rows
+.append([label, n_finished, n_crashed, lower, excluding, upper])`` pattern (duplicated at
+the per-domain, per-difficulty, and overall call sites) into a shared ``_metrics_row(label,
+entries) -> list`` helper.
+"""
+
+import json
+
+from navi_bench.base import DatasetItem, FinalResult
+from evaluation.stats import Crashed, show_results
+
+
+def _item(task_id: str, domain: str, difficulty: str | None) -> DatasetItem:
+    return DatasetItem(
+        task_id=task_id,
+        task_generation_config_json=json.dumps({"_target_": "x.y.z"}),
+        env="real",
+        domain=domain,
+        l1_category="food",
+        suggested_difficulty=difficulty,
+    )
+
+
+def _run_show_results(monkeypatch) -> list[str]:
+    logged: list[str] = []
+    monkeypatch.setattr("evaluation.stats.logger.info", logged.append)
+    monkeypatch.setattr("evaluation.stats.logger.error", logged.append)
+
+    dataset = [
+        _item("t/opentable/0", "opentable", "easy"),
+        _item("t/opentable/1", "opentable", "hard"),
+        _item("t/resy/0", "resy", "easy"),
+        _item("t/resy/1", "resy", None),
+    ]
+    results = [
+        FinalResult(score=1.0),
+        Crashed(score=0.0, exception="boom"),
+        FinalResult(score=0.5),
+        FinalResult(score=0.0),
+    ]
+    show_results(dataset, results)
+    return logged
+
+
+class TestShowResultsSummaryTable:
+    def test_per_domain_and_overall_rows_pinned(self, monkeypatch):
+        logged = _run_show_results(monkeypatch)
+        table_lines = [line for line in logged if line.strip()]
+
+        # Header + per-domain block (opentable, then resy, alphabetically) + Overall.
+        assert "opentable              1            1           0.50             1.00           1.00" in table_lines
+        assert "└─ easy                1            0           1.00             1.00           1.00" in table_lines
+        assert "└─ hard                0            1           0.00              N/A           1.00" in table_lines
+        assert "resy                   2            0           0.25             0.25           0.25" in table_lines
+        assert "└─ easy                1            0           0.50             0.50           0.50" in table_lines
+        assert "└─ unknown             1            0           0.00             0.00           0.00" in table_lines
+        assert "Overall                3            1           0.38             0.50           0.62" in table_lines
+
+    def test_per_task_detail_lines_pinned(self, monkeypatch):
+        logged = _run_show_results(monkeypatch)
+        assert "  [  0] t/opentable/0                                                | easy   | score = 1.00" in logged
+        assert (
+            "  [  1] t/opentable/1                                                | hard   | score = 0.00 (crashed)"
+            in logged
+        )
+        assert "  [  2] t/resy/0                                                     | easy   | score = 0.50" in logged
+        assert "  [  3] t/resy/1                                                     | unknown | score = 0.00" in logged


### PR DESCRIPTION
## Issue

`evaluation/stats.py`'s `show_results` builds three summary-table rows (per-domain, per-difficulty, and the final "Overall" row) by calling `_compute_metrics(entries)`, destructuring its fixed 5-tuple (`n_finished, n_crashed, lower, excluding, upper`) into named locals, and then prepending a label to build the `table_rows` entry. All three call sites repeat this identical shape, differing only in the label string and the `entries` argument.

## Improvement

Extract a small helper:

```python
def _metrics_row(label: str, entries: list[tuple[float, bool]]) -> list:
    return [label, *_compute_metrics(entries)]
```

and use it at all three call sites (domain row, per-difficulty sub-row, overall row), removing the repeated tuple-unpacking/list-construction.

## Safety

- `evaluation/stats.py` had **zero prior test coverage** (confirmed via grep across `tests/`). Per this repo's established convention (see `tests/test_dates.py`), this PR adds `tests/test_stats.py` **first**, with characterization tests that pin `show_results`'s exact printed output (per-domain rows, per-difficulty sub-rows, the Overall row, and per-task detail lines) against a small synthetic dataset (two domains, mixed difficulties including `None`/"unknown", one crashed result).
- The characterization tests were captured from the actual pre-refactor output (not hand-derived), then verified to pass unchanged after the refactor — confirming byte-identical behavior.
- Full suite: **275 passed** on `main` before this change → **277 passed** after (the 2 new characterization tests), with the same 277 passing both before and after the `_metrics_row` extraction itself.
- `ruff check` and `ruff format --check` both pass on the changed files.
- The diff is purely mechanical: no change to `_compute_metrics`, `_avg_score`, `_fmt`, or the values/order returned — only how the resulting tuple is packed into a `table_rows` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYYUYR2NoQp91bgaUQfKqm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no metric logic changes; new tests lock existing printed output.
> 
> **Overview**
> **`show_results`** summary table construction is deduplicated by introducing **`_metrics_row(label, entries)`**, which prepends a label to **`_compute_metrics`** output. Per-domain, per-difficulty, and **Overall** rows now call this helper instead of repeating tuple unpack and list assembly.
> 
> Adds **`tests/test_stats.py`** with characterization tests that pin logged summary table lines and per-task detail output (mixed domains, difficulties, one crash) so the refactor stays behavior-identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c60d08b76da5b695cc47f2ed0926d4a9ee4e18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->