### PR TITLE
refactor: extract shared isVisible() DOM helper for resy/opentable JS

### DIFF
--- a/navi_bench/dom_visibility.js
+++ b/navi_bench/dom_visibility.js
@@ -1,0 +1,36 @@
+/**
+ * Shared DOM-visibility check.
+ *
+ * Returns true iff at least 50% of `el`'s bounding rect area is currently within the
+ * viewport. Extracted because `resy/resy_no_availability_check.js` and
+ * `opentable/opentable_info_gathering.js` each defined byte-for-byte identical copies of
+ * this function to decide whether an availability slot / "no availability" message is
+ * actually visible on screen before treating it as evidence.
+ *
+ * Callers load this file as a script preamble (see `read_sidecar` call sites in
+ * `resy_url_match.py`/`opentable_info_gathering.py`) so `isVisible` is in scope via
+ * closure for the IIFE that follows in the same evaluated script.
+ */
+const isVisible = (el) => {
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+
+    // Calculate the visible area of the element
+    const visibleTop = Math.max(rect.top, 0);
+    const visibleLeft = Math.max(rect.left, 0);
+    const visibleBottom = Math.min(rect.bottom, viewportHeight);
+    const visibleRight = Math.min(rect.right, viewportWidth);
+
+    // If element is completely outside viewport
+    if (visibleTop >= visibleBottom || visibleLeft >= visibleRight) {
+        return false;
+    }
+
+    const visibleArea = (visibleBottom - visibleTop) * (visibleRight - visibleLeft);
+    const totalArea = rect.height * rect.width;
+
+    // Consider visible if at least 50% of the element is in viewport
+    return totalArea > 0 && (visibleArea / totalArea) >= 0.5;
+};

--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -1,29 +1,9 @@
 (() => {
+    // `isVisible` is defined by the shared ../dom_visibility.js preamble (see
+    // opentable_info_gathering.py's js_script property), which loads it into scope ahead
+    // of this IIFE.
     const results = [];
     const url = window.location.href.replace(/\/+$/, "");
-
-    const isVisible = (el) => {
-        const rect = el.getBoundingClientRect();
-        const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-        const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
-
-        // Calculate the visible area of the element
-        const visibleTop = Math.max(rect.top, 0);
-        const visibleLeft = Math.max(rect.left, 0);
-        const visibleBottom = Math.min(rect.bottom, viewportHeight);
-        const visibleRight = Math.min(rect.right, viewportWidth);
-
-        // If element is completely outside viewport
-        if (visibleTop >= visibleBottom || visibleLeft >= visibleRight) {
-            return false;
-        }
-
-        const visibleArea = (visibleBottom - visibleTop) * (visibleRight - visibleLeft);
-        const totalArea = rect.height * rect.width;
-
-        // Consider visible if at least 50% of the element is in viewport
-        return totalArea > 0 && (visibleArea / totalArea) >= 0.5;
-    };
 
     const isRecorded = (el) => {
         return el.getAttribute("__recorded") === "true";

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -101,7 +101,14 @@ class OpenTableInfoGathering(BaseMetric):
 
     @functools.cached_property
     def js_script(self) -> str:
-        return read_sidecar(__file__, "opentable_info_gathering.js")
+        """Load the JavaScript for gathering restaurant availability info.
+
+        Prefixed with the shared ``isVisible`` DOM-visibility helper (../dom_visibility.js)
+        that this script relies on via closure, also shared with ResyUrlMatch.
+        """
+        shared_helpers = read_sidecar(__file__, "../dom_visibility.js")
+        script = read_sidecar(__file__, "opentable_info_gathering.js")
+        return f"{shared_helpers}\n{script}"
 
     def _iter_uncovered_queries(self) -> Iterator[tuple[int, list[MultiCandidateQuery]]]:
         """Yield ``(i, alternative_conditions)`` for each query in ``self.queries`` not yet

--- a/navi_bench/resy/resy_no_availability_check.js
+++ b/navi_bench/resy/resy_no_availability_check.js
@@ -2,31 +2,11 @@
     /**
      * Simple check for "no online availability" message on Resy pages.
      * Returns true if the message is found and visible, false otherwise.
+     *
+     * Relies on `isVisible` being defined by the shared ../dom_visibility.js preamble
+     * (see resy_url_match.py's js_script property), which loads it into scope ahead of
+     * this IIFE.
      */
-    
-    const isVisible = (el) => {
-        if (!el) return false;
-        const rect = el.getBoundingClientRect();
-        const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-        const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
-
-        // Calculate the visible area of the element
-        const visibleTop = Math.max(rect.top, 0);
-        const visibleLeft = Math.max(rect.left, 0);
-        const visibleBottom = Math.min(rect.bottom, viewportHeight);
-        const visibleRight = Math.min(rect.right, viewportWidth);
-
-        // If element is completely outside viewport
-        if (visibleTop >= visibleBottom || visibleLeft >= visibleRight) {
-            return false;
-        }
-
-        const visibleArea = (visibleBottom - visibleTop) * (visibleRight - visibleLeft);
-        const totalArea = rect.height * rect.width;
-
-        // Consider visible if at least 50% of the element is in viewport
-        return totalArea > 0 && (visibleArea / totalArea) >= 0.5;
-    };
 
     // Look for the "no online availability" message
     const availabilityMessages = document.querySelectorAll('.ShiftInventory__availability-message');

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -191,8 +191,14 @@ class ResyUrlMatch(BaseMetric):
 
     @functools.cached_property
     def js_script(self) -> str:
-        """Load the JavaScript for checking 'no availability' message"""
-        return read_sidecar(__file__, "resy_no_availability_check.js")
+        """Load the JavaScript for checking 'no availability' message.
+
+        Prefixed with the shared ``isVisible`` DOM-visibility helper (../dom_visibility.js)
+        that this script relies on via closure, also shared with OpenTableInfoGathering.
+        """
+        shared_helpers = read_sidecar(__file__, "../dom_visibility.js")
+        script = read_sidecar(__file__, "resy_no_availability_check.js")
+        return f"{shared_helpers}\n{script}"
 
     @functools.cached_property
     def availability_script(self) -> str:


### PR DESCRIPTION
## Structural issue

`navi_bench/resy/resy_no_availability_check.js` and `navi_bench/opentable/opentable_info_gathering.js` each defined a byte-for-byte identical `isVisible(el)` helper (a viewport area-overlap check: "visible if at least 50% of the element's bounding rect is within the viewport"). The only difference between the two copies was a missing `if (!el) return false;` null-guard in the opentable copy — never exercised in practice, since both call sites only ever invoke it on real elements yielded by `querySelectorAll(...).forEach(...)`.

## Change

Extracted the duplicated function into a new shared file, `navi_bench/dom_visibility.js`. Each Python call site's `js_script` cached property now loads it as a script preamble (via the existing `read_sidecar` helper) ahead of its own IIFE:

```python
shared_helpers = read_sidecar(__file__, "../dom_visibility.js")
script = read_sidecar(__file__, "resy_no_availability_check.js")
return f"{shared_helpers}\n{script}"
```

Since both scripts are evaluated as one concatenated script string via `page.evaluate(...)`, the inner IIFE picks up `isVisible` from the enclosing scope through normal JS closure — no wrapper/module system needed.

## Why it's safe

- Zero behavior change: the retained copy (resy's, which has the `!el` guard) is a strict superset of what opentable's copy did, and opentable never calls it with a null element.
- Verified with `node --check` on both composed scripts (shared preamble + each IIFE) — valid syntax.
- Verified with a runtime smoke test (Node + a minimal DOM stub) exercising the closure end-to-end for both composed scripts — both execute correctly and use the shared `isVisible` without `ReferenceError`.
- No test pins the literal JS file contents (checked `tests/test_resy_url_match.py` and `tests/test_opentable_info_gathering.py`).
- Full test suite passes locally: 237 passed (all tests runnable without the heavy `yutori` SDK dependency, which `test_vis.py` needs and is unrelated to this change).
- `ruff check` and `ruff format --check` clean on all touched Python files.

Scope: 5 files (1 new shared JS file, 2 site JS files with the duplicate removed, 2 Python call sites updated to load the shared preamble). No drive-by changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cvfnjv34LRpY9Twrj3xkoP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication of client-side eval scripts; intended behavior is unchanged aside from aligning OpenTable with Resy’s null-element guard.
> 
> **Overview**
> Deduplicates the viewport visibility helper used when Resy and OpenTable bench scripts decide whether DOM evidence counts.
> 
> Adds **`navi_bench/dom_visibility.js`** with a single **`isVisible`** implementation (≥50% of the element’s bounding rect in the viewport, with a null guard). The identical inline copies are removed from **`resy_no_availability_check.js`** and **`opentable_info_gathering.js`**.
> 
> **`ResyUrlMatch.js_script`** and **`OpenTableInfoGathering.js_script`** now prepend that file via **`read_sidecar`** before the site-specific IIFE so **`page.evaluate`** still sees **`isVisible`** in closure scope—no module wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea6378a3c60b09bef66135d93121d6c480ebf5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->