### PR TITLE
refactor(opentable): extract _one_week_later helper for weekend offset shift

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -607,6 +607,15 @@ def get_first_weekend_of_next_month_offsets(today: datetime) -> list[int]:
     return [days_to_saturday, days_to_sunday]
 
 
+def _one_week_later(offsets: list[int]) -> list[int]:
+    """Shift a ``[Saturday, Sunday]`` day-offset pair one week later.
+
+    Extracted from ``get_days_until_date``'s "the following weekend" and "the next two
+    weekends" branches, which each computed ``[upcoming[0] + 7, upcoming[1] + 7]`` inline.
+    """
+    return [offset + 7 for offset in offsets]
+
+
 def get_days_until_date(date_label: str, today: datetime) -> list[int]:
     """
     Calculate the number of days until the target date(s) based on the label.
@@ -627,14 +636,12 @@ def get_days_until_date(date_label: str, today: datetime) -> list[int]:
     elif date_label == "upcoming weekend":
         return get_next_weekend_offsets(today)
     elif date_label == "the following weekend":
-        # Get upcoming weekend first, then add 7 days
-        upcoming = get_next_weekend_offsets(today)
-        return [upcoming[0] + 7, upcoming[1] + 7]
+        # Get upcoming weekend first, then shift a week later
+        return _one_week_later(get_next_weekend_offsets(today))
     elif date_label == "the next two weekends":
         # Combine upcoming weekend and following weekend
         upcoming = get_next_weekend_offsets(today)
-        following = [upcoming[0] + 7, upcoming[1] + 7]
-        return upcoming + following
+        return upcoming + _one_week_later(upcoming)
     elif date_label in {"the first weekend of the next calendar month", "the first weekend of next month"}:
         return get_first_weekend_of_next_month_offsets(today)
     elif date_label.startswith("for the upcoming "):

--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -500,6 +500,37 @@ class TestGetDaysUntilDateUpcomingWeekday:
         assert get_days_until_date(f"for the upcoming {weekday_name}", self._TODAY) == [expected_days]
 
 
+class TestGetDaysUntilDateFollowingAndTwoWeekends:
+    """Pin the "the following weekend" and "the next two weekends" branches of
+    ``get_days_until_date``, neither of which had direct test coverage before. Both branches
+    each build a "one week after the upcoming weekend" pair (previously duplicated inline as
+    ``[upcoming[0] + 7, upcoming[1] + 7]`` in both branches) on top of
+    ``get_next_weekend_offsets``. Covers both a mid-week and a weekend "today" so the
+    Saturday/Sunday rollover inside ``get_next_weekend_offsets`` is also exercised through
+    these two call sites.
+    """
+
+    def test_following_weekend_is_one_week_after_upcoming_weekend(self):
+        # 2025-11-06 is a Thursday; upcoming weekend is 11-08/11-09 (offsets [2, 3]),
+        # so the following weekend is 11-15/11-16 (offsets [9, 10]).
+        today = datetime(2025, 11, 6, tzinfo=timezone.utc)
+        assert get_days_until_date("the following weekend", today) == [9, 10]
+
+    def test_following_weekend_from_saturday_today(self):
+        # 2025-11-08 is a Saturday; upcoming weekend rolls to 11-15/11-16 (offsets [7, 8]),
+        # so the following weekend is 11-22/11-23 (offsets [14, 15]).
+        today = datetime(2025, 11, 8, tzinfo=timezone.utc)
+        assert get_days_until_date("the following weekend", today) == [14, 15]
+
+    def test_next_two_weekends_concatenates_upcoming_and_following(self):
+        today = datetime(2025, 11, 6, tzinfo=timezone.utc)
+        assert get_days_until_date("the next two weekends", today) == [2, 3, 9, 10]
+
+    def test_next_two_weekends_from_saturday_today(self):
+        today = datetime(2025, 11, 8, tzinfo=timezone.utc)
+        assert get_days_until_date("the next two weekends", today) == [7, 8, 14, 15]
+
+
 class TestGetNextWeekendOffsets:
     """Pin the exact offsets returned by ``get_next_weekend_offsets``, which delegates its
     Saturday-rollover math to the shared ``relative_dates.days_until_next_weekday`` helper


### PR DESCRIPTION
## What

`get_days_until_date`'s `"the following weekend"` and `"the next two weekends"` branches each
hand-computed `[upcoming[0] + 7, upcoming[1] + 7]` inline — the exact same expression
duplicated verbatim in two places. Extracted a small `_one_week_later(offsets: list[int])`
helper and reused it in both branches.

## Why

Both branches were also previously uncovered by direct tests (only exercised transitively via
`DATE_OPTIONS`), so per this repo's convention I added characterization tests first, pinning
current behavior across both a mid-week and a Saturday "today" (the latter also exercises the
Saturday/Sunday rollover inside `get_next_weekend_offsets` through these call sites), then did
the extraction.

## Safety verification

- This is a **pure refactor** — no latent bug. Unlike several recent fixes in this file
  (`get_next_weekend_offsets`/`get_first_weekend_of_next_month_offsets`'s Saturday-rollover and
  month-rollover bugs), this duplication was just "add 7 to two offsets," done identically in
  both spots — no rollover/edge-case divergence was possible here.
- Added 4 new characterization tests in `tests/test_opentable_info_gathering.py` pinning the
  exact offsets for both branches before touching the implementation; they pass unchanged after
  the refactor.
- Ran a 400-day randomized/grid parity check comparing the new helper's output against the old
  inline formula for both branches across every day from 2025-01-01 through ~2026-02: zero
  mismatches.
- Full suite: `pytest tests/` — 291 passed (287 existing + 4 new).
- `ruff check` and `ruff format --check` pass clean on both changed files (two unrelated
  pre-existing formatting diffs in `evaluation/eval_n1.py` / `navi_bench/dates.py` were
  confirmed present before this change via `git stash` and are untouched by this PR).

🤖 Generated with automated structural-refactor cronjob

https://claude.ai/code/session_018WNg7fVJuZduRGPZEYmfke


---
_Generated by [Claude Code](https://claude.ai/code/session_018WNg7fVJuZduRGPZEYmfke)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of date-offset math with new tests locking existing behavior; no auth, data, or API surface changes.
> 
> **Overview**
> Introduces **`_one_week_later`** to centralize the “add 7 days to each weekend offset” logic that was duplicated in **`get_days_until_date`** for **`"the following weekend"`** and **`"the next two weekends"`**.
> 
> Those branches now call the helper instead of inlining **`[upcoming[0] + 7, upcoming[1] + 7]`**; behavior is unchanged.
> 
> Adds **`TestGetDaysUntilDateFollowingAndTwoWeekends`** with four tests (mid-week and Saturday **`today`**) so those date labels and weekend rollover through **`get_next_weekend_offsets`** stay pinned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33619b1ccb6b69f5e5f047722c266daebde5798d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->