### PR TITLE
refactor(opentable): extract shared handleNextAvailablePopup() helper

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -236,6 +236,96 @@
         return availabilities;
     };
 
+    const handleNextAvailablePopup = (partySize, baseDate, baseTime) => {
+        // Popup when clicking "Show next available"
+        const popup = document.querySelector('[data-test="multi-day-availability-modal"]');
+        if (popup) {
+            const restaurantName = popup.querySelector('h2')?.textContent;
+            let prevAvailable = null;
+            let nextAvailable = null;
+            popup.querySelectorAll('[data-test="multi-day-timeslot-container"]').forEach((el) => {
+                if (isVisible(el)) {
+                    const { date, _ } = parseDateAndTimes(el.textContent);
+                    const timesArray = Array.from(el.querySelectorAll('li'))
+                        .map((el) => el.textContent)
+                        .filter((el) => el === "" || el.includes("AM") || el.includes("PM"));
+                    const availabilities = parseTimesAndAvailabilities(date, timesArray);
+
+                    for (const a of availabilities) {
+                        results.push({
+                            url: url,
+                            restaurantName: restaurantName,
+                            partySize: partySize,
+                            date: a.date,
+                            time: a.time,
+                            info: a.availability,
+                        });
+                        if (a.availability === "available") {
+                            // update prevAvailable
+                            if (a.date < baseDate || (a.date === baseDate && a.time <= baseTime)) {
+                                if (prevAvailable === null) {
+                                    prevAvailable = {
+                                        date: a.date,
+                                        time: a.time,
+                                    };
+                                } else if (a.date > prevAvailable.date || (a.date === prevAvailable.date && a.time > prevAvailable.time)) {
+                                    prevAvailable = {
+                                        date: a.date,
+                                        time: a.time,
+                                    };
+                                }
+                            }
+
+                            // update nextAvailable
+                            if (a.date > baseDate || (a.date === baseDate && a.time > baseTime)) {
+                                if (nextAvailable === null) {
+                                    nextAvailable = {
+                                        date: a.date,
+                                        time: a.time,
+                                    };
+                                } else if (a.date < nextAvailable.date || (a.date === nextAvailable.date && a.time < nextAvailable.time)) {
+                                    nextAvailable = {
+                                        date: a.date,
+                                        time: a.time,
+                                    };
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            // if the first page in the popup, then no available slots between the base query
+            // date/time and the first available date/time in the popup
+            const curPage = popup.querySelector('.qfZDsxm8aWs-')?.textContent;
+            if (curPage === "1") {
+                if (prevAvailable && nextAvailable) {
+                    results.push({
+                        url: url,
+                        restaurantName: restaurantName,
+                        partySize: partySize,
+                        startDate: prevAvailable.date,  // inclusive
+                        startTime: prevAvailable.time,  // inclusive
+                        endDate: nextAvailable.date,  // exclusive
+                        endTime: nextAvailable.time,  // exclusive
+                        info: "unavailable",
+                    });
+                } else if (nextAvailable) {
+                    results.push({
+                        url: url,
+                        restaurantName: restaurantName,
+                        partySize: partySize,
+                        startDate: baseDate,  // inclusive
+                        startTime: baseTime,  // inclusive
+                        endDate: nextAvailable.date,  // exclusive
+                        endTime: nextAvailable.time,  // exclusive
+                        info: "unavailable",
+                    });
+                }
+            }
+        }
+    };
+
     const handleSearchPage = () => {
         let partySize = null;
         document.querySelectorAll('[data-testid="party-size-picker-overlay"]').forEach((el) => {
@@ -345,93 +435,7 @@
             }
         });
 
-        // Popup when clicking "Show next available"
-        const popup = document.querySelector('[data-test="multi-day-availability-modal"]');
-        if (popup) {
-            const restaurantName = popup.querySelector('h2')?.textContent;
-            let prevAvailable = null;
-            let nextAvailable = null;
-            popup.querySelectorAll('[data-test="multi-day-timeslot-container"]').forEach((el) => {
-                if (isVisible(el)) {
-                    const { date, _ } = parseDateAndTimes(el.textContent);
-                    const timesArray = Array.from(el.querySelectorAll('li'))
-                        .map((el) => el.textContent)
-                        .filter((el) => el === "" || el.includes("AM") || el.includes("PM"));
-                    const availabilities = parseTimesAndAvailabilities(date, timesArray);
-
-                    for (const a of availabilities) {
-                        results.push({
-                            url: url,
-                            restaurantName: restaurantName,
-                            partySize: partySize,
-                            date: a.date,
-                            time: a.time,
-                            info: a.availability,
-                        });
-                        if (a.availability === "available") {
-                            // update prevAvailable
-                            if (a.date < baseDate || (a.date === baseDate && a.time <= baseTime)) {
-                                if (prevAvailable === null) {
-                                    prevAvailable = {
-                                        date: a.date,
-                                        time: a.time,
-                                    };
-                                } else if (a.date > prevAvailable.date || (a.date === prevAvailable.date && a.time > prevAvailable.time)) {
-                                    prevAvailable = {
-                                        date: a.date,
-                                        time: a.time,
-                                    };
-                                }
-                            }
-
-                            // update nextAvailable
-                            if (a.date > baseDate || (a.date === baseDate && a.time > baseTime)) {
-                                if (nextAvailable === null) {
-                                    nextAvailable = {
-                                        date: a.date,
-                                        time: a.time,
-                                    };
-                                } else if (a.date < nextAvailable.date || (a.date === nextAvailable.date && a.time < nextAvailable.time)) {
-                                    nextAvailable = {
-                                        date: a.date,
-                                        time: a.time,
-                                    };
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-
-            // if the first page in the popup, then no available slots between the base query
-            // date/time and the first available date/time in the popup
-            const curPage = popup.querySelector('.qfZDsxm8aWs-')?.textContent;
-            if (curPage === "1") {
-                if (prevAvailable && nextAvailable) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        startDate: prevAvailable.date,  // inclusive
-                        startTime: prevAvailable.time,  // inclusive
-                        endDate: nextAvailable.date,  // exclusive
-                        endTime: nextAvailable.time,  // exclusive
-                        info: "unavailable",
-                    });
-                } else if (nextAvailable) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        startDate: baseDate,  // inclusive
-                        startTime: baseTime,  // inclusive
-                        endDate: nextAvailable.date,  // exclusive
-                        endTime: nextAvailable.time,  // exclusive
-                        info: "unavailable",
-                    });
-                }
-            }
-        }
+        handleNextAvailablePopup(partySize, baseDate, baseTime);
     };
 
     const handleBookingPage = () => {
@@ -944,93 +948,7 @@
             }
         }
 
-        // Popup when clicking "Show next available"
-        const popup = document.querySelector('[data-test="multi-day-availability-modal"]');
-        if (popup) {
-            const restaurantName = popup.querySelector('h2')?.textContent;
-            let prevAvailable = null;
-            let nextAvailable = null;
-            popup.querySelectorAll('[data-test="multi-day-timeslot-container"]').forEach((el) => {
-                if (isVisible(el)) {
-                    const { date, _ } = parseDateAndTimes(el.textContent);
-                    const timesArray = Array.from(el.querySelectorAll('li'))
-                        .map((el) => el.textContent)
-                        .filter((el) => el === "" || el.includes("AM") || el.includes("PM"));
-                    const availabilities = parseTimesAndAvailabilities(date, timesArray);
-
-                    for (const a of availabilities) {
-                        results.push({
-                            url: url,
-                            restaurantName: restaurantName,
-                            partySize: partySize,
-                            date: a.date,
-                            time: a.time,
-                            info: a.availability,
-                        });
-                        if (a.availability === "available") {
-                            // update prevAvailable
-                            if (a.date < baseDate || (a.date === baseDate && a.time <= baseTime)) {
-                                if (prevAvailable === null) {
-                                    prevAvailable = {
-                                        date: a.date,
-                                        time: a.time,
-                                    };
-                                } else if (a.date > prevAvailable.date || (a.date === prevAvailable.date && a.time > prevAvailable.time)) {
-                                    prevAvailable = {
-                                        date: a.date,
-                                        time: a.time,
-                                    };
-                                }
-                            }
-
-                            // update nextAvailable
-                            if (a.date > baseDate || (a.date === baseDate && a.time > baseTime)) {
-                                if (nextAvailable === null) {
-                                    nextAvailable = {
-                                        date: a.date,
-                                        time: a.time,
-                                    };
-                                } else if (a.date < nextAvailable.date || (a.date === nextAvailable.date && a.time < nextAvailable.time)) {
-                                    nextAvailable = {
-                                        date: a.date,
-                                        time: a.time,
-                                    };
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-
-            // if the first page in the popup, then no available slots between the base query
-            // date/time and the first available date/time in the popup
-            const curPage = popup.querySelector('.qfZDsxm8aWs-')?.textContent;
-            if (curPage === "1") {
-                if (prevAvailable && nextAvailable) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        startDate: prevAvailable.date,  // inclusive
-                        startTime: prevAvailable.time,  // inclusive
-                        endDate: nextAvailable.date,  // exclusive
-                        endTime: nextAvailable.time,  // exclusive
-                        info: "unavailable",
-                    });
-                } else if (nextAvailable) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        startDate: baseDate,  // inclusive
-                        startTime: baseTime,  // inclusive
-                        endDate: nextAvailable.date,  // exclusive
-                        endTime: nextAvailable.time,  // exclusive
-                        info: "unavailable",
-                    });
-                }
-            }
-        }
+        handleNextAvailablePopup(partySize, baseDate, baseTime);
     };
 
     if (url.includes("opentable.com/s?") || /opentable\.com\/[^/]+-restaurant-listings/.test(url)) {


### PR DESCRIPTION
## What

`handleSearchPage()` and `handleRestaurantPage()` in `navi_bench/opentable/opentable_info_gathering.js` each contained a byte-for-byte identical 87-line block that parses the "Show next available" modal (multi-day availability popup) into result entries.

Extracted the block into a shared `handleNextAvailablePopup(partySize, baseDate, baseTime)` helper; both call sites now delegate to it. 1054 -> 972 lines.

## Why

Same class of duplicated-DOM-parsing-block issue already fixed for this file's sibling JS via the shared `isVisible()` extraction in #167 (`dom_visibility.js`). This was the one remaining large duplicated block in the file — a fresh full read of `opentable_info_gathering.js` (and the rest of the repo: `eval_n1.py`, `recorder.py`, `stats.py`, `browser.py`, `dataset.py`, `custom_task.py`, `cli.py`, `demo.py`, `resy_availability_extractor.js`) found nothing else safely extractable this pass — a couple of near-misses (JS `isElementVisible` vs `isVisible`, Python `_safe_evaluator_update` vs `_safe_update_evaluator`) were checked and rejected as not true duplicates.

## Why safe

Pure code-motion: the extracted block only reads variables already in closure scope at both call sites (`results`, `url`, `isVisible`, `parseDateAndTimes`, `parseTimesAndAvailabilities`), plus each caller's own `partySize`/`baseDate`/`baseTime` locals, now passed as parameters with identical values. No logic changed.

This repo has no JS test harness (no `package.json`/jest), so verification was:
- `diff` on the two original 87-line ranges — exit 0, byte-identical
- `node --check` for syntax
- a hand-rolled Node `vm` harness stubbing the DOM (`querySelector`/`querySelectorAll`/`getBoundingClientRect`) to exercise the popup branch from both `handleSearchPage` and `handleRestaurantPage`, run against the pre-refactor file (via `git show HEAD:...`) and the post-refactor file — identical JSON `results` arrays for both scenarios
- full `pytest tests/` — 244/244 passing (excluding `test_vis.py`, which needs the private `yutori` package, per this repo's established convention)
- `ruff check` / `ruff format --check` — clean

## Test plan

- [x] `diff` byte-comparison of both original duplicated ranges
- [x] `node --check navi_bench/opentable/opentable_info_gathering.js`
- [x] Node `vm`-based before/after smoke test of the popup logic (both call sites)
- [x] `pytest tests/` (244/244, excluding `test_vis.py`)
- [x] `ruff check` / `ruff format --check`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01GAa7gyQugk4kigLdo4qtYJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no logic changes; only affects bench DOM scraping in one JS file.
> 
> **Overview**
> Removes duplicate **“Show next available”** modal parsing from `handleSearchPage()` and `handleRestaurantPage()` by moving the same ~87-line block into **`handleNextAvailablePopup(partySize, baseDate, baseTime)`**. Both handlers now call that helper at the end of their flows.
> 
> This is **code motion only**—same DOM selectors, availability inference, and `results` entries (including page-1 “unavailable” ranges between base query time and next slot). File size drops from ~1054 to ~972 lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9169b30c0cc997e9d9efff7090c9434dff7835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->