### PR TITLE
refactor(opentable): extract pushSlotResult/pushRangeResult JS helpers

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -5,6 +5,19 @@
     const results = [];
     const url = window.location.href.replace(/\/+$/, "");
 
+    // Push a single-slot info result. Extracted because every `results.push({...})` call
+    // site across the handlers below repeated the identical `url`/`restaurantName`/
+    // `partySize` triple, differing only in `date`/`time`/`info`.
+    const pushSlotResult = (restaurantName, partySize, date, time, info) => {
+        results.push({ url, restaurantName, partySize, date, time, info });
+    };
+
+    // Push a date/time-range info result (used for the "unavailable between X and Y"
+    // shape), sharing the same `url`/`restaurantName`/`partySize` triple as pushSlotResult.
+    const pushRangeResult = (restaurantName, partySize, startDate, startTime, endDate, endTime, info) => {
+        results.push({ url, restaurantName, partySize, startDate, startTime, endDate, endTime, info });
+    };
+
     const isRecorded = (el) => {
         return el.getAttribute("__recorded") === "true";
     };
@@ -264,14 +277,7 @@
                     const availabilities = extractSlotAvailabilities(el, 'li', date);
 
                     for (const a of availabilities) {
-                        results.push({
-                            url: url,
-                            restaurantName: restaurantName,
-                            partySize: partySize,
-                            date: a.date,
-                            time: a.time,
-                            info: a.availability,
-                        });
+                        pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
                         if (a.availability === "available") {
                             // update prevAvailable
                             if (a.date < baseDate || (a.date === baseDate && a.time <= baseTime)) {
@@ -312,27 +318,9 @@
             const curPage = popup.querySelector('.qfZDsxm8aWs-')?.textContent;
             if (curPage === "1") {
                 if (prevAvailable && nextAvailable) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        startDate: prevAvailable.date,  // inclusive
-                        startTime: prevAvailable.time,  // inclusive
-                        endDate: nextAvailable.date,  // exclusive
-                        endTime: nextAvailable.time,  // exclusive
-                        info: "unavailable",
-                    });
+                    pushRangeResult(restaurantName, partySize, prevAvailable.date, prevAvailable.time, nextAvailable.date, nextAvailable.time, "unavailable");
                 } else if (nextAvailable) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        startDate: baseDate,  // inclusive
-                        startTime: baseTime,  // inclusive
-                        endDate: nextAvailable.date,  // exclusive
-                        endTime: nextAvailable.time,  // exclusive
-                        info: "unavailable",
-                    });
+                    pushRangeResult(restaurantName, partySize, baseDate, baseTime, nextAvailable.date, nextAvailable.time, "unavailable");
                 }
             }
         }
@@ -379,25 +367,11 @@
                 const restaurantName = (el.querySelector('[data-test="res-card-name"]') || el.querySelector('h6'))?.textContent;
                 const timeSlots = el.querySelector('[data-test="time-slots"]')?.textContent;
                 if (timeSlots && timeSlots.includes("no online availability")) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        date: baseDate,
-                        time: baseTime,
-                        info: timeSlots,
-                    });
+                    pushSlotResult(restaurantName, partySize, baseDate, baseTime, timeSlots);
                 } else {
                     const availabilities = extractSlotAvailabilities(el, 'li', baseDate);
                     for (const a of availabilities) {
-                        results.push({
-                            url: url,
-                            restaurantName: restaurantName,
-                            partySize: partySize,
-                            date: a.date,
-                            time: a.time,
-                            info: a.availability,
-                        });
+                        pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
                     }
                 }
             }
@@ -412,26 +386,12 @@
                 const restaurantName = (el.querySelector('[data-test="res-card-name"]') || el.querySelector('h6'))?.textContent;
                 const timeSlots = el.querySelector('[data-test="time-slots"]')?.textContent;
                 if (timeSlots && timeSlots.includes("no online availability")) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        date: baseDate,
-                        time: baseTime,
-                        info: timeSlots,
-                    });
+                    pushSlotResult(restaurantName, partySize, baseDate, baseTime, timeSlots);
                     setIsRecorded(el);
                 } else {
                     const availabilities = extractSlotAvailabilities(el, 'li', baseDate);
                     for (const a of availabilities) {
-                        results.push({
-                            url: url,
-                            restaurantName: restaurantName,
-                            partySize: partySize,
-                            date: a.date,
-                            time: a.time,
-                            info: a.availability,
-                        });
+                        pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
                     }
                     if (availabilities.length > 0) {
                         setIsRecorded(el);
@@ -471,14 +431,7 @@
         if (baseDate && baseTime) {
             const dateAndTimes = parseDateAndTimes(baseDate + " " + baseTime);
             for (const time of dateAndTimes.times) {
-                results.push({
-                    url: url,
-                    restaurantName: restaurantName,
-                    partySize: partySize,
-                    date: dateAndTimes.date,
-                    time: time,
-                    info: "available",
-                });
+                pushSlotResult(restaurantName, partySize, dateAndTimes.date, time, "available");
             }
         }
     };
@@ -526,14 +479,7 @@
         });
 
         if (availability) {
-            results.push({
-                url: url,
-                restaurantName: restaurantName,
-                partySize: partySize,
-                date: baseDate,
-                time: baseTime,
-                info: availability,
-            });
+            pushSlotResult(restaurantName, partySize, baseDate, baseTime, availability);
         }
 
         // searched day slots
@@ -542,14 +488,7 @@
                 const availabilities = extractSlotAvailabilities(el, 'li', baseDate, false);
 
                 for (const a of availabilities) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        date: a.date,
-                        time: a.time,
-                        info: a.availability,
-                    });
+                    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
                 }
             }
         });
@@ -562,14 +501,7 @@
                 const availabilities = extractSlotAvailabilities(el, 'li', date, false);
 
                 for (const a of availabilities) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        date: a.date,
-                        time: a.time,
-                        info: a.availability,
-                    });
+                    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
                 }
             }
         });
@@ -618,14 +550,7 @@
         });
 
         if (availability) {
-            results.push({
-                url: url,
-                restaurantName: restaurantName,
-                partySize: partySize,
-                date: baseDate,
-                time: baseTime,
-                info: availability,
-            });
+            pushSlotResult(restaurantName, partySize, baseDate, baseTime, availability);
         }
 
         // searched day slots
@@ -634,14 +559,7 @@
                 const availabilities = extractSlotAvailabilities(el, '[data-test="slot"]', baseDate);
 
                 for (const a of availabilities) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        date: a.date,
-                        time: a.time,
-                        info: a.availability,
-                    });
+                    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
                 }
             }
         });
@@ -654,14 +572,7 @@
                 const availabilities = extractSlotAvailabilities(el, '[data-test="slot"]', date);
 
                 for (const a of availabilities) {
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        date: a.date,
-                        time: a.time,
-                        info: a.availability,
-                    });
+                    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
                 }
             }
         });
@@ -697,25 +608,10 @@
         }
 
         if (timeSlots && timeSlots.textContent.includes("no online availability on the selected day")) {
-            results.push({
-                url: url,
-                restaurantName: restaurantName,
-                partySize: partySize,
-                startDate: baseDate,  // inclusive
-                startTime: "00:00:00",  // inclusive
-                endDate: getNextDate(baseDate),  // exclusive
-                endTime: "00:00:00",  // exclusive
-                info: "unavailable",
-            });
+            pushRangeResult(restaurantName, partySize, baseDate, "00:00:00", getNextDate(baseDate), "00:00:00", "unavailable");
         } else if (timeSlots && timeSlots.textContent.includes("Unfortunately")) {
-            results.push({
-                url: url,
-                restaurantName: restaurantName,
-                partySize: partySize,
-                date: baseDate,
-                time: "00:00:00",  // here the time is not actually used, as the entire date or the party size is not available
-                info: timeSlots.textContent,
-            });
+            // here the time is not actually used, as the entire date or the party size is not available
+            pushSlotResult(restaurantName, partySize, baseDate, "00:00:00", timeSlots.textContent);
         } else if (timeSlots) {
             const timesAndVisibilities = [];
 
@@ -775,14 +671,7 @@
 
             const availableTimes = new Set(timesAndVisibilities.map(x => x.time));
             for (let t = start; t <= end; t = getNextTime(t, deltaMinutes)) {
-                results.push({
-                    url: url,
-                    restaurantName: restaurantName,
-                    partySize: partySize,
-                    date: baseDate,
-                    time: t,
-                    info: availableTimes.has(t) ? "available" : "unavailable",
-                });
+                pushSlotResult(restaurantName, partySize, baseDate, t, availableTimes.has(t) ? "available" : "unavailable");
             }
         }
     };
@@ -861,27 +750,13 @@
         }
 
         if (timeSlots && (timeSlots.includes("no online availability") || timeSlots.includes("Unfortunately"))) {
-            results.push({
-                url: url,
-                restaurantName: restaurantName,
-                partySize: partySize,
-                date: baseDate,
-                time: baseTime,
-                info: timeSlots,
-            });
+            pushSlotResult(restaurantName, partySize, baseDate, baseTime, timeSlots);
         } else {
             const dateAndTimes = parseDateAndTimes(timeSlots);
 
             const availableTimes = dateAndTimes.times;
             for (const time of availableTimes) {
-                results.push({
-                    url: url,
-                    restaurantName: restaurantName,
-                    partySize: partySize,
-                    date: baseDate,
-                    time: time,
-                    info: "available",
-                });
+                pushSlotResult(restaurantName, partySize, baseDate, time, "available");
             }
 
             if (availableTimes.length > 0) {
@@ -929,14 +804,7 @@
                 // push the unavailable times to the results
                 for (const ts of unavailableTimestamps) {
                     const dt = timestampToDateAndTime(ts);
-                    results.push({
-                        url: url,
-                        restaurantName: restaurantName,
-                        partySize: partySize,
-                        date: dt.date,
-                        time: dt.time,
-                        info: "unavailable",
-                    });
+                    pushSlotResult(restaurantName, partySize, dt.date, dt.time, "unavailable");
                 }
             }
         }


### PR DESCRIPTION
## Issue

`navi_bench/opentable/opentable_info_gathering.js`'s page handlers (`handleNextAvailablePopup`, `handleSearchPage`, `handleRestrefPage`, `handleBookingRestrefPage`, `handleRestaurantPageWithFullAvailabilityPopup`, `handleRestaurantPage`) each independently built `results.push({...})` calls that repeated the identical `url`/`restaurantName`/`partySize` triple, differing only in:
- a `date`/`time`/`info` shape (16 call sites), or
- a `startDate`/`startTime`/`endDate`/`endTime`/`info` range shape (4 call sites)

This is the same "duplicated block, parameterize the one thing that differs" pattern already applied to this exact file's `extractSlotAvailabilities()` (#182) and to `evaluation/prepare_page.js`'s `patchTargetProperty()` (#180) — just not yet swept for this particular shape.

## Improvement

Extracted two small helpers at the top of the IIFE:
```js
const pushSlotResult = (restaurantName, partySize, date, time, info) => {
    results.push({ url, restaurantName, partySize, date, time, info });
};

const pushRangeResult = (restaurantName, partySize, startDate, startTime, endDate, endTime, info) => {
    results.push({ url, restaurantName, partySize, startDate, startTime, endDate, endTime, info });
};
```
All 20 call sites now delegate to one of these. File shrinks from 965 -> 833 lines with zero logic changes — this is pure object-construction deduplication, not a change to any scraping/parsing logic.

## Safety verification

- **No behavior change**: JS object property order doesn't affect downstream equality/consumption (the result objects are consumed as plain data via Playwright's `page.evaluate()` return value). Wrote a standalone node harness comparing the new helpers' output against the exact old inline `{url: url, restaurantName: restaurantName, ...}` construction across representative fixtures, including edge cases (`null`/`undefined` values) — all outputs byte-for-byte identical (`JSON.stringify` match).
- `node --check navi_bench/opentable/opentable_info_gathering.js` passes.
- No Python test executes this JS file directly (only loaded via `read_sidecar_with_shared_js_prefix` at runtime), so this isn't exercised by `pytest`, but ran the full suite anyway to confirm nothing else regressed: **247 passed** (excluding `tests/test_vis.py` and `tests/test_recorder.py`, which require the private `yutori` package unavailable in this sandbox — expected per this repo's established test-running convention).
- `ruff check .` clean. (`ruff format --check` flags 2 pre-existing, unrelated files (`evaluation/eval_n1.py`, `navi_bench/dates.py`) not touched by this change.)
- Touches 1 file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015JchJJsKKGmHrMVvtn6ktG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with identical result object shapes; no changes to DOM selectors, parsing, or evaluation logic.
> 
> **Overview**
> Deduplicates how OpenTable scraping results are appended in `opentable_info_gathering.js` by introducing **`pushSlotResult`** and **`pushRangeResult`** at the top of the IIFE. Both helpers centralize the repeated `url` / `restaurantName` / `partySize` fields while callers only pass slot or range-specific data.
> 
> All **20** former inline `results.push({...})` sites across page handlers (`handleNextAvailablePopup`, `handleSearchPage`, `handleBookingPage`, `handleRestrefPage`, `handleBookingRestrefPage`, `handleRestaurantPageWithFullAvailabilityPopup`, `handleRestaurantPage`) now call one of these helpers. **Scraping, parsing, and the shape of emitted objects are unchanged**—only how those objects are constructed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6def42b1b823d60da5e9bb0375dc6e0f8f1c4f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->