### PR TITLE
refactor(relative_dates): delegate _expand_md_range day-clamping to clamp_day

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -506,9 +506,10 @@ def _expand_md_range(
     """
     if end_day < start_day:
         start_day, end_day = end_day, start_day
-    last = _days_in_month(y, m)
-    start_day = max(1, min(start_day, last))
-    end_day = max(1, min(end_day, last))
+    # clamp_day (not raw min/max against _days_in_month) so day clamping stays consistent
+    # with every other "bump year, clamp day" rollover in this module.
+    start_day = clamp_day(y, m, max(1, start_day)).day
+    end_day = clamp_day(y, m, max(1, end_day)).day
 
     # If using "next" modifier and the start of the range has passed, bump to next year
     # Check against current year first to handle cases where _month_ref_to_year_month
@@ -521,10 +522,10 @@ def _expand_md_range(
             # Otherwise bump to next year
             if y <= base.year:
                 y += 1
-                # Revalidate days for new year (handles leap year edge cases)
-                last = _days_in_month(y, m)
-                start_day = max(1, min(start_day, last))
-                end_day = max(1, min(end_day, last))
+                # Re-clamp via clamp_day for the new year (handles leap year Feb 29 -> 28
+                # rollover instead of raising ValueError)
+                start_day = clamp_day(y, m, start_day).day
+                end_day = clamp_day(y, m, end_day).day
 
     return [date(y, m, d) for d in range(start_day, end_day + 1)]
 

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -14,7 +14,12 @@ from datetime import date
 
 import pytest
 
-from navi_bench.relative_dates import days_until_next_weekday, parse_relative_date, parse_relative_dates
+from navi_bench.relative_dates import (
+    _expand_md_range,
+    days_until_next_weekday,
+    parse_relative_date,
+    parse_relative_dates,
+)
 
 
 BASE_DATE = date(2025, 11, 6)  # a Thursday
@@ -365,3 +370,65 @@ class TestFeb29YearBump:
             "2029-02-17",
             "2029-02-24",
         ]
+
+
+class TestExpandMdRangeDirect:
+    """Direct coverage for ``_expand_md_range`` (no prior direct test coverage; it was
+    previously only exercised indirectly through ``parse_relative_dates``). Pins its
+    day-clamping behavior, including the "next"-modifier year-bump branch, which now
+    delegates to ``clamp_day`` instead of hand-rolling ``_days_in_month``/``min``/``max``
+    twice (matching the "bump year, clamp day" idiom already used elsewhere in this module,
+    e.g. ``TestFeb29YearBump`` above)."""
+
+    def test_no_modifier_no_bump(self):
+        assert _expand_md_range(2025, 5, 11, 14) == [
+            date(2025, 5, 11),
+            date(2025, 5, 12),
+            date(2025, 5, 13),
+            date(2025, 5, 14),
+        ]
+
+    def test_reversed_start_end_normalized(self):
+        assert _expand_md_range(2025, 5, 14, 11) == [
+            date(2025, 5, 11),
+            date(2025, 5, 12),
+            date(2025, 5, 13),
+            date(2025, 5, 14),
+        ]
+
+    def test_out_of_range_days_clamp_to_month_length(self):
+        # April has 30 days; day 31 should clamp down to 30.
+        assert _expand_md_range(2025, 4, 29, 35) == [date(2025, 4, 29), date(2025, 4, 30)]
+
+    def test_next_modifier_bumps_year_when_start_has_passed(self):
+        base = date(2025, 6, 1)  # after May 11-14, 2025 has already passed
+        assert _expand_md_range(2025, 5, 11, 14, base=base, modifier="next") == [
+            date(2026, 5, 11),
+            date(2026, 5, 12),
+            date(2026, 5, 13),
+            date(2026, 5, 14),
+        ]
+
+    def test_next_modifier_no_bump_when_start_still_upcoming(self):
+        base = date(2025, 4, 1)  # before May 11-14, 2025
+        assert _expand_md_range(2025, 5, 11, 14, base=base, modifier="next") == [
+            date(2025, 5, 11),
+            date(2025, 5, 12),
+            date(2025, 5, 13),
+            date(2025, 5, 14),
+        ]
+
+    def test_next_modifier_feb_29_bumped_into_non_leap_year_clamps_to_28(self):
+        # 2028 is a leap year; bumping "next Feb 27-29" past it lands on 2029, a non-leap
+        # year, so day 29 must clamp to 28 via clamp_day instead of raising ValueError.
+        base = date(2028, 3, 1)  # after Feb 27-29, 2028 has already passed
+        assert _expand_md_range(2028, 2, 27, 29, base=base, modifier="next") == [
+            date(2029, 2, 27),
+            date(2029, 2, 28),
+        ]
+
+    def test_coming_modifier_behaves_like_next(self):
+        base = date(2025, 6, 1)
+        assert _expand_md_range(2025, 5, 11, 14, base=base, modifier="coming") == _expand_md_range(
+            2025, 5, 11, 14, base=base, modifier="next"
+        )


### PR DESCRIPTION
## Issue

`_expand_md_range` in `navi_bench/relative_dates.py` hand-rolled `_days_in_month` + `min`/`max` day-clamping logic **twice** (once on the initial start/end day clamp, once again after the "next"/"coming" modifier bumps the year) instead of delegating to the module's own `clamp_day` helper. Every other "bump year, clamp day" rollover in this file already goes through `clamp_day` (see `TestFeb29YearBump` in `tests/test_relative_dates.py`, added in a prior PR for the same pattern in `_choose_occurrence` and the "from...through" branch) — this function was the one remaining hand-rolled instance of that idiom.

Functionally the existing code already avoided crashing on the Feb 29 → non-leap-year edge case (it re-derives `_days_in_month` after the bump and re-clamps), so this is a pure mechanical dedup, not a bug fix — but it removes duplicated calendar math and brings the function in line with the rest of the module's convention.

## Change

- `_expand_md_range` now calls `clamp_day(y, m, day).day` instead of manually computing `_days_in_month` and doing `max(1, min(day, last))` inline, in both the initial clamp and the post-year-bump re-clamp.

## Safety verification

- **Characterization tests added first**: `_expand_md_range` had no direct test coverage (only indirect coverage through `parse_relative_dates`). Added `TestExpandMdRangeDirect` in `tests/test_relative_dates.py` covering: no-bump case, reversed start/end normalization, out-of-range day clamping, "next"-modifier year bump, no-bump-when-still-upcoming, the Feb 29 → Feb 28 leap-year rollover, and "coming" behaving like "next". These pass against the pre-refactor code first.
- **Numeric parity sweep**: wrote a standalone script pitting the old inline implementation against the new `clamp_day`-based implementation across ~5.3M combinations (years 2020–2032, all months, start/end day 0–31, modifiers `""`/`next`/`coming`/`last`, and base dates offset ±400/±40/±5/±1/0 days from the month) — **0 mismatches**. Re-ran the sweep against the actual post-refactor `_expand_md_range` import (not just a standalone copy) across ~2.66M combinations — **0 mismatches**.
- **Full test suite**: 296 passed before → 303 passed after (296 existing + 7 new characterization tests), all green.
- `ruff check` and `ruff format --check` both pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QMGPpACDfVuWJi8jqcfhwk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor in date-range expansion with new characterization tests and reported numeric parity; no auth, security, or external API surface changes.
> 
> **Overview**
> **`_expand_md_range`** no longer hand-rolls `_days_in_month` plus `min`/`max` for start/end days. It uses **`clamp_day(...).day`** on the initial clamp and again after a **next/coming** year bump, matching the rest of the module’s “bump year, clamp day” pattern.
> 
> Adds **`TestExpandMdRangeDirect`** with seven characterization tests that call **`_expand_md_range`** directly (normalization, month-length clamping, next/coming year bump, Feb 29 → Feb 28 after bump). Intended as parity-preserving refactor, not a behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c51f090900bc058bdc694c0ceef4f0f21fbf26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->