### PR TITLE
refactor(dates): delegate resolve_city_now's UserMetadata construction to initialize_user_metadata

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -222,14 +222,16 @@ def initialize_user_metadata(
 
 
 def resolve_city_now(city_meta: dict) -> tuple[datetime, UserMetadata]:
-    """Resolve the current tz-aware time and UserMetadata for a CITY_METADATA entry."""
+    """Resolve the current tz-aware time and UserMetadata for a CITY_METADATA entry.
+
+    Delegates the ``UserMetadata`` construction to :func:`initialize_user_metadata` (passing
+    the already-computed ``today``'s timestamp explicitly) instead of re-building the same
+    ``location``/``timezone``/``timestamp`` object inline, as this function previously did.
+    """
     tz_info = ZoneInfo(city_meta["timezone"])
     today = datetime.now(tz_info)
-    timestamp = int(today.timestamp())
-    user_metadata = UserMetadata(
-        location=city_meta["location"],
-        timezone=city_meta["timezone"],
-        timestamp=timestamp,
+    user_metadata = initialize_user_metadata(
+        city_meta["timezone"], city_meta["location"], timestamp=int(today.timestamp())
     )
     return today, user_metadata
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -32,11 +32,19 @@ every year-spanning or backward ("last") case.
 """
 
 from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
+import navi_bench.dates as dates_module
 from navi_bench.base import UserMetadata
-from navi_bench.dates import initialize_placeholder_map, render_task_statement, resolve_placeholder_values
+from navi_bench.dates import (
+    initialize_placeholder_map,
+    initialize_user_metadata,
+    render_task_statement,
+    resolve_city_now,
+    resolve_placeholder_values,
+)
 
 
 def _user_metadata(base_date: date) -> UserMetadata:
@@ -223,6 +231,67 @@ class TestResolvePlaceholderValuesDynamicOffset:
         assert description == "the 3rd of December"
         assert iso_dates == ["2026-12-03"]
         assert is_dynamic is False
+
+
+class _FrozenDatetime(datetime):
+    """``datetime`` subclass whose ``now()`` always returns a fixed instant.
+
+    Used to deterministically test ``initialize_user_metadata``/``resolve_city_now``, which
+    otherwise derive "now" from the real clock via ``datetime.now(...)``.
+    """
+
+    _frozen: datetime
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls._frozen if tz is None else cls._frozen.astimezone(tz)
+
+
+def _freeze_now(monkeypatch: pytest.MonkeyPatch, frozen: datetime) -> None:
+    _FrozenDatetime._frozen = frozen
+    monkeypatch.setattr(dates_module, "datetime", _FrozenDatetime)
+
+
+class TestInitializeUserMetadata:
+    """``initialize_user_metadata`` had zero direct test coverage even though it is the
+    shared ``UserMetadata`` constructor used by apartments/craigslist task generation
+    (and, after this refactor, by ``resolve_city_now`` too)."""
+
+    def test_explicit_timestamp_is_used_as_is(self):
+        user_metadata = initialize_user_metadata("America/New_York", "New York, NY, United States", timestamp=1000)
+        assert user_metadata.location == "New York, NY, United States"
+        assert user_metadata.timezone == "America/New_York"
+        assert user_metadata.timestamp == 1000
+
+    def test_omitted_timestamp_defaults_to_current_utc_time(self, monkeypatch: pytest.MonkeyPatch):
+        frozen = datetime(2026, 3, 10, 15, 30, 45, 123456, tzinfo=timezone.utc)
+        _freeze_now(monkeypatch, frozen)
+
+        user_metadata = initialize_user_metadata("America/New_York", "New York, NY, United States")
+
+        assert user_metadata.timestamp == int(frozen.timestamp())
+
+
+class TestResolveCityNow:
+    """``resolve_city_now`` had zero direct test coverage even though it is the shared
+    "current time in a CITY_METADATA entry's timezone" resolver used by resy's and
+    opentable's ``generate_task_config_random``. Pins that ``today`` and ``user_metadata``
+    describe the exact same instant, so a future refactor that delegates the ``UserMetadata``
+    construction to ``initialize_user_metadata`` can be verified as behavior-preserving.
+    """
+
+    def test_today_and_user_metadata_describe_the_same_instant(self, monkeypatch: pytest.MonkeyPatch):
+        frozen = datetime(2026, 3, 10, 15, 30, 45, 123456, tzinfo=timezone.utc)
+        _freeze_now(monkeypatch, frozen)
+
+        city_meta = {"location": "New York, NY, United States", "timezone": "America/New_York"}
+        today, user_metadata = resolve_city_now(city_meta)
+
+        assert today == frozen.astimezone(ZoneInfo("America/New_York"))
+        assert user_metadata.location == "New York, NY, United States"
+        assert user_metadata.timezone == "America/New_York"
+        assert user_metadata.timestamp == int(frozen.timestamp())
+        assert user_metadata.timestamp == int(today.timestamp())
 
 
 class TestRenderTaskStatement:


### PR DESCRIPTION
## What

`resolve_city_now` (used by resy's and opentable's `generate_task_config_random`) hand-rolled the same "build a `UserMetadata` from `location`/`timezone`/a computed timestamp" logic that `initialize_user_metadata` already centralizes (and which apartments/craigslist task generation already calls). The two functions duplicated the `UserMetadata(location=..., timezone=..., timestamp=...)` field mapping in the same module.

```python
# before
tz_info = ZoneInfo(city_meta["timezone"])
today = datetime.now(tz_info)
timestamp = int(today.timestamp())
user_metadata = UserMetadata(
    location=city_meta["location"],
    timezone=city_meta["timezone"],
    timestamp=timestamp,
)
return today, user_metadata

# after
tz_info = ZoneInfo(city_meta["timezone"])
today = datetime.now(tz_info)
user_metadata = initialize_user_metadata(
    city_meta["timezone"], city_meta["location"], timestamp=int(today.timestamp())
)
return today, user_metadata
```

`resolve_city_now` still computes `today` itself (callers need the full tz-aware `datetime`, not just the metadata), but now delegates the `UserMetadata` construction instead of duplicating it. Passing `timestamp` explicitly means `initialize_user_metadata` uses it as-is and skips its own `datetime.now()` call, so `today` and `user_metadata.timestamp` still describe the exact same instant as before — this is a pure dedup, not a behavior change.

## Why this is safe

- Neither `initialize_user_metadata` nor `resolve_city_now` had any direct test coverage before this PR. I added `TestInitializeUserMetadata` and `TestResolveCityNow` in `tests/test_dates.py` first, using a frozen-clock `datetime` subclass to make "now" deterministic.
- Ran the new tests against the **pre-refactor** code and confirmed they pass (pinning existing behavior), then applied the refactor and confirmed they still pass unchanged.
- Full suite: 318/318 tests pass. `ruff check`/`ruff format --check` clean on both touched files (there's a pre-existing, unrelated formatting nit elsewhere in `dates.py` that predates this branch — confirmed via `git stash`).
- Only one call site (`resolve_city_now` itself) changes; `initialize_user_metadata`'s public signature and behavior are untouched.

## Test plan

- [x] `pytest tests/test_dates.py -v` — 24/24 pass, including new `TestInitializeUserMetadata`/`TestResolveCityNow`
- [x] `pytest tests/ -q` — 318/318 pass
- [x] `ruff check` / `ruff format --check` clean on changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01KttKmM2At59RsAUomG8ip6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single internal refactor in `navi_bench/dates.py` with behavior pinned by new tests; no API or caller changes beyond the shared helper path.
> 
> **Overview**
> **Deduplicates `UserMetadata` construction** in `resolve_city_now` (used by resy/opentable task generation): it still computes the city-local `today` with `datetime.now(tz)`, but passes `int(today.timestamp())` into `initialize_user_metadata` instead of constructing `UserMetadata` inline. Passing an explicit timestamp avoids a second clock read, so `today` and `user_metadata` stay aligned with prior behavior.
> 
> **Adds direct test coverage** in `tests/test_dates.py` for `initialize_user_metadata` and `resolve_city_now`, using a monkeypatched `datetime` subclass to freeze "now" and assert field mapping, default UTC timestamp when omitted, and that `today` and `user_metadata.timestamp` describe the same instant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f671dfc2430c64d6e9ccdad5b66dc28b847ea177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->