### PR TITLE
refactor(recorder): extract shared _save_model/_load_model helpers

### DIFF
--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -95,6 +95,25 @@ class Recorder:
             logger.opt(exception=True).error(f"Failed to load {kind} from: {load_path}")
             return None
 
+    async def _save_model(self, filename: str, model: BaseModel, kind: str) -> None:
+        """Save a plain pydantic model as JSON via ``model.model_dump(mode="json")``.
+
+        Shared by ``save_usage``/``save_timing``, which each previously repeated this exact
+        "wrap model_dump, delegate to _save_json" one-liner, differing only in filename/kind.
+        Contrast with ``save_result``, which additionally embeds a "_target_" class marker for
+        polymorphic reconstruction via ``instantiate`` and doesn't fit this simpler pair.
+        """
+        await self._save_json(filename, lambda: model.model_dump(mode="json"), kind)
+
+    async def _load_model(self, filename: str, cls: type[T], kind: str) -> T | None:
+        """Load a plain pydantic model of type ``cls`` from JSON via ``cls.model_validate``.
+
+        Shared by ``load_usage``/``load_timing``; see :meth:`_save_model` for why
+        ``load_result`` (which uses ``instantiate`` for polymorphic reconstruction) is a
+        separate pattern.
+        """
+        return await self._load_json(filename, cls.model_validate, kind)
+
     async def save_result(self, result: BaseModel) -> None:
         await self._save_json(
             "result.json",
@@ -106,13 +125,13 @@ class Recorder:
         return await self._load_json("result.json", instantiate, "result")
 
     async def save_usage(self, usage: BaseModel) -> None:
-        await self._save_json("usage.json", lambda: usage.model_dump(mode="json"), "usage")
+        await self._save_model("usage.json", usage, "usage")
 
     async def load_usage(self, cls: type[BaseModel]) -> BaseModel | None:
-        return await self._load_json("usage.json", cls.model_validate, "usage")
+        return await self._load_model("usage.json", cls, "usage")
 
     async def save_timing(self, timing: TimingStats) -> None:
-        await self._save_json("timing.json", lambda: timing.model_dump(mode="json"), "timing")
+        await self._save_model("timing.json", timing, "timing")
 
     async def load_timing(self) -> TimingStats | None:
-        return await self._load_json("timing.json", TimingStats.model_validate, "timing")
+        return await self._load_model("timing.json", TimingStats, "timing")

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,98 @@
+"""Characterization tests for ``Recorder``'s JSON save/load helpers, added ahead of extracting
+a shared ``_save_model``/``_load_model`` pair for ``save_usage``/``load_usage`` and
+``save_timing``/``load_timing`` (previously four near-identical one-liners differing only in
+filename and pydantic model type). ``recorder.py`` had zero prior test coverage.
+"""
+
+import json
+from os import path as osp
+
+import pytest
+from pydantic import BaseModel
+
+from evaluation.recorder import Recorder
+from evaluation.stats import TimingStats
+
+
+class _DummyUsage(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+@pytest.mark.asyncio
+async def test_save_usage_then_load_usage_round_trips(tmp_path):
+    recorder = Recorder(str(tmp_path), "task-1")
+    usage = _DummyUsage(input_tokens=10, output_tokens=20)
+
+    await recorder.save_usage(usage)
+    loaded = await recorder.load_usage(_DummyUsage)
+
+    assert loaded == usage
+
+
+@pytest.mark.asyncio
+async def test_save_usage_writes_expected_json_shape(tmp_path):
+    recorder = Recorder(str(tmp_path), "task-1")
+    usage = _DummyUsage(input_tokens=10, output_tokens=20)
+
+    await recorder.save_usage(usage)
+
+    save_path = osp.join(str(tmp_path), "task-1", "usage.json")
+    with open(save_path) as f:
+        content = json.load(f)
+    assert content == {"input_tokens": 10, "output_tokens": 20}
+
+
+@pytest.mark.asyncio
+async def test_load_usage_returns_none_when_file_missing(tmp_path):
+    recorder = Recorder(str(tmp_path), "task-1")
+
+    assert await recorder.load_usage(_DummyUsage) is None
+
+
+@pytest.mark.asyncio
+async def test_load_usage_returns_none_on_invalid_content(tmp_path):
+    recorder = Recorder(str(tmp_path), "task-1")
+    save_path = osp.join(str(tmp_path), "task-1", "usage.json")
+    with open(save_path, "w") as f:
+        f.write('{"not_a_valid_field": "oops"')  # malformed JSON
+
+    assert await recorder.load_usage(_DummyUsage) is None
+
+
+@pytest.mark.asyncio
+async def test_save_timing_then_load_timing_round_trips(tmp_path):
+    recorder = Recorder(str(tmp_path), "task-1")
+    timing = TimingStats()
+    timing.add_call(100.0)
+    timing.add_call(200.0)
+
+    await recorder.save_timing(timing)
+    loaded = await recorder.load_timing()
+
+    assert loaded == timing
+    assert loaded.call_count == 2
+    assert loaded.total_time_ms == 300.0
+
+
+@pytest.mark.asyncio
+async def test_load_timing_returns_none_when_file_missing(tmp_path):
+    recorder = Recorder(str(tmp_path), "task-1")
+
+    assert await recorder.load_timing() is None
+
+
+@pytest.mark.asyncio
+async def test_save_timing_writes_expected_json_shape(tmp_path):
+    recorder = Recorder(str(tmp_path), "task-1")
+    timing = TimingStats()
+    timing.add_call(50.0)
+
+    await recorder.save_timing(timing)
+
+    save_path = osp.join(str(tmp_path), "task-1", "timing.json")
+    with open(save_path) as f:
+        content = json.load(f)
+    assert content["times_ms"] == [50.0]
+    assert content["call_count"] == 1
+    assert content["total_time_ms"] == 50.0


### PR DESCRIPTION
## What

`Recorder.save_usage`/`load_usage` and `save_timing`/`load_timing` in `evaluation/recorder.py` each repeated the identical one-liner shape:

```python
async def save_usage(self, usage: BaseModel) -> None:
    await self._save_json("usage.json", lambda: usage.model_dump(mode="json"), "usage")

async def load_usage(self, cls: type[BaseModel]) -> BaseModel | None:
    return await self._load_json("usage.json", cls.model_validate, "usage")

async def save_timing(self, timing: TimingStats) -> None:
    await self._save_json("timing.json", lambda: timing.model_dump(mode="json"), "timing")

async def load_timing(self) -> TimingStats | None:
    return await self._load_json("timing.json", TimingStats.model_validate, "timing")
```

Extracted `_save_model(filename, model, kind)` / `_load_model(filename, cls, kind)` to centralize the "wrap `model_dump(mode='json')`, delegate to `_save_json`" / "delegate to `_load_json` via `cls.model_validate`" pattern. This matches this repo's established "same shape, differs only in a name/type" extraction convention already used elsewhere (`_metrics_row` in `stats.py`, `_render_section`/`_render_response_section` in `vis.py`).

`save_result`/`load_result` are intentionally **not** folded in: they embed a `"_target_"` class marker and use `instantiate()` for polymorphic reconstruction (needed because the concrete result type varies per task), a genuinely different shape from the other two pairs — not the same pattern despite the superficial similarity.

## Why it's safe

- `recorder.py` had **zero prior test coverage**. Per this repo's established convention, added `tests/test_recorder.py` with 7 characterization tests **before** refactoring: round-trip save/load for both `usage.json` and `timing.json`, exact JSON-shape assertions, `None` return when the file is missing, and `None` return on malformed JSON content.
- Confirmed all 7 tests pass identically against the pre-refactor code (via `git stash`) and post-refactor code — pure structural change, no behavior difference.
- Full suite: **315/315 passing** before and after (308 pre-existing + 7 new).
- `ruff check` / `ruff format --check` clean on both touched files.

Two files touched: `evaluation/recorder.py` (the refactor) and `tests/test_recorder.py` (new characterization tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_01V8Fo9pooLuChebF6PfkC2N)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in evaluation persistence with new tests; no auth, security, or production-path changes.
> 
> **Overview**
> **Refactors** `Recorder` usage/timing persistence by pulling duplicated `model_dump` / `model_validate` wiring into **`_save_model`** and **`_load_model`**, so `save_usage`/`load_usage` and `save_timing`/`load_timing` only pass filename, model type, and kind. **`save_result`/`load_result`** stay on the existing `_target_` + `instantiate` path.
> 
> Adds **`tests/test_recorder.py`** with characterization coverage: usage/timing round-trips, on-disk JSON shape, and `None` when files are missing or JSON is invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d42a858aa8786080719c95262ad198bc3215757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->