### PR TITLE
refactor(vis): dedupe .modal-close/.modal-nav CSS rules

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -959,23 +959,29 @@ def generate_visualization_html(
             padding: 12px 12px;
         }}
 
-        .modal-close {{
+        /* Shares its base circular-button declarations with .modal-nav below via a
+           comma-separated selector list (same dedup convention as .section/.step,
+           .nav-btn:hover/.modal-nav:hover, and .modal-overlay/.answer-modal-overlay). */
+        .modal-close, .modal-nav {{
             position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
             width: 48px;
             height: 48px;
             background: var(--bg-tertiary);
             border: 1px solid var(--border-color);
             border-radius: 50%;
             color: var(--text-primary);
-            font-size: 1.5rem;
             cursor: pointer;
             display: flex;
             align-items: center;
             justify-content: center;
             transition: all 0.2s;
             z-index: 1001;
+        }}
+
+        .modal-close {{
+            top: 1.5rem;
+            right: 1.5rem;
+            font-size: 1.5rem;
         }}
 
         .modal-close:hover {{
@@ -998,22 +1004,9 @@ def generate_visualization_html(
         }}
 
         .modal-nav {{
-            position: fixed;
             top: 50%;
             transform: translateY(-50%);
-            width: 48px;
-            height: 48px;
-            background: var(--bg-tertiary);
-            border: 1px solid var(--border-color);
-            border-radius: 50%;
-            color: var(--text-primary);
             font-size: 1.25rem;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            transition: all 0.2s;
-            z-index: 1001;
         }}
 
         .nav-btn:hover, .modal-nav:hover {{


### PR DESCRIPTION
## Issue

In `evaluation/vis.py`'s `generate_visualization_html()`, the `.modal-close` and `.modal-nav` CSS rules each declared the same 11 properties verbatim (`position`, `width`/`height`, `background`, `border`, `border-radius`, `color`, `cursor`, `display`, `align-items`, `justify-content`, `transition`, `z-index`), differing only in the position-offset properties (`top`/`right` vs. `top`/`transform`) and `font-size`. This is the same class of duplication this repo's prior PRs have already mechanically fixed for other CSS rule pairs (#169 for `.section`/`.step`, #173 for `.modal-overlay`/`.answer-modal-overlay`), but this particular pair was missed.

## Improvement

Extracted the shared declarations into a `.modal-close, .modal-nav` comma-separated selector (matching the existing dedup convention, referenced in a comment), keeping each selector's own smaller rule for its differing top/right/transform/font-size properties.

## Safety

- Debug/visualization output only — no production code path affected.
- Verified the *computed* CSS for both `.modal-close` and `.modal-nav` is unchanged: wrote a small script that parses both the before and after `<style>` block, simulates the cascade (later same-specificity rule wins per property), and confirmed the resulting effective property dict for each selector is byte-identical before/after.
- Full test suite: 318/318 passing (`pytest tests/`).
- `ruff check` / `ruff format --check` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EtFgSf68gMmEW4BHivHVYt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visualization-only CSS refactor in `evaluation/vis.py`; computed styles for those selectors are intended to be unchanged.
> 
> **Overview**
> In **`generate_visualization_html`**’s embedded stylesheet, **`.modal-close`** and **`.modal-nav`** no longer repeat the same circular fixed-button rules. Shared properties now live on **`.modal-close, .modal-nav`**, with separate smaller blocks for placement and typography (`top`/`right`/`font-size` vs `top`/`transform`/`font-size`).
> 
> A short comment documents the same comma-selector dedup pattern already used for **`.section`/`.step`**, overlay pairs, and shared hover rules. **`.modal-close:hover`** stays separate (red accent); nav hover remains on **`.nav-btn:hover, .modal-nav:hover`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae194331c49b914e898d5242f76de1bbc399c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->