### PR TITLE
refactor(dates): extract shared format_natural_date helper

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -53,6 +53,16 @@ def _format_month_day(d: date, include_month: bool = True, month_style: str = "s
     return f"{d.day}{suffix}"
 
 
+def format_natural_date(d: date) -> str:
+    """Format a date in full natural-language form, e.g. "November 15, 2025".
+
+    Shared by opentable's and resy's ``generate_task_config_random`` single-date
+    natural-language task descriptions, which previously hand-rolled the identical
+    ``strftime("%B %d, %Y")`` call in each file.
+    """
+    return d.strftime("%B %d, %Y")
+
+
 def _format_placeholder_span(start_date: date, end_date: date, month_style: str, year_style: str = "none") -> str:
     if start_date == end_date:
         return _format_month_day(start_date, month_style=month_style, year_style=year_style)

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -26,6 +26,7 @@ from navi_bench.base import (
 )
 from navi_bench.dates import (
     ensure_resolved_dates,
+    format_natural_date,
     initialize_placeholder_map,
     initialize_user_metadata,
     render_task_statement,
@@ -756,7 +757,7 @@ def generate_task_config_random(
 
     # Format natural language date display
     if len(target_dates) == 1:
-        date_natural = target_dates[0].strftime("%B %d, %Y")  # e.g., "October 16, 2025"
+        date_natural = format_natural_date(target_dates[0])  # e.g., "October 16, 2025"
     elif len(target_dates) == 2:
         # Weekend: "October 18-19, 2025"
         date_natural = f"{_format_weekend_span(target_dates[0], target_dates[1])}, {target_dates[1].year}"

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -26,6 +26,7 @@ from navi_bench.base import (
 )
 from navi_bench.dates import (
     ensure_resolved_dates,
+    format_natural_date,
     initialize_placeholder_map,
     initialize_user_metadata,
     render_task_statement,
@@ -1021,7 +1022,7 @@ def generate_task_config_random(
     # Select a valid date (avoiding closed days)
     target_date = select_valid_date(today, date_range, closed_days)
     date_str = target_date.strftime("%Y-%m-%d")
-    date_display = target_date.strftime("%B %d, %Y")  # e.g., "November 15, 2025"
+    date_display = format_natural_date(target_date)  # e.g., "November 15, 2025"
 
     # Determine time
     if time is None:


### PR DESCRIPTION
## Summary

- `navi_bench/opentable/opentable_info_gathering.py` and `navi_bench/resy/resy_url_match.py` each hand-rolled the identical `strftime("%B %d, %Y")` call (with matching `# e.g., "<Month> <Day>, <Year>"` comment) inside `generate_task_config_random` to render a single natural-language date like "November 15, 2025".
- Extracted `format_natural_date(d: date) -> str` into `navi_bench/dates.py`, co-located with the module's other date-formatting helpers (`_format_month_day`, `_format_placeholder_span`). Both call sites now delegate to it instead of duplicating the format string.
- No behavior change — output is byte-identical for both call sites.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check` on all three touched files — clean (repo-wide `dates.py` had a pre-existing, unrelated formatting drift on an unrelated line; confirmed via `git stash` that it exists on `main` too and is untouched by this diff)
- [x] `pytest tests/` — 305 passed, 0 failed (full suite, including `test_dates.py`, `test_resy_url_match.py`, `test_opentable_info_gathering.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016r2bW5MTgAzS8zAr9gWwWP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deduplication with identical output; only affects benchmark task description strings, not runtime booking logic.
> 
> **Overview**
> Adds **`format_natural_date`** in `navi_bench/dates.py` so single-date task text uses one shared `strftime("%B %d, %Y")` implementation instead of duplicating it in OpenTable and Resy.
> 
> **OpenTable** (`generate_task_config_random`) and **Resy** (`generate_task_config_random`) now import and call `format_natural_date` for the one-date branch of natural-language date display. Weekend and multi-weekend formatting in OpenTable is unchanged.
> 
> **No behavior change** — formatted strings stay the same for both call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afc042e03c06ec41a4d07cd3c8982930cd714b22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->