### PR TITLE
refactor(browser): extract shared patchTargetProperty() in prepare_page.js

### DIFF
--- a/evaluation/prepare_page.js
+++ b/evaluation/prepare_page.js
@@ -58,9 +58,12 @@
             Element.prototype._setAttributePatched = true;
         }
 
-        // 4. Prevent form.target from being set to new-tab values (allow _self, _parent, _top)
-        if (!HTMLFormElement.prototype._targetPatched) {
-            Object.defineProperty(HTMLFormElement.prototype, 'target', {
+        // 4. Prevent form.target/anchor.target from being set to new-tab values (allow _self, _parent, _top).
+        // Shared by both prototypes since the guard logic was byte-identical apart from which
+        // prototype it patched.
+        const patchTargetProperty = (Prototype) => {
+            if (Prototype._targetPatched) return;
+            Object.defineProperty(Prototype, 'target', {
                 set: function (val) {
                     if (!val || val === '_self' || val === '_parent' || val === '_top') {
                         this.setAttribute('target', val || '');
@@ -70,25 +73,12 @@
                 get: function () { return this.getAttribute('target') || ''; },
                 configurable: true
             });
-            HTMLFormElement.prototype._targetPatched = true;
-        }
+            Prototype._targetPatched = true;
+        };
+        patchTargetProperty(HTMLFormElement.prototype);
+        patchTargetProperty(HTMLAnchorElement.prototype);
 
-        // 5. Prevent anchor.target from being set to new-tab values (allow _self, _parent, _top)
-        if (!HTMLAnchorElement.prototype._targetPatched) {
-            Object.defineProperty(HTMLAnchorElement.prototype, 'target', {
-                set: function (val) {
-                    if (!val || val === '_self' || val === '_parent' || val === '_top') {
-                        this.setAttribute('target', val || '');
-                    }
-                    // Otherwise silently block (e.g., _blank or named targets)
-                },
-                get: function () { return this.getAttribute('target') || ''; },
-                configurable: true
-            });
-            HTMLAnchorElement.prototype._targetPatched = true;
-        }
-
-        // 6. Monitor form submissions to ensure bad targets are removed (preserving _self, _parent, _top)
+        // 5. Monitor form submissions to ensure bad targets are removed (preserving _self, _parent, _top)
         if (!window._submitListenerPatched) {
             document.addEventListener('submit', (e) => {
                 const target = e.target.getAttribute('target');
@@ -99,7 +89,7 @@
             window._submitListenerPatched = true;
         }
 
-        // 7. Watch for new elements with target attributes
+        // 6. Watch for new elements with target attributes
         if (!window._mutationObserverPatched) {
             new MutationObserver(removeTargets).observe(document.documentElement, {
                 childList: true, subtree: true, attributes: true, attributeFilter: ['target', 'formtarget']


### PR DESCRIPTION
## Issue

`evaluation/prepare_page.js`'s `disableNewTabs()` had two byte-for-byte identical `Object.defineProperty` blocks guarding `target` on `HTMLFormElement.prototype` and `HTMLAnchorElement.prototype` — same setter/getter logic, same `_targetPatched` guard idiom, differing only in which prototype was patched. Same class of "duplicated block, parameterize the one thing that differs" issue this repo has repeatedly extracted in Python (`_save_model`/`_load_model` in recorder.py, `_render_section` in vis.py) and JS (`isVisible()` dedup in #167), just not yet applied to this particular JS file.

## Improvement

Extracted a single `patchTargetProperty(Prototype)` helper; both call sites now delegate to it. Renumbered the trailing step comments (5→ and 6→ collapsed into 4, subsequent steps shifted down by one) since the two blocks merged into one step. No behavior change — same property descriptor, same per-prototype `_targetPatched` guard.

## Safety / verification

- `node --check evaluation/prepare_page.js` — syntax OK.
- Isolated smoke test of the extracted `patchTargetProperty` function against fake `Form`/`Anchor` prototype objects: blocked values (`_blank`, named tabs) are rejected, allowed values (`_self`, `_parent`, `_top`) pass through, both prototypes are patched independently, and re-invoking is idempotent (no throw).
- Full-file smoke test executing the whole IIFE against a minimal DOM stub (document/window/Element/HTMLFormElement/HTMLAnchorElement/MutationObserver): executes without throwing, returns `true`, both prototypes end up with a `target` property descriptor and `_targetPatched = true`, and a second injection is a no-op — ran this identically against the pre-refactor file via `git stash` and got byte-identical output both times.
- Python suite: `PYTHONPATH=. python -m pytest tests/` — 240/240 passing before and after (excluding `test_vis.py`/`test_cli.py`/`test_recorder.py`, which require the private `yutori` package not installed in this environment — consistent with prior PRs' documented exclusion).
- `ruff check .` clean. `ruff format --check .` flags two pre-existing, untouched files (`evaluation/eval_n1.py`, `navi_bench/dates.py`) unrelated to this change (confirmed via `git stash`).

Single file touched, no test/behavior change — purely mechanical.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DLktREW8jUHpmZBqz9x7rA

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLktREW8jUHpmZBqz9x7rA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor of evaluation-page new-tab guards; logic is unchanged and scope is a single JS file.
> 
> **Overview**
> In `disableNewTabs()` inside `evaluation/prepare_page.js`, the duplicate `Object.defineProperty` guards on `HTMLFormElement.prototype` and `HTMLAnchorElement.prototype` are replaced by a shared **`patchTargetProperty(Prototype)`** helper that keeps the same setter/getter behavior and per-prototype **`_targetPatched`** idempotency flag.
> 
> Inline step comments are renumbered after merging the former steps 4 and 5 into one. **No intended behavior change** for blocking `_blank`/named targets on forms and anchors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d619c41b80e4bbc7964e51da3a6ad466722e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->