### PR TITLE
refactor(relative_dates): remove unreachable strict "of the &lt;mod&gt; month" branch

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -345,13 +345,6 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
         mod = _normalize_modifier(m.group(2))
         return _day_in_shifted_month(base, day, _shift_for_modifier(mod), return_iso)
 
-    # Keep the original strict "of the <mod> month" for safety
-    m = re.fullmatch(rf"{_ORDINAL_DAY}\s+of\s+the\s+{_MOD_GROUP}\s+month", s)
-    if m:
-        day = _parse_ordinal_day(m.group(1))
-        mod = _normalize_modifier(m.group(2))
-        return _day_in_shifted_month(base, day, _shift_for_modifier(mod), return_iso)
-
     # ----------------------------
     # D) "<D> in N months"
     # ----------------------------

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -153,6 +153,26 @@ class TestMonthDayRangePattern:
         assert parse_relative_dates("Dec 5-3", BASE_DATE) == ["2025-12-03", "2025-12-04", "2025-12-05"]
 
 
+class TestOfTheModMonthBranch:
+    """Characterization tests for the "<D> of the <mod> month" branch of
+    ``parse_relative_date`` (e.g. "26th of the next month"). The loose pattern here
+    (optional leading "on"/"the", optional "of"/"the" before the modifier) is a strict
+    superset of the "<D> of the <mod> month" literal phrasing, so it always matches first
+    and the phrasing pins down that the loose pattern alone is sufficient -- no separate
+    "strict" fallback pattern is reachable or needed."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("26th of the next month", "2025-12-26"),
+            ("3rd of the last month", "2025-10-03"),
+            ("1st of the this month", "2025-11-01"),
+        ],
+    )
+    def test_of_the_mod_month_phrasing(self, text, expected):
+        assert parse_relative_date(text, BASE_DATE) == expected
+
+
 class TestWeekdaysInMonthRangeBranch:
     """Characterization tests for the ``parse_relative_dates`` "<weekdays> in <month-ref>
     through <month-ref>" branch (e.g. "Mondays and Fridays in next Jan through Mar"), which


### PR DESCRIPTION
## What

`parse_relative_date()`'s "C) `<D> of the <mod> month` AND loose variants" section in `navi_bench/relative_dates.py` had a duplicate fallback regex immediately after the main one:

```python
m = re.fullmatch(
    rf"(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+(?:of\s+)?(?:the\s+)?{_MOD_GROUP}\s+month",
    s,
)
if m:
    ...
    return _day_in_shifted_month(...)

# Keep the original strict "of the <mod> month" for safety
m = re.fullmatch(rf"{_ORDINAL_DAY}\s+of\s+the\s+{_MOD_GROUP}\s+month", s)
if m:
    ...  # identical body
    return _day_in_shifted_month(...)
```

## Why this is dead code

The first ("loose") pattern has optional `(?:of\s+)?` and `(?:the\s+)?` groups between the day and the modifier. Every string matched by the second ("strict") pattern — which requires the literal `of the` — is therefore also matched by the loose pattern, since the loose pattern's two optional groups can independently match `of ` and `the ` to reconstruct the same literal text. Because the loose branch runs first and returns immediately on match, the strict branch can never execute.

Verified exhaustively (not just by inspection): a script cross-checked both regexes against 480 combinations of day tokens × modifiers × optional prefixes × middle tokens (`of `, `of the `, `the `, ``) — zero cases where the strict pattern matched but the loose pattern didn't.

## Safety

- Single file touched for the fix (`navi_bench/relative_dates.py`), plus one test file.
- Added `TestOfTheModMonthBranch` in `tests/test_relative_dates.py` first, pinning the "of the `<mod>` month" phrasing (including a case using `"of the this month"`, exercising both optional middle groups at once) — confirmed passing *before* the removal.
- Removed the dead branch; re-ran the full suite: 287 passed (284 → 287), identical/improved pass count.
- `ruff check` and `ruff format --check` clean on both touched files.

No behavioral change — the removed branch was provably unreachable, so no user-visible output differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017YCw4NWCHjSFCFrk7FPrhK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in date parsing with characterization tests; removed code was provably unreachable, so runtime behavior should be unchanged.
> 
> **Overview**
> Removes a second **`fullmatch`** in **`parse_relative_date`** section C that required the literal **`of the`** before the month modifier. The remaining loose pattern already covers that phrasing via optional **`of`** / **`the`** groups and returns on the first match, so the strict block was unreachable dead code.
> 
> Adds **`TestOfTheModMonthBranch`** in **`tests/test_relative_dates.py`** to lock in outputs for phrases like **`26th of the next month`**, **`3rd of the last month`**, and **`1st of the this month`** against a fixed base date.
> 
> **No user-visible parsing change** — only deduplication and regression coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c0b1b7c7c8a9cf75de8afcdbdad42492d6f2f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->