### PR TITLE
refactor(vis): dedupe .modal-overlay/.answer-modal-overlay CSS rules

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -890,8 +890,10 @@ def generate_visualization_html(
             word-break: break-word;
         }}
 
-        /* Modal / Lightbox */
-        .modal-overlay {{
+        /* Modal / Lightbox. Shares its base overlay/active declarations with
+           .answer-modal-overlay below via a comma-separated selector list (same
+           dedup convention as .section/.step and .nav-btn:hover/.modal-nav:hover). */
+        .modal-overlay, .answer-modal-overlay {{
             display: none;
             position: fixed;
             top: 0;
@@ -903,10 +905,13 @@ def generate_visualization_html(
             justify-content: center;
             align-items: center;
             padding: 2rem;
+        }}
+
+        .modal-overlay {{
             cursor: zoom-out;
         }}
 
-        .modal-overlay.active {{
+        .modal-overlay.active, .answer-modal-overlay.active {{
             display: flex;
         }}
 
@@ -1072,25 +1077,7 @@ def generate_visualization_html(
             font-family: 'SF Mono', 'Fira Code', monospace;
         }}
 
-        /* Answer Modal */
-        .answer-modal-overlay {{
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.92);
-            z-index: 1000;
-            justify-content: center;
-            align-items: center;
-            padding: 2rem;
-        }}
-
-        .answer-modal-overlay.active {{
-            display: flex;
-        }}
-
+        /* Answer Modal (base overlay/active rules declared above, shared with .modal-overlay) */
         .answer-modal-content {{
             background: var(--bg-secondary);
             border: 1px solid var(--border-color);

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -533,3 +533,60 @@ class TestStyleSheetDeduplication:
         assert "background: var(--accent-blue);" in body
         assert "border-color: var(--accent-blue);" in body
         assert html.count("background: var(--accent-blue);\n            border-color: var(--accent-blue);") == 1
+
+
+class TestModalOverlayStyleSheetDeduplication:
+    """Pins that ``.modal-overlay`` (the screenshot lightbox) and ``.answer-modal-overlay``
+    (the final-answer modal) share their identical base/``.active`` declarations via the same
+    comma-separated-selector convention as ``TestStyleSheetDeduplication`` above, instead of
+    each repeating the full ``display/position/top/left/width/height/background/z-index/
+    justify-content/align-items/padding`` rule body verbatim. ``.modal-overlay`` keeps its
+    extra ``cursor: zoom-out;`` declaration in its own rule since ``.answer-modal-overlay``
+    does not share it.
+    """
+
+    @staticmethod
+    def _html() -> str:
+        messages = [{"role": "user", "content": [{"type": "text", "text": "do the task"}]}]
+        return generate_visualization_html("task1", messages, None)
+
+    def test_overlay_base_rule_shared_and_declared_once(self):
+        html = self._html()
+        match = re.search(r"\.modal-overlay,\s*\.answer-modal-overlay\s*\{([^}]*)\}", html)
+        assert match is not None, html
+        body = match.group(1)
+        for prop in (
+            "display: none;",
+            "position: fixed;",
+            "top: 0;",
+            "left: 0;",
+            "width: 100%;",
+            "height: 100%;",
+            "background: rgba(0, 0, 0, 0.92);",
+            "z-index: 1000;",
+            "justify-content: center;",
+            "align-items: center;",
+            "padding: 2rem;",
+        ):
+            assert prop in body
+        # The body must appear exactly once in the stylesheet, not once per selector.
+        assert html.count("background: rgba(0, 0, 0, 0.92);\n            z-index: 1000;") == 1
+        # cursor: zoom-out belongs only to .modal-overlay, not the shared rule.
+        assert "cursor: zoom-out;" not in body
+
+    def test_modal_overlay_keeps_its_own_cursor_rule(self):
+        html = self._html()
+        match = re.search(r"\.modal-overlay\s*\{\s*cursor: zoom-out;\s*\}", html)
+        assert match is not None, html
+        # .answer-modal-overlay never gets cursor: zoom-out.
+        assert "answer-modal-overlay {\n            cursor: zoom-out;" not in html
+
+    def test_active_rule_shared_and_declared_once(self):
+        html = self._html()
+        match = re.search(r"\.modal-overlay\.active,\s*\.answer-modal-overlay\.active\s*\{([^}]*)\}", html)
+        assert match is not None, html
+        assert "display: flex;" in match.group(1)
+        # Each selector appears exactly once in the stylesheet (as part of the shared rule),
+        # not once per selector as two separate ``.active { display: flex; }`` rules.
+        assert len(re.findall(r"\.modal-overlay\.active", html)) == 1
+        assert len(re.findall(r"\.answer-modal-overlay\.active", html)) == 1


### PR DESCRIPTION
## Summary

- `generate_visualization_html()`'s embedded `<style>` block had `.modal-overlay` (the screenshot lightbox) and `.answer-modal-overlay` (the final-answer modal) each declaring the identical `display`/`position`/`top`/`left`/`width`/`height`/`background`/`z-index`/`justify-content`/`align-items`/`padding` rule body, plus identical `.active { display: flex; }` rules.
- Same class of issue as the already-merged `.section`/`.step` and `.nav-btn:hover`/`.modal-nav:hover` CSS dedup (#169): merged via a comma-separated selector list, with `.modal-overlay` keeping its one extra `cursor: zoom-out` declaration in its own follow-on rule.
- Debug/visualization output only; no Python logic changed.

## Verification

- Added `tests/test_vis.py::TestModalOverlayStyleSheetDeduplication` following the existing `TestStyleSheetDeduplication` convention, pinning that both rule bodies are declared exactly once via the shared selector.
- Ran a before/after CSS-rule parity check (parsed the rendered `<style>` block pre- and post-refactor) confirming every affected selector's effective declaration set is byte-identical.
- `pytest tests/`: 308/308 passing (up from 305 baseline; +3 new tests).
- `ruff check` / `ruff format --check` clean on both touched files.

## Test plan

- [x] `pytest tests/` passes (308/308)
- [x] `ruff check evaluation/vis.py tests/test_vis.py` clean
- [x] `ruff format --check evaluation/vis.py tests/test_vis.py` clean
- [x] Before/after CSS-rule parity check confirms no visual/behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWpJDabcTmwM1Xz2paZBNa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Stylesheet-only refactor in generated debug HTML with characterization tests; effective CSS is intended to remain identical.
> 
> **Overview**
> **Deduplicates** identical overlay CSS in `generate_visualization_html()`’s embedded stylesheet by merging `.modal-overlay` (screenshot lightbox) and `.answer-modal-overlay` (final-answer modal) into shared comma-separated rules for the base overlay and `.active { display: flex; }`, following the same pattern as `.section`/`.step` and `.nav-btn:hover`/`.modal-nav:hover`.
> 
> `.modal-overlay` still has its own follow-on rule for `cursor: zoom-out`, which the answer modal does not use. **No Python behavior changes**—debug/visualization HTML only.
> 
> Adds `TestModalOverlayStyleSheetDeduplication` in `tests/test_vis.py` to lock in the shared selectors and that `cursor: zoom-out` stays modal-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d93794631c98989d6a1d657f55aa6f3fe0d1558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->