### PR TITLE
refactor(resy): collapse ResyUrlMatch._normalize_url's two bool flags into one mode enum

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -216,7 +216,10 @@ class ResyUrlMatch(BaseMetric):
         )
 
         availabilities = await self._extract_availabilities(page)
-        normalized_url = self._normalize_url(url, ignore_seats_time=has_no_availability)
+        # "no availability" detected -> relax matching to date-only, since the entire day is
+        # unavailable regardless of party size or time slot.
+        normalize_mode: Literal["full", "date_only"] = "date_only" if has_no_availability else "full"
+        normalized_url = self._normalize_url(url, mode=normalize_mode)
         normalized_url_without_time = self._normalize_url_without_time(url)
         url_time = self._extract_time_from_url(url)
 
@@ -239,7 +242,7 @@ class ResyUrlMatch(BaseMetric):
             # Check if the URL matches any alternative in this query group
             for state in group_states:
                 gt_url = state.gt_url
-                normalized_gt_url = self._normalize_url(gt_url, ignore_seats_time=has_no_availability)
+                normalized_gt_url = self._normalize_url(gt_url, mode=normalize_mode)
                 logger.debug(
                     f"ResyUrlMatch.update comparing normalized_url={normalized_url} "
                     f"with normalized_gt_url={normalized_gt_url} (group={group_index}, alt={state.alt_index})"
@@ -342,7 +345,7 @@ class ResyUrlMatch(BaseMetric):
             states.append(group_states)
         return states
 
-    def _normalize_url(self, url: str, ignore_seats_time: bool = False, include_time: bool = True) -> str:
+    def _normalize_url(self, url: str, mode: Literal["full", "no_time", "date_only"] = "full") -> str:
         """
         Normalize Resy URL for comparison.
 
@@ -358,12 +361,15 @@ class ResyUrlMatch(BaseMetric):
 
         Args:
             url: The URL to normalize
-            ignore_seats_time: If True, exclude 'seats' and 'time' parameters from the normalized URL.
-                              This is used when "no availability" is detected, since the entire day is
-                              unavailable regardless of party size or time slot.
-            include_time: If False (and ignore_seats_time is False), include 'date' and 'seats' but
-                          drop 'time'. Used by ``_normalize_url_without_time`` for conditional matching
-                          when the time slot differs but everything else about the query matches.
+            mode: Which query parameters to keep, replacing what used to be two overlapping bool
+                  flags (``ignore_seats_time``/``include_time``) with only three of their four
+                  combinations ever reachable:
+                  - "full": keep 'date', 'seats', and 'time' (strict matching, the default).
+                  - "no_time": keep 'date' and 'seats' but drop 'time'. Used by
+                    ``_normalize_url_without_time`` for conditional matching when the time slot
+                    differs but everything else about the query matches.
+                  - "date_only": keep only 'date'. Used when "no availability" is detected, since
+                    the entire day is unavailable regardless of party size or time slot.
         """
         parsed, fallback = basic_normalize_url(url, "resy.com")
         if parsed is None:
@@ -398,16 +404,12 @@ class ResyUrlMatch(BaseMetric):
         # parse_qs returns lists, so we take the first value
         normalized_params = {}
 
-        # Determine which parameters to include based on ignore_seats_time/include_time flags
-        if ignore_seats_time:
-            # Only include date (ignore seats and time when no availability detected)
-            params_to_include = ["date"]
-        elif include_time:
-            # Include all parameters for strict matching
-            params_to_include = ["date", "seats", "time"]
-        else:
-            # Include date and seats, but drop time (conditional matching)
-            params_to_include = ["date", "seats"]
+        # Determine which parameters to include based on mode
+        params_to_include = {
+            "full": ["date", "seats", "time"],
+            "no_time": ["date", "seats"],
+            "date_only": ["date"],
+        }[mode]
 
         for key in params_to_include:
             if key in query_params and query_params[key]:
@@ -422,7 +424,7 @@ class ResyUrlMatch(BaseMetric):
         return result
 
     def _normalize_url_without_time(self, url: str) -> str:
-        return self._normalize_url(url, ignore_seats_time=False, include_time=False)
+        return self._normalize_url(url, mode="no_time")
 
     async def _extract_availabilities(self, page: PageLike) -> list[AvailabilitySlot]:
         raw_availabilities = await safe_evaluate(


### PR DESCRIPTION
## Structural issue

`ResyUrlMatch._normalize_url` took two overlapping boolean flags, `ignore_seats_time` and `include_time`, which together encode 4 possible combinations. Looking at the actual call sites, only 3 of those 4 combinations are ever reachable:

- `ignore_seats_time=False, include_time=True` -> "full" (date+seats+time)
- `ignore_seats_time=False, include_time=False` -> "no_time" (date+seats), used by `_normalize_url_without_time`
- `ignore_seats_time=True, include_time=True` -> "date_only", used when "no availability" is detected
- `ignore_seats_time=True, include_time=False` -> **dead**, never constructed anywhere

This is a classic "overly broad interface" smell: two independent-looking booleans that actually encode one 3-state choice, with a silently-unreachable 4th state that a future caller could accidentally hit.

## The change

Replaced the two bools with a single `mode: Literal["full", "no_time", "date_only"] = "full"` parameter naming exactly the three states in use (matching the vocabulary the original docstring already used per-branch). Also factored the `has_no_availability`-dependent mode selection into one `normalize_mode` local in `update()` instead of repeating the same ternary at both of its call sites.

Single file touched: `navi_bench/resy/resy_url_match.py`. No other files reference `_normalize_url`'s bool kwargs (checked call sites and tests).

## Why it's safe

- Purely an interface/internal refactor of one private method (`_normalize_url`) and its two internal call sites plus its `_normalize_url_without_time` wrapper — no verifier scoring/matching logic changed.
- Confirmed the three reachable old flag-combinations map 1:1 onto the three new `mode` values by inspection of every call site.
- Full test suite passes: `pytest tests/ --ignore=tests/test_vis.py` -> 232 passed (test_vis.py fails to collect in this sandbox only because the private `yutori` package isn't installed here, unrelated to this change).
- `ruff check` and `ruff format --check` both pass on the changed file.
- Manually verified byte-identical output for all three modes against the pre-refactor behavior, e.g.:
  ```
  full:      resy.com/cities/sf/venues/foo?date=2025-07-15&seats=2&time=18:00
  no_time:   resy.com/cities/sf/venues/foo?date=2025-07-15&seats=2
  date_only: resy.com/cities/sf/venues/foo?date=2025-07-15
  ```
  and that `_normalize_url_without_time(url) == _normalize_url(url, mode="no_time")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYt9tG49cTU9oGDFeAawYP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor of private normalization helpers with 1:1 behavior mapping; no changes to Resy coverage or scoring logic.
> 
> **Overview**
> **`ResyUrlMatch._normalize_url`** no longer takes overlapping `ignore_seats_time` / `include_time` booleans. It now takes a single `mode` argument: `"full"`, `"no_time"`, or `"date_only"`, matching the three behaviors that were actually used in production.
> 
> In **`update()`**, the no-availability branch picks `normalize_mode` once (`date_only` vs `full`) and passes it to both browser and ground-truth normalizations instead of repeating the same flag at each call site. **`_normalize_url_without_time`** is now a thin wrapper that calls `_normalize_url(..., mode="no_time")`.
> 
> Parameter selection inside **`_normalize_url`** is a small mode→field list map instead of nested if/elif on the old flags. **URL matching and verifier scoring behavior are unchanged**—this is an internal API cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03bea6f431635957eb65b3151470b9b157b7bceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->