### PR TITLE
refactor(opentable): extract shared extractSlotAvailabilities() JS helper

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -236,6 +236,21 @@
         return availabilities;
     };
 
+    // Scrape a container's time-slot elements into availabilities via parseTimesAndAvailabilities.
+    // Extracted because handleNextAvailablePopup, handleSearchPage, handleRestrefPage, and
+    // handleBookingRestrefPage each repeated this identical "querySelectorAll -> map textContent
+    // -> filter to slot-shaped strings -> parseTimesAndAvailabilities" sequence, differing only
+    // in the slot selector and (on OpenTable's restref page specifically) the AM/PM casing used
+    // in the rendered slot text. `ampmUpper` defaults to true (the common case) and is passed
+    // false for the two restref-page call sites, which render lowercase "am"/"pm".
+    const extractSlotAvailabilities = (container, slotSelector, baseDateForSlots, ampmUpper = true) => {
+        const [amToken, pmToken] = ampmUpper ? ["AM", "PM"] : ["am", "pm"];
+        const timesArray = Array.from(container.querySelectorAll(slotSelector))
+            .map((el) => el.textContent)
+            .filter((el) => el === "" || el.includes(amToken) || el.includes(pmToken));
+        return parseTimesAndAvailabilities(baseDateForSlots, timesArray);
+    };
+
     const handleNextAvailablePopup = (partySize, baseDate, baseTime) => {
         // Popup when clicking "Show next available"
         const popup = document.querySelector('[data-test="multi-day-availability-modal"]');
@@ -246,10 +261,7 @@
             popup.querySelectorAll('[data-test="multi-day-timeslot-container"]').forEach((el) => {
                 if (isVisible(el)) {
                     const { date, _ } = parseDateAndTimes(el.textContent);
-                    const timesArray = Array.from(el.querySelectorAll('li'))
-                        .map((el) => el.textContent)
-                        .filter((el) => el === "" || el.includes("AM") || el.includes("PM"));
-                    const availabilities = parseTimesAndAvailabilities(date, timesArray);
+                    const availabilities = extractSlotAvailabilities(el, 'li', date);
 
                     for (const a of availabilities) {
                         results.push({
@@ -376,10 +388,7 @@
                         info: timeSlots,
                     });
                 } else {
-                    const timesArray = Array.from(el.querySelectorAll('li'))
-                        .map((el) => el.textContent)
-                        .filter((el) => el === "" || el.includes("AM") || el.includes("PM"));
-                    const availabilities = parseTimesAndAvailabilities(baseDate, timesArray);
+                    const availabilities = extractSlotAvailabilities(el, 'li', baseDate);
                     for (const a of availabilities) {
                         results.push({
                             url: url,
@@ -413,10 +422,7 @@
                     });
                     setIsRecorded(el);
                 } else {
-                    const timesArray = Array.from(el.querySelectorAll('li'))
-                        .map((el) => el.textContent)
-                        .filter((el) => el === "" || el.includes("AM") || el.includes("PM"));
-                    const availabilities = parseTimesAndAvailabilities(baseDate, timesArray);
+                    const availabilities = extractSlotAvailabilities(el, 'li', baseDate);
                     for (const a of availabilities) {
                         results.push({
                             url: url,
@@ -533,10 +539,7 @@
         // searched day slots
         document.querySelectorAll('.styled__AvailabilityDayWrapper-sc-1xhoeow-5').forEach((el) => {
             if (isVisible(el)) {
-                const timesArray = Array.from(el.querySelectorAll('li'))
-                    .map((el) => el.textContent)
-                    .filter((el) => el === "" || el.includes("am") || el.includes("pm"));
-                const availabilities = parseTimesAndAvailabilities(baseDate, timesArray);
+                const availabilities = extractSlotAvailabilities(el, 'li', baseDate, false);
 
                 for (const a of availabilities) {
                     results.push({
@@ -556,11 +559,7 @@
             if (isVisible(el)) {
                 const dateText = el.querySelector('p')?.textContent;
                 const { date, _ } = parseDateAndTimes(dateText);
-                const timesArray = Array.from(el.querySelectorAll('li'))
-                    .map((el) => el.textContent)
-                    .filter((el) => el === "" || el.includes("am") || el.includes("pm"));
-                console.log(`date: ${date}, timesArray: ${timesArray}`);
-                const availabilities = parseTimesAndAvailabilities(date, timesArray);
+                const availabilities = extractSlotAvailabilities(el, 'li', date, false);
 
                 for (const a of availabilities) {
                     results.push({
@@ -632,10 +631,7 @@
         // searched day slots
         document.querySelectorAll('[data-test="searched-day-slots"]').forEach((el) => {
             if (isVisible(el)) {
-                const timesArray = Array.from(el.querySelectorAll('[data-test="slot"]'))
-                    .map((el) => el.textContent)
-                    .filter((el) => el === "" || el.includes("AM") || el.includes("PM"));
-                const availabilities = parseTimesAndAvailabilities(baseDate, timesArray);
+                const availabilities = extractSlotAvailabilities(el, '[data-test="slot"]', baseDate);
 
                 for (const a of availabilities) {
                     results.push({
@@ -655,10 +651,7 @@
             if (isVisible(el)) {
                 const dateText = el.querySelector('p')?.textContent;
                 const { date, _ } = parseDateAndTimes(dateText);
-                const timesArray = Array.from(el.querySelectorAll('[data-test="slot"]'))
-                    .map((el) => el.textContent)
-                    .filter((el) => el === "" || el.includes("AM") || el.includes("PM"));
-                const availabilities = parseTimesAndAvailabilities(date, timesArray);
+                const availabilities = extractSlotAvailabilities(el, '[data-test="slot"]', date);
 
                 for (const a of availabilities) {
                     results.push({


### PR DESCRIPTION
## What's duplicated

`navi_bench/opentable/opentable_info_gathering.js`'s `handleNextAvailablePopup`,
`handleSearchPage` (x2), `handleRestrefPage` (x2), and `handleBookingRestrefPage` (x2) each
repeated an identical 7-line block:

```js
const timesArray = Array.from(el.querySelectorAll(SLOT_SELECTOR))
    .map((el) => el.textContent)
    .filter((el) => el === "" || el.includes(AM_TOKEN) || el.includes(PM_TOKEN));
const availabilities = parseTimesAndAvailabilities(BASE_DATE, timesArray);
```

The 7 call sites differed only in:
- the slot selector (`'li'` vs `'[data-test="slot"]'`)
- the AM/PM casing used in the rendered slot text (OpenTable's restref page renders
  lowercase `am`/`pm`; every other page renders uppercase `AM`/`PM`)
- the date expression fed in (`baseDate` vs a locally-parsed `date`)

## The refactor

Extracted the shared sequence into `extractSlotAvailabilities(container, slotSelector,
baseDateForSlots, ampmUpper = true)`, which each of the 7 call sites now calls instead of
repeating the querySelectorAll/map/filter/parse chain inline. Each site's own surrounding
loop logic (the simple push loop vs. `handleNextAvailablePopup`'s extra
prev/next-availability tracking) is untouched — only the shared "scrape the DOM into an
`availabilities` list" step moved into the helper.

One incidental cleanup: dropped a stray `console.log(`date: ..., timesArray: ...`)` debug
statement that only existed in one of these 7 call sites (the restref-page "future
availability" branch) — it only ever wrote to the browser console during evaluation and
has zero effect on the metric's `results` output or any consumed signal.

## Why it's safe

- **`node --check`** passes on the refactored file.
- **Behavioral equivalence harness**: since this file has no existing test coverage that
  actually executes the JS (the Python tests fake `page.evaluate` entirely), I wrote a node
  script that loads `parseTimesAndAvailabilities` from both the pre- and post-refactor file
  content, then compares the old 7-line inline block against the new
  `extractSlotAvailabilities()` call across 6 fixtures spanning both selectors, both AM/PM
  cases, an empty-container case, and a no-time-strings case, plus a check that omitting
  `ampmUpper` (defaulting to `true`) matches passing it explicitly. All outputs are
  byte-identical (`JSON.stringify` equal).
- **Full pytest suite**: 321/321 pass (`PYTHONPATH=. python3 -m pytest tests/ -q`),
  unaffected since this JS module isn't exercised by the Python test suite directly.
- **`ruff check`/`ruff format`**: no Python files touched by this change.
- Scope: single file changed, purely mechanical extraction, no change to selectors, dates,
  or the shared `parseTimesAndAvailabilities` logic itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GprCD9seazvXdzRGCpYipZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in a single bench JS file; parsing logic and selectors are preserved, with only debug logging removed.
> 
> **Overview**
> Introduces **`extractSlotAvailabilities(container, slotSelector, baseDateForSlots, ampmUpper)`** in `opentable_info_gathering.js` and replaces seven copies of the same DOM scrape → filter by AM/PM → `parseTimesAndAvailabilities` block across the next-available popup, search, restref, and booking-restref handlers.
> 
> Call sites only pass their slot selector (`li` vs `[data-test="slot"]`), date, and whether slot text uses uppercase **AM/PM** (default) or lowercase **am/pm** on restref pages. Surrounding loops and result pushing are unchanged.
> 
> Also removes a one-off **`console.log`** on the restref future-availability branch; it did not affect scraped `results`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f577348b817e0ec51816051f36b20b83925876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->