### PR TITLE
refactor(vis): dedupe .section/.step and .nav-btn:hover/.modal-nav:hover CSS rules

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -557,7 +557,7 @@ def generate_visualization_html(
             border: 1px solid var(--accent-yellow);
         }}
 
-        .section {{
+        .section, .step {{
             background: var(--bg-secondary);
             border: 1px solid var(--border-color);
             border-radius: 8px;
@@ -613,14 +613,6 @@ def generate_visualization_html(
             font-size: 0.8rem;
             white-space: pre-wrap;
             word-break: break-word;
-        }}
-
-        .step {{
-            background: var(--bg-secondary);
-            border: 1px solid var(--border-color);
-            border-radius: 8px;
-            margin-bottom: 1.5rem;
-            overflow: hidden;
         }}
 
         .step-header {{
@@ -887,11 +879,6 @@ def generate_visualization_html(
             transition: all 0.2s;
         }}
 
-        .nav-btn:hover {{
-            background: var(--accent-blue);
-            border-color: var(--accent-blue);
-        }}
-
         .text-observation {{
             background: var(--bg-tertiary);
             padding: 0.75rem;
@@ -1024,7 +1011,7 @@ def generate_visualization_html(
             z-index: 1001;
         }}
 
-        .modal-nav:hover {{
+        .nav-btn:hover, .modal-nav:hover {{
             background: var(--accent-blue);
             border-color: var(--accent-blue);
         }}

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -494,3 +494,42 @@ class TestTopLevelSectionsEndToEnd:
         messages = [{"role": "user", "content": [{"type": "text", "text": "do the task"}]}]
         html = generate_visualization_html("task1", messages, None)
         assert "System Prompt" not in html
+
+
+class TestStyleSheetDeduplication:
+    """Pins that the embedded ``<style>`` block declares the ``.section``/``.step`` and
+    ``.nav-btn:hover``/``.modal-nav:hover`` rule bodies exactly once each via a comma-separated
+    selector list, rather than as two separate rules with byte-identical declarations (the
+    latter having gone unnoticed by the many prior Python-logic dedup passes on this file since
+    it lives inside an f-string's literal CSS text rather than in any branching logic).
+    """
+
+    @staticmethod
+    def _html() -> str:
+        messages = [{"role": "user", "content": [{"type": "text", "text": "do the task"}]}]
+        return generate_visualization_html("task1", messages, None)
+
+    def test_section_and_step_share_one_rule_with_all_properties(self):
+        html = self._html()
+        match = re.search(r"\.section,\s*\.step\s*\{([^}]*)\}", html)
+        assert match is not None, html
+        body = match.group(1)
+        for prop in (
+            "background: var(--bg-secondary);",
+            "border: 1px solid var(--border-color);",
+            "border-radius: 8px;",
+            "margin-bottom: 1.5rem;",
+            "overflow: hidden;",
+        ):
+            assert prop in body
+        # The body must appear exactly once in the stylesheet, not once per selector.
+        assert html.count("border-radius: 8px;\n            margin-bottom: 1.5rem;\n            overflow: hidden;") == 1
+
+    def test_nav_btn_hover_and_modal_nav_hover_share_one_rule(self):
+        html = self._html()
+        match = re.search(r"\.nav-btn:hover,\s*\.modal-nav:hover\s*\{([^}]*)\}", html)
+        assert match is not None, html
+        body = match.group(1)
+        assert "background: var(--accent-blue);" in body
+        assert "border-color: var(--accent-blue);" in body
+        assert html.count("background: var(--accent-blue);\n            border-color: var(--accent-blue);") == 1


### PR DESCRIPTION
## Issue

`evaluation/vis.py`'s embedded stylesheet (inside `generate_visualization_html`'s f-string) declared two pairs of CSS rules with byte-for-byte identical bodies under different selectors:

1. `.section { ... }` (5-property body: `background`, `border`, `border-radius`, `margin-bottom`, `overflow`) and `.step { ... }` — same 5 properties, same values, same order.
2. `.nav-btn:hover { ... }` and `.modal-nav:hover { ... }` — same 2 properties (`background`, `border-color`), same values.

This repo has had 168+ merged structural-refactor PRs, several specifically on `vis.py`'s Python-side logic (`_STOP_ACTION_TYPES`, `_ACTION_COLOR_CLASSES`, `_first_present`, `_render_section`/`_render_response_section`, etc. — PRs #101, #111, #113, #120, #122, #123, #126, #129, #131, #132), but none of those passes looked inside the literal CSS text embedded in the f-string, so this duplication went unnoticed.

## Improvement

Merged each pair into a single rule with a comma-separated selector list:
- `.section, .step { ... }`
- `.nav-btn:hover, .modal-nav:hover { ... }`

## Safety

This is a pure CSS-cascade no-op: a comma-separated selector list applies the identical declaration block to all listed selectors, with no change to specificity, cascade order, or computed styles for either class. I checked every HTML/JS reference to `.section`/`.step` and `.nav-btn`/`.modal-nav` in the same file (they only ever add/toggle/query these class names on elements — nothing depends on the *rule* being declared twice).

Verification:
- Added `TestStyleSheetDeduplication` in `tests/test_vis.py` asserting each merged rule appears exactly once (via `html.count(...)`) and contains all of its declared properties.
- Confirmed both new tests **fail** against the pre-fix source (via a temporary revert of just `evaluation/vis.py`) and **pass** after the fix — proving they actually characterize the change.
- Full suite: 305/305 passing (up from 303 baseline + 2 new tests).
- `ruff check` / `ruff format --check`: clean on both touched files.

## Scope

2 files touched: `evaluation/vis.py` (source) and `tests/test_vis.py` (new characterization tests). No functionality change — output HTML renders identically for both merged class pairs.

## Test plan

- [x] `python3 -m pytest tests/` — 305/305 passed
- [x] New tests verified to fail pre-fix / pass post-fix via temporary source revert
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9oHfr8xGbfdHeAwg57qFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9oHfr8xGbfdHeAwg57qFv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only refactor with equivalent cascade; no Python logic or HTML structure changes beyond smaller embedded styles.
> 
> **Overview**
> **Deduplicates literal CSS** inside `generate_visualization_html`'s embedded `<style>` block by merging duplicate selector pairs into comma-separated lists: `.section, .step { … }` and `.nav-btn:hover, .modal-nav:hover { … }`, removing the redundant standalone `.step` and `.nav-btn:hover` rules.
> 
> Adds **`TestStyleSheetDeduplication`** in `tests/test_vis.py` to assert each merged rule appears once in the generated HTML and still contains the expected properties—locking in the stylesheet shape without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96849202ba7010c1917eb280f53d3d4f5a85da29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->