### PR TITLE
refactor(opentable): use itertools.product for query cartesian product

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -845,17 +845,19 @@ def _render_placeholders_in_queries_all(
     for placeholder_key, (_, dates) in resolved_placeholders.items():
         ensure_resolved_dates(dates, placeholder_key)
 
-        for date in dates:
-            for restaurant_name in template_query_dict.get("restaurant_names", [None]):
-                for time in template_query_dict.get("times", [None]):
-                    for party_size in template_query_dict.get("party_sizes", [None]):
-                        query_dict: MultiCandidateQuery = {
-                            "restaurant_names": [restaurant_name],
-                            "dates": [date],
-                            "times": [time],
-                            "party_sizes": [party_size],
-                        }
-                        queries.append([query_dict])
+        for date, restaurant_name, time, party_size in itertools.product(
+            dates,
+            template_query_dict.get("restaurant_names", [None]),
+            template_query_dict.get("times", [None]),
+            template_query_dict.get("party_sizes", [None]),
+        ):
+            query_dict: MultiCandidateQuery = {
+                "restaurant_names": [restaurant_name],
+                "dates": [date],
+                "times": [time],
+                "party_sizes": [party_size],
+            }
+            queries.append([query_dict])
 
     return queries
 


### PR DESCRIPTION
## Summary

`_render_placeholders_in_queries_all` in `navi_bench/opentable/opentable_info_gathering.py` hand-rolled a nested `for` loop (dates → restaurant_names → times → party_sizes) to build a cartesian product of query candidates. The same file already solves this identical problem in `_is_exhausted` (via a `_singleton_choices()` helper + `itertools.product`), and `itertools` is already imported at the top of the file. This PR replaces the nested loop with `itertools.product` for consistency, with **no behavior change**:

- The `query_dict` construction and `queries.append([query_dict])` logic is unchanged.
- Nesting/iteration order is preserved exactly (dates outer, then restaurant_names, then times, then party_sizes) via the argument order passed to `itertools.product`.
- Checked the sole caller (`generate_task_config_deterministic`, same file) and the consumer (`OpenTableInfoGathering`, which tracks each query independently by index for coverage/exhaustion) — the order of the resulting `queries` list does not affect correctness, only that each expanded combination appears exactly once.

## Testing

- Wrote a standalone script that runs the old nested-loop logic and the new `itertools.product` logic side-by-side against several sample input combinations (including `None`-only axes) and asserted byte-identical output — confirmed identical.
- Ran `tests/test_opentable_info_gathering.py` and `tests/test_resy_url_match.py` before and after the change: 107 passed in both cases.
- Ran the full repo test suite after the change: `318 passed`.
- Ran `ruff check` and `ruff format --check` on the modified file: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NvC616meincf7p2eiZLizJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with preserved expansion logic; no auth, data, or eval semantics changes beyond equivalent list construction.
> 
> **Overview**
> **`_render_placeholders_in_queries_all`** no longer uses four nested `for` loops to expand placeholder dates against restaurant names, times, and party sizes. It now builds the same combinations with **`itertools.product`**, matching how **`_is_exhausted`** already enumerates query axes in this module.
> 
> Each combination still becomes a single-element **`MultiCandidateQuery`** wrapped in **`queries.append([query_dict])`**. Argument order to **`product`** keeps the previous iteration order (dates → restaurants → times → party sizes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159af6163d9b87ad3a57e8858c71eda82a6ba41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->