### PR TITLE
test(vis): add characterization tests for .modal-close/.modal-nav CSS dedup

### DIFF
--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -590,3 +590,60 @@ class TestModalOverlayStyleSheetDeduplication:
         # not once per selector as two separate ``.active { display: flex; }`` rules.
         assert len(re.findall(r"\.modal-overlay\.active", html)) == 1
         assert len(re.findall(r"\.answer-modal-overlay\.active", html)) == 1
+
+
+class TestModalCloseNavStyleSheetDeduplication:
+    """Pins that ``.modal-close`` (the lightbox close button) and ``.modal-nav`` (the
+    prev/next lightbox arrows) share their identical circular-button declarations via the
+    same comma-separated-selector convention as ``TestStyleSheetDeduplication`` and
+    ``TestModalOverlayStyleSheetDeduplication`` above, instead of each repeating the full
+    ``position/width/height/background/border/border-radius/color/cursor/display/
+    align-items/justify-content/transition/z-index`` rule body verbatim. Each selector keeps
+    its own rule for the properties it doesn't share (``.modal-close``'s ``top``/``right``/
+    ``font-size``; ``.modal-nav``'s ``top``/``transform``/``font-size``).
+    """
+
+    @staticmethod
+    def _html() -> str:
+        messages = [{"role": "user", "content": [{"type": "text", "text": "do the task"}]}]
+        return generate_visualization_html("task1", messages, None)
+
+    def test_close_and_nav_share_one_rule_with_all_properties(self):
+        html = self._html()
+        match = re.search(r"\.modal-close,\s*\.modal-nav\s*\{([^}]*)\}", html)
+        assert match is not None, html
+        body = match.group(1)
+        for prop in (
+            "position: fixed;",
+            "width: 48px;",
+            "height: 48px;",
+            "background: var(--bg-tertiary);",
+            "border: 1px solid var(--border-color);",
+            "border-radius: 50%;",
+            "color: var(--text-primary);",
+            "cursor: pointer;",
+            "display: flex;",
+            "align-items: center;",
+            "justify-content: center;",
+            "transition: all 0.2s;",
+            "z-index: 1001;",
+        ):
+            assert prop in body
+        # The body must appear exactly once in the stylesheet, not once per selector.
+        assert html.count("border-radius: 50%;\n            color: var(--text-primary);") == 1
+
+    def test_modal_close_keeps_its_own_position_and_font_size(self):
+        html = self._html()
+        match = re.search(r"\.modal-close\s*\{\s*top: 1\.5rem;\s*right: 1\.5rem;\s*font-size: 1\.5rem;\s*\}", html)
+        assert match is not None, html
+        # .modal-nav never gets .modal-close's fixed corner offset.
+        assert "modal-nav {\n            top: 1.5rem;" not in html
+
+    def test_modal_nav_keeps_its_own_position_and_font_size(self):
+        html = self._html()
+        match = re.search(
+            r"\.modal-nav\s*\{\s*top: 50%;\s*transform: translateY\(-50%\);\s*font-size: 1\.25rem;\s*\}", html
+        )
+        assert match is not None, html
+        # .modal-close never gets .modal-nav's centered-vertical offset.
+        assert "modal-close {\n            top: 50%;" not in html


### PR DESCRIPTION
## Why

Daily doc/test-drift review of the last 24h of commits on `main` (#175-#180). All of them are
clean, well-tested pure refactors — except one gap:

PR #176 (`refactor(vis): dedupe .modal-close/.modal-nav CSS rules`) merged
`.modal-close`/`.modal-nav`'s identical declarations in `generate_visualization_html()`
into a comma-separated selector, explicitly following the same convention as #169
(`.section`/`.step`, `.nav-btn:hover`/`.modal-nav:hover`) and #173
(`.modal-overlay`/`.answer-modal-overlay`). Both of those sibling PRs added a
`TestXStyleSheetDeduplication` test class to `tests/test_vis.py` pinning the merged rule
body and each selector's own remaining properties — #176 did not add the matching class,
leaving this one dedup without characterization coverage.

## What

Adds `TestModalCloseNavStyleSheetDeduplication` to `tests/test_vis.py`, mirroring the
existing `TestStyleSheetDeduplication`/`TestModalOverlayStyleSheetDeduplication` classes:
- pins that `.modal-close, .modal-nav` declares the full shared rule body exactly once
- pins that `.modal-close` keeps its own `top`/`right`/`font-size` rule
- pins that `.modal-nav` keeps its own `top`/`transform`/`font-size` rule

No production code changed — `evaluation/vis.py` is untouched. This is test-only, closing a
coverage gap so a future edit to this stylesheet can be verified as behavior-preserving,
consistent with its sibling dedups.

## Verification

- `pytest -q` — 321 passed (was 318 before; +3 new tests)
- `ruff check .` — clean
- `ruff format --check tests/test_vis.py` — clean (two pre-existing, unrelated formatting
  diffs on `main` in `evaluation/eval_n1.py`/`navi_bench/dates.py` were left untouched)

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_015EpQ5JjvayU4XsK6TJGVn4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only PR with no runtime or stylesheet changes.
> 
> **Overview**
> Adds **`TestModalCloseNavStyleSheetDeduplication`** in `tests/test_vis.py`, matching the pattern used for other embedded-stylesheet dedup tests. It locks in that **`.modal-close, .modal-nav`** declares the shared circular-button CSS once, and that each selector still has its own rule for non-shared layout (**close**: `top`/`right`/`font-size`; **nav**: centered `top`/`transform`/`font-size`).
> 
> **No production changes** — this only closes test coverage for the refactor already in `generate_visualization_html()`’s CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2486e391700d3173cca18692537517a0cc75b79e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->