### PR TITLE
refactor: extract shared _reset_state() helper in url/info-gathering metrics

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -65,13 +65,16 @@ class ApartmentsUrlMatch(BaseMetric):
             self.gt_urls = [gt_url]
         else:
             self.gt_urls = gt_url
+        self._reset_state()
+
+    def _reset_state(self) -> None:
         self._found_match = False
 
     def __repr__(self) -> str:
         return repr_with_attr(self, "gt_urls")
 
     async def reset(self) -> None:
-        self._found_match = False
+        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: UrlMetricInput = kwargs

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -33,13 +33,16 @@ class CraigslistUrlMatch(BaseMetric):
         self.gt_urls = gt_urls
 
         self._gt_states = [[self._parse_state(url) for url in urls] for urls in gt_urls]
+        self._reset_state()
+
+    def _reset_state(self) -> None:
         self._intermediate_url_to_state = {}
 
     def __repr__(self) -> str:
         return repr_with_attr(self, "gt_urls")
 
     async def reset(self) -> None:
-        self._intermediate_url_to_state = {}
+        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: UrlMetricInput = kwargs

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -75,6 +75,9 @@ class GoogleFlightsSearchMatch(BaseMetric):
         # these must parse successfully, otherwise an exception will be raised
         self._gt_base_info = [self._create_base_info(gt_info) for gt_info in gt_info]
 
+        self._reset_state()
+
+    def _reset_state(self) -> None:
         self._url_to_flight_info = defaultdict(Info)
 
     def __repr__(self) -> str:
@@ -131,7 +134,7 @@ class GoogleFlightsSearchMatch(BaseMetric):
         return info
 
     async def reset(self) -> None:
-        self._url_to_flight_info = defaultdict(Info)
+        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: UrlMetricInput = kwargs

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -81,16 +81,18 @@ class OpenTableInfoGathering(BaseMetric):
     def __init__(self, queries: list[list[MultiCandidateQuery]]) -> None:
         super().__init__()
         self.queries = queries
+        self._reset_state()
 
+    def _reset_state(self) -> None:
         # all the information gathered along the steps
         self._all_infos: list[list[InfoDict]] = []
 
         # whether the query is covered
-        self._is_query_covered: list[bool] = [False] * len(queries)
+        self._is_query_covered: list[bool] = [False] * len(self.queries)
 
         # to claim a query is unavailable, we need to collect the evidences to support the claim
         self._unavailable_evidences: list[list[list[InfoDict]]] = [
-            [[] for _ in alternative_conditions] for alternative_conditions in queries
+            [[] for _ in alternative_conditions] for alternative_conditions in self.queries
         ]
 
     def __repr__(self) -> str:
@@ -116,9 +118,7 @@ class OpenTableInfoGathering(BaseMetric):
                 yield i, alternative_conditions
 
     async def reset(self) -> None:
-        self._all_infos = []
-        self._is_query_covered = [False] * len(self.queries)
-        self._unavailable_evidences = [[[] for _ in alternative_conditions] for alternative_conditions in self.queries]
+        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: InputDict = kwargs

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -177,10 +177,13 @@ class ResyUrlMatch(BaseMetric):
         """
         super().__init__()
         self.queries = queries
+        self._reset_state()
+
+    def _reset_state(self) -> None:
         # Track which queries have been covered
-        self._is_query_covered: list[bool] = [False] * len(queries)
+        self._is_query_covered: list[bool] = [False] * len(self.queries)
         self._query_states_by_group = self._build_query_states()
-        self._coverage_reasons: list[dict[str, Any] | None] = [None] * len(queries)
+        self._coverage_reasons: list[dict[str, Any] | None] = [None] * len(self.queries)
 
     def __repr__(self) -> str:
         return repr_with_attr(self, "queries")
@@ -196,9 +199,7 @@ class ResyUrlMatch(BaseMetric):
         return read_sidecar(__file__, "resy_availability_extractor.js")
 
     async def reset(self) -> None:
-        self._is_query_covered = [False] * len(self.queries)
-        self._query_states_by_group = self._build_query_states()
-        self._coverage_reasons = [None] * len(self.queries)
+        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: InputDict = kwargs


### PR DESCRIPTION
## What

Five `BaseMetric` subclasses each independently duplicate their mutable-state initialization between `__init__` and `reset()` — the exact same assignments appear twice, verbatim, in each class:

- `navi_bench/apartments/apartments_url_match.py` — `ApartmentsUrlMatch`
- `navi_bench/craigslist/craigslist_url_match.py` — `CraigslistUrlMatch`
- `navi_bench/google_flights/google_flights_search_match.py` — `GoogleFlightsSearchMatch`
- `navi_bench/resy/resy_url_match.py` — `ResyUrlMatch`
- `navi_bench/opentable/opentable_info_gathering.py` — `OpenTableInfoGathering`

This is exactly the "someone adds a new piece of mutable state and only updates one of the two spots" bug class — `__init__` and `reset()` are supposed to produce identical initial state but the logic was hand-copied instead of shared.

Extracted a private synchronous `_reset_state()` helper in each class, called once from `__init__` (after immutable ground-truth fields like `queries`/`gt_urls` are set) with `async def reset(self)` now delegating to it as a one-liner.

## Why it's safe

- Purely mechanical — moving identical lines that already existed in two places into one place, called from both. No branching, no new logic, no change to what values get assigned or when.
- Same fields, same initial values, same order in every case.
- Existing tests construct each class via `__init__` (`tests/test_apartments_url_match.py`, `tests/test_resy_url_match.py`, `tests/test_opentable_info_gathering.py`), so the `__init__` path stays covered; the `reset()` path is trivially identical to the extracted helper by construction.
- Full test suite passes unchanged: `pytest tests/` — 284 passed.

## Scope

5 files, purely mechanical extract-method refactor. No production behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_0143tDC2FScrLKaUccNHadNZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extract-method refactor in eval-only benchmark code; no scoring or production logic changes.
> 
> **Overview**
> Five **benchmark metrics** (`ApartmentsUrlMatch`, `CraigslistUrlMatch`, `GoogleFlightsSearchMatch`, `OpenTableInfoGathering`, `ResyUrlMatch`) no longer duplicate mutable-state setup in both `__init__` and `async reset()`.
> 
> Each class now defines a private **`_reset_state()`** that holds the same assignments that used to appear twice (match flags, URL caches, coverage arrays, unavailable-evidence structures, etc.). **`__init__`** sets immutable config (`gt_urls`, `queries`, parsed GT state) then calls `_reset_state()`; **`reset()`** only delegates to `_reset_state()`.
> 
> In **OpenTable** and **Resy**, list comprehensions inside `_reset_state()` now size off **`self.queries`** instead of the constructor parameter name—behavior unchanged, slightly clearer when reset runs later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09453dfae9ddead19fbb736545f95150ed476a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->