### PR TITLE
refactor(relative_dates): dedupe ordinal-day parsing onto shared _DAY_NUM pattern

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -175,7 +175,7 @@ def _canon(s: str) -> str:
 
 
 def _parse_ordinal_day(tok: str) -> int | None:
-    m = re.fullmatch(r"(\d{1,2})(st|nd|rd|th)?", tok)
+    m = re.fullmatch(_DAY_NUM, tok)
     return int(m.group(1)) if m else None
 
 
@@ -734,9 +734,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
 
     def _day_from(tok: str) -> int | None:
         # Strip trailing punctuation (commas, periods) before matching
-        tok = _clean_tok(tok)
-        m = re.fullmatch(_DAY_NUM, tok)
-        return int(m.group(1)) if m else None
+        return _parse_ordinal_day(_clean_tok(tok))
 
     tokens = s.split()
     i = 0


### PR DESCRIPTION
## What

`navi_bench/relative_dates.py` had the "day token → int" parsing logic duplicated in two places:

- `_parse_ordinal_day()` (module-level) re-declared an inline regex `r"(\d{1,2})(st|nd|rd|th)?"` that is functionally identical to the already-extracted module constant `_DAY_NUM = r"(\d{1,2})(?:st|nd|rd|th)?"` — the only difference is a capturing vs. non-capturing suffix group, which is irrelevant since only `group(1)` is ever read.
- `_day_from()`, a nested closure inside `parse_relative_dates()`, independently did the same `fullmatch(_DAY_NUM, ...) -> int(m.group(1)) if m else None` after cleaning the token.

Now `_parse_ordinal_day()` uses the shared `_DAY_NUM` constant, and `_day_from()` just calls `_parse_ordinal_day(_clean_tok(tok))` instead of re-implementing the match/extract logic.

## Why it's safe

- Verified the two regex variants match the identical set of strings and extract the identical `group(1)` value (confirmed with a standalone repro across `"5"`, `"5th"`, `"21st"`, `"3rd"`, `"100"`, `"abc"`, `"02nd"`).
- `tests/test_relative_dates.py` (44 tests) passes unchanged after the change.
- `ruff check` passes.
- Single file touched, no signature or call-site changes — `_parse_ordinal_day` is called from 8 other sites in this file unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HauDbyvqDezsv7H1Z3iuVw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor with equivalent regex semantics; parsing behavior should be unchanged if tests pass.
> 
> **Overview**
> **Deduplicates ordinal day parsing** in `navi_bench/relative_dates.py` so one helper owns the logic.
> 
> `_parse_ordinal_day()` now matches tokens with the existing `_DAY_NUM` regex constant instead of a separate inline pattern. The nested `_day_from()` used when scanning multi-day phrases (e.g. `next Nov 9th, 16th, …`) no longer repeats `fullmatch` + `group(1)`; it cleans the token and calls `_parse_ordinal_day()`.
> 
> No API or behavior change intended—same accepted day strings and same integer extraction for all existing call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebed8d82892a0d8088925bb0deef641da1723459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->