### PR TITLE
refactor(base): extract shared unwrap_single_template_query helper

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import Any, TypedDict, Union, get_args, get_origin
+from typing import Any, TypedDict, TypeVar, Union, get_args, get_origin
 from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value
@@ -137,6 +137,30 @@ def parse_filtered_query_params(query: str, ignored: Iterable[str]) -> dict[str,
     comparison.
     """
     return {k: v for k, v in parse_qs(query).items() if k not in ignored}
+
+
+_T = TypeVar("_T")
+
+
+def unwrap_single_template_query(
+    template_query: list[list[_T]],
+    *,
+    group_message: str,
+    item_message: str,
+) -> _T:
+    """Validate ``template_query`` is a single query group containing a single item, then return it.
+
+    Centralizes the "assert exactly one query group, assert exactly one item within it, then
+    unwrap to ``template_query[0][0]``" precondition that opentable's and resy's
+    ``_render_placeholders_in_queries_all`` each repeated verbatim (mode='all' multi-date
+    expansion only supports a single templated query/URL) before diverging into their own
+    per-placeholder expansion logic. ``group_message``/``item_message`` are the exact
+    ``AssertionError`` text each caller already used, kept caller-specific since they name the
+    domain-specific unit (e.g. "candidate object", "URL").
+    """
+    assert len(template_query) == 1, group_message
+    assert len(template_query[0]) == 1, item_message
+    return template_query[0][0]
 
 
 def omni_import(path: str):

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -22,6 +22,7 @@ from navi_bench.base import (
     read_sidecar,
     repr_with_attr,
     safe_evaluate,
+    unwrap_single_template_query,
 )
 from navi_bench.dates import (
     ensure_resolved_dates,
@@ -828,9 +829,11 @@ def _render_placeholders_in_queries_all(
     Returns:
         Expanded list of queries, one per date
     """
-    assert len(template_query) == 1, "Only support single query for now"
-    assert len(template_query[0]) == 1, "Only support one candidate object per query for now"
-    template_query_dict = template_query[0][0]
+    template_query_dict = unwrap_single_template_query(
+        template_query,
+        group_message="Only support single query for now",
+        item_message="Only support one candidate object per query for now",
+    )
 
     queries = []
     for placeholder_key, (_, dates) in resolved_placeholders.items():

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -22,6 +22,7 @@ from navi_bench.base import (
     read_sidecar,
     repr_with_attr,
     safe_evaluate,
+    unwrap_single_template_query,
 )
 from navi_bench.dates import (
     ensure_resolved_dates,
@@ -1092,11 +1093,11 @@ def _render_placeholders_in_queries_all(
     Returns:
         Expanded list of queries, one per date
     """
-    assert len(template_query) == 1, "Only single query group is supported in the template for multi-date expansion"
-    assert len(template_query[0]) == 1, (
-        "Only single URL per query group is supported in the template for multi-date expansion"
+    template_url = unwrap_single_template_query(
+        template_query,
+        group_message="Only single query group is supported in the template for multi-date expansion",
+        item_message="Only single URL per query group is supported in the template for multi-date expansion",
     )
-    template_url = template_query[0][0]
 
     queries = []
     for placeholder_key, (_, dates) in resolved_placeholders.items():


### PR DESCRIPTION
## Structural issue

`navi_bench/opentable/opentable_info_gathering.py`'s and `navi_bench/resy/resy_url_match.py`'s `_render_placeholders_in_queries_all` (the `mode='all'` multi-date expansion path for each domain's `generate_task_config_deterministic`) each repeated the identical precondition:

```python
assert len(template_query) == 1, "<domain-specific group message>"
assert len(template_query[0]) == 1, "<domain-specific item message>"
template_x = template_query[0][0]
```

Both only support expanding a single templated query/URL, and both validate that with the same two-assert-then-unwrap shape, differing only in their message text.

## Change

Extracted a shared `unwrap_single_template_query(template_query, *, group_message, item_message)` helper into `navi_bench/base.py` (alongside the other cross-domain matcher helpers like `repr_with_attr`, `all_or_nothing_coverage_result`, `parse_filtered_query_params`). Each caller passes its own exact original message strings, so the `AssertionError` text is byte-for-byte unchanged.

## Why it's safe

- Zero behavior change: the assert conditions, unwrap logic, and exact error message text are all preserved per call site.
- This is task-generation/config-expansion boilerplate, not verification/scoring logic — no eval outcome is affected.
- No test asserts on these specific `AssertionError` messages (checked `tests/test_resy_url_match.py` and `tests/test_opentable_info_gathering.py`).
- Full test suite passes locally: `296 passed`.
- `ruff check` and `ruff format --check` clean on all three touched files.

Scope: 3 files (`navi_bench/base.py`, `navi_bench/opentable/opentable_info_gathering.py`, `navi_bench/resy/resy_url_match.py`), no drive-by changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_016pCwymiCMikDwBus3TTkcr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of task-config expansion preconditions with preserved assertions and error messages; no scoring or verification logic changes.
> 
> **Overview**
> Adds **`unwrap_single_template_query`** in `navi_bench/base.py` to centralize the repeated “exactly one query group, exactly one item, then return `template_query[0][0]`” checks used by **`mode='all'`** multi-date expansion.
> 
> **OpenTable** (`_render_placeholders_in_queries_all`) and **Resy** (`_render_placeholders_in_queries_all`) now call the helper instead of inline `assert` + unwrap. Each site still passes its **original** `group_message` / `item_message` strings, so failure behavior and `AssertionError` text stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a46f76a69ed19feeb832b89f26e955b54360a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->