### PR TITLE
refactor: extract ResetsViaState mixin for duplicated reset() override

### DIFF
--- a/evaluation/custom_task.py
+++ b/evaluation/custom_task.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from navi_bench.base import BaseMetric, BaseTaskConfig, UserMetadata, get_import_path
+from navi_bench.base import BaseTaskConfig, ResetsViaState, UserMetadata, get_import_path
 
 
 class CustomTaskResult(BaseModel):
@@ -8,16 +8,13 @@ class CustomTaskResult(BaseModel):
     final_answer: str | None = None
 
 
-class CustomTaskCaptureMetric(BaseMetric):
+class CustomTaskCaptureMetric(ResetsViaState):
     def __init__(self) -> None:
         super().__init__()
         self._reset_state()
 
     def _reset_state(self) -> None:
         self.answer_message: str | None = None
-
-    async def reset(self) -> None:
-        self._reset_state()
 
     async def update(self, /, **kwargs) -> None:
         if kwargs.get("answer_message") is not None:

--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -6,9 +6,9 @@ from beartype import beartype
 from loguru import logger
 
 from navi_bench.base import (
-    BaseMetric,
     BaseTaskConfig,
     FinalResult,
+    ResetsViaState,
     UrlMetricInput,
     basic_normalize_url,
     build_task_config,
@@ -55,7 +55,7 @@ _APARTMENT_FEATURES_BY_LENGTH_DESC = sorted(_APARTMENT_FEATURES, key=len, revers
 
 
 @beartype
-class ApartmentsUrlMatch(BaseMetric):
+class ApartmentsUrlMatch(ResetsViaState):
     IGNORED_PARAMS = ("io", "ss")
 
     def __init__(self, gt_url: str | list[str]) -> None:
@@ -72,9 +72,6 @@ class ApartmentsUrlMatch(BaseMetric):
 
     def __repr__(self) -> str:
         return repr_with_attr(self, "gt_urls")
-
-    async def reset(self) -> None:
-        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: UrlMetricInput = kwargs

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -350,6 +350,21 @@ class BaseMetric:
     async def reset(self) -> None: ...
 
 
+class ResetsViaState(BaseMetric):
+    """A :class:`BaseMetric` whose ``reset()`` delegates to a ``_reset_state()`` hook.
+
+    Several metric subclasses reinitialize their per-episode state in a synchronous
+    ``_reset_state()`` helper (also called from ``__init__``) and wire it into
+    ``reset()`` with an identical one-line override. Subclassing this instead of
+    ``BaseMetric`` directly removes that duplication.
+    """
+
+    def _reset_state(self) -> None: ...
+
+    async def reset(self) -> None:
+        self._reset_state()
+
+
 def repr_with_attr(instance: object, attr_name: str, *, label: str | None = None) -> str:
     """Render ``ClassName(label=value)`` for a single-attribute ``__repr__``.
 

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -4,9 +4,9 @@ from beartype import beartype
 from loguru import logger
 
 from navi_bench.base import (
-    BaseMetric,
     BaseTaskConfig,
     FinalResult,
+    ResetsViaState,
     UrlMetricInput,
     build_task_config,
     fractional_coverage_score,
@@ -20,7 +20,7 @@ IGNORE_URL_PARAMS = ("isTrusted",)
 
 
 @beartype
-class CraigslistUrlMatch(BaseMetric):
+class CraigslistUrlMatch(ResetsViaState):
     def __init__(self, gt_urls: list[list[str]]) -> None:
         """
         Args:
@@ -40,9 +40,6 @@ class CraigslistUrlMatch(BaseMetric):
 
     def __repr__(self) -> str:
         return repr_with_attr(self, "gt_urls")
-
-    async def reset(self) -> None:
-        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: UrlMetricInput = kwargs

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -9,9 +9,9 @@ from beartype import beartype
 from loguru import logger
 
 from navi_bench.base import (
-    BaseMetric,
     BaseTaskConfig,
     FinalResult,
+    ResetsViaState,
     UrlMetricInput,
     all_or_nothing_coverage_result,
     build_task_config,
@@ -30,7 +30,7 @@ protoc --python_out=. google_flights.proto
 
 
 @beartype
-class GoogleFlightsSearchMatch(BaseMetric):
+class GoogleFlightsSearchMatch(ResetsViaState):
     def __init__(self, gt_info: list[dict]) -> None:
         """
         Args:
@@ -132,9 +132,6 @@ class GoogleFlightsSearchMatch(BaseMetric):
         info.trip = gt_info["trip"]
 
         return info
-
-    async def reset(self) -> None:
-        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: UrlMetricInput = kwargs

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -14,8 +14,8 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from navi_bench.base import (
-    BaseMetric,
     BaseTaskConfig,
+    ResetsViaState,
     build_task_config,
     fractional_coverage_score,
     hour_to_12h_period,
@@ -77,7 +77,7 @@ class FinalResult(BaseModel):
 
 
 @beartype
-class OpenTableInfoGathering(BaseMetric):
+class OpenTableInfoGathering(ResetsViaState):
     """Gather restaurant availability information from OpenTable to evaluate query coverage"""
 
     def __init__(self, queries: list[list[MultiCandidateQuery]]) -> None:
@@ -123,9 +123,6 @@ class OpenTableInfoGathering(BaseMetric):
         for i, alternative_conditions in enumerate(self.queries):
             if not self._is_query_covered[i]:
                 yield i, alternative_conditions
-
-    async def reset(self) -> None:
-        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: InputDict = kwargs

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -12,9 +12,9 @@ from loguru import logger
 from playwright.async_api import Page
 
 from navi_bench.base import (
-    BaseMetric,
     BaseTaskConfig,
     FinalResult,
+    ResetsViaState,
     all_or_nothing_coverage_result,
     basic_normalize_url,
     build_task_config,
@@ -149,7 +149,7 @@ _BOUNDARY_REASON_MESSAGE_TEMPLATES = {
 
 
 @beartype
-class ResyUrlMatch(BaseMetric):
+class ResyUrlMatch(ResetsViaState):
     def __init__(self, queries: list[list[str]]) -> None:
         """
         Args:
@@ -204,9 +204,6 @@ class ResyUrlMatch(BaseMetric):
     def availability_script(self) -> str:
         """Load the JavaScript for extracting availability metadata."""
         return read_sidecar(__file__, "resy_availability_extractor.js")
-
-    async def reset(self) -> None:
-        self._reset_state()
 
     async def update(self, **kwargs) -> None:
         inputs: InputDict = kwargs


### PR DESCRIPTION
## What

Six `BaseMetric` subclasses each defined an identical boilerplate override:

```python
async def reset(self) -> None:
    self._reset_state()
```

repeated verbatim in `ApartmentsUrlMatch`, `CraigslistUrlMatch`, `GoogleFlightsSearchMatch`, `OpenTableInfoGathering`, `ResyUrlMatch`, and `CustomTaskCaptureMetric`. This goes one step further than #178, which extracted the *body* of `_reset_state()` inside `CustomTaskCaptureMetric`, but never centralized the `reset()` → `_reset_state()` wiring shared by all six classes.

Added a `ResetsViaState(BaseMetric)` mixin in `navi_bench/base.py` that provides this `reset()` implementation once, and switched all six subclasses to inherit from it instead of `BaseMetric` directly, deleting their now-redundant `reset()` overrides.

## Why it's safe

- Purely mechanical: one base-class swap + deletion of 2 duplicate lines per file.
- No logic change — each subclass's own `_reset_state()` body (which does the actual state reset) is untouched.
- Full test suite passes: `318 passed` (including all metric-specific tests: `test_apartments_url_match.py`, `test_base.py`, `test_custom_task.py`, `test_opentable_info_gathering.py`, `test_resy_url_match.py`).
- `ruff check` passes with no findings.

## Test plan

- [x] `pytest` full suite — 318 passed
- [x] `ruff check` — all checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lby77tHRSiPctrC1SRqV5h)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical inheritance swap with no change to reset semantics or metric scoring logic.
> 
> **Overview**
> Introduces **`ResetsViaState`** on `BaseMetric` in `navi_bench/base.py`, implementing `async reset()` as a call to a subclass **`_reset_state()`** hook.
> 
> **Six evaluators** (`CustomTaskCaptureMetric`, `ApartmentsUrlMatch`, `CraigslistUrlMatch`, `GoogleFlightsSearchMatch`, `OpenTableInfoGathering`, `ResyUrlMatch`) now inherit from **`ResetsViaState`** instead of **`BaseMetric`** and drop their identical two-line `reset()` overrides. Each class’s **`_reset_state()`** bodies are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd401e34b9ac637bece6ecbfc9564d80770e6f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->