### PR TITLE
refactor(base): dedupe dom_visibility.js-prefix js_script loader

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -24,6 +24,17 @@ def read_sidecar(module_file: str, filename: str) -> str:
     return (Path(module_file).parent / filename).read_text()
 
 
+def read_sidecar_with_shared_js_prefix(
+    module_file: str, filename: str, *, shared_filename: str = "../dom_visibility.js"
+) -> str:
+    """Read a sidecar JS file, prefixed with a shared helper script it relies on via closure.
+
+    Centralizes the "read the shared helper, then this script, join with a newline" pattern
+    duplicated across verifiers whose JS depends on ``dom_visibility.js``'s ``isVisible``.
+    """
+    return f"{read_sidecar(module_file, shared_filename)}\n{read_sidecar(module_file, filename)}"
+
+
 async def safe_evaluate(
     page: Any,
     script: str,

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -19,7 +19,7 @@ from navi_bench.base import (
     build_task_config,
     fractional_coverage_score,
     hour_to_12h_period,
-    read_sidecar,
+    read_sidecar_with_shared_js_prefix,
     repr_with_attr,
     safe_evaluate,
     unwrap_single_template_query,
@@ -106,9 +106,7 @@ class OpenTableInfoGathering(BaseMetric):
         Prefixed with the shared ``isVisible`` DOM-visibility helper (../dom_visibility.js)
         that this script relies on via closure, also shared with ResyUrlMatch.
         """
-        shared_helpers = read_sidecar(__file__, "../dom_visibility.js")
-        script = read_sidecar(__file__, "opentable_info_gathering.js")
-        return f"{shared_helpers}\n{script}"
+        return read_sidecar_with_shared_js_prefix(__file__, "opentable_info_gathering.js")
 
     def _iter_uncovered_queries(self) -> Iterator[tuple[int, list[MultiCandidateQuery]]]:
         """Yield ``(i, alternative_conditions)`` for each query in ``self.queries`` not yet

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -20,6 +20,7 @@ from navi_bench.base import (
     build_task_config,
     hour_to_12h_period,
     read_sidecar,
+    read_sidecar_with_shared_js_prefix,
     repr_with_attr,
     safe_evaluate,
     unwrap_single_template_query,
@@ -196,9 +197,7 @@ class ResyUrlMatch(BaseMetric):
         Prefixed with the shared ``isVisible`` DOM-visibility helper (../dom_visibility.js)
         that this script relies on via closure, also shared with OpenTableInfoGathering.
         """
-        shared_helpers = read_sidecar(__file__, "../dom_visibility.js")
-        script = read_sidecar(__file__, "resy_no_availability_check.js")
-        return f"{shared_helpers}\n{script}"
+        return read_sidecar_with_shared_js_prefix(__file__, "resy_no_availability_check.js")
 
     @functools.cached_property
     def availability_script(self) -> str:


### PR DESCRIPTION
## What

`ResyUrlMatch.js_script` (`navi_bench/resy/resy_url_match.py`) and `OpenTableInfoGathering.js_script` (`navi_bench/opentable/opentable_info_gathering.py`) each had a byte-identical three-line loader:

```python
shared_helpers = read_sidecar(__file__, "../dom_visibility.js")
script = read_sidecar(__file__, "<own_script>.js")
return f"{shared_helpers}\n{script}"
```

Both docstrings already noted the pattern was "also shared with" the other class — the duplication was known but never consolidated.

Extracted a `read_sidecar_with_shared_js_prefix()` helper into `navi_bench/base.py`, next to the existing `read_sidecar()`. Both `js_script` properties are now one-liners.

## Why it's safe

- Pure extraction: same two file reads, same `\n` join, same output string — no behavioral change.
- Confined to 3 files; doesn't touch verifier scoring/matching logic, only how the JS source text is assembled before being handed to `page.evaluate`.
- No test asserts on the internal composition (only on the final evaluated script's effect).
- Full test suite passes locally: `305 passed`.

🤖 Generated by an automated refactor cronjob.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BdYLutVK8iuou2SyshpJVa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure extraction with identical assembled script strings; no scoring or matching logic touched.
> 
> **Overview**
> Adds **`read_sidecar_with_shared_js_prefix()`** in `navi_bench/base.py` next to `read_sidecar()`, defaulting the shared preamble to `../dom_visibility.js` and joining it with a domain sidecar script via a newline.
> 
> **OpenTable** `OpenTableInfoGathering.js_script` and **Resy** `ResyUrlMatch.js_script` now call that helper instead of repeating the two `read_sidecar` calls and string join. Verifier behavior is unchanged—only how the JS bundle text is assembled before `page.evaluate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d07384805c54417105c068da1e93640e53b482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->