### PR TITLE
refactor(opentable): extract extractPartySizeDateTime/normalizeBaseDateTime JS helpers

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -303,11 +303,12 @@
         time: '[data-testid="time-picker-overlay"]',
     };
 
-    // Re-parse a raw `baseDate`/`baseTime` pair (as scraped by extractPartySizeDateTime) through
-    // parseDateAndTimes so the returned date/time are in the same normalized form used elsewhere.
-    // Extracted because handleSearchPage, handleBookingRestrefPage, and handleRestaurantPage's
-    // dropdown-menu branch each repeated this identical "if both are set, re-parse and take the
-    // first parsed time" block immediately after scraping the picker overlays.
+    // Re-parse a raw `baseDate`/`baseTime` pair (as scraped by extractPartySizeDateTime, or by
+    // handleRestrefPage's own differently-selectored scrape) through parseDateAndTimes so the
+    // returned date/time are in the same normalized form used elsewhere. Extracted because
+    // handleSearchPage, handleBookingRestrefPage, handleRestaurantPage's dropdown-menu branch,
+    // and handleRestrefPage each repeated this identical "if both are set, re-parse and take
+    // the first parsed time" block immediately after scraping the picker overlays.
     const normalizeBaseDateTime = (baseDate, baseTime) => {
         if (baseDate && baseTime) {
             const { date, times } = parseDateAndTimes(baseDate + " " + baseTime);
@@ -491,13 +492,7 @@
             }
         });
 
-        if (baseDate && baseTime) {
-            const { date, times } = parseDateAndTimes(baseDate + " " + baseTime);
-            if (times.length > 0) {
-                baseDate = date;
-                baseTime = times[0];
-            }
-        }
+        ({ baseDate, baseTime } = normalizeBaseDateTime(baseDate, baseTime));
 
         let availability = null;
         document.querySelectorAll('.styled__AvailabilityDayWrapper-sc-1xhoeow-5').forEach((el) => {

--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -264,6 +264,60 @@
         return parseTimesAndAvailabilities(baseDateForSlots, timesArray);
     };
 
+    // Scan `root` for the visible party-size/date/time picker-overlay elements and return
+    // their raw text content. Extracted because handleSearchPage, handleBookingRestrefPage,
+    // and handleRestaurantPage's dropdown-menu branch each repeated this identical
+    // "querySelectorAll -> find the visible element -> read its textContent" sequence three
+    // times in a row (once per field), differing only in which element (`document` vs a
+    // scoped `reservationPanel`) is searched.
+    const extractPartySizeDateTime = (root, selectors) => {
+        let partySize = null;
+        root.querySelectorAll(selectors.partySize).forEach((el) => {
+            if (isVisible(el)) {
+                partySize = parsePartySize(el.textContent);
+            }
+        });
+
+        let baseDate = null;
+        root.querySelectorAll(selectors.date).forEach((el) => {
+            if (isVisible(el)) {
+                baseDate = el.textContent;
+            }
+        });
+
+        let baseTime = null;
+        root.querySelectorAll(selectors.time).forEach((el) => {
+            if (isVisible(el)) {
+                baseTime = el.textContent;
+            }
+        });
+
+        return { partySize, baseDate, baseTime };
+    };
+
+    // The picker-overlay selectors shared by handleSearchPage, handleBookingRestrefPage, and
+    // handleRestaurantPage's dropdown-menu branch (see extractPartySizeDateTime above).
+    const PICKER_OVERLAY_SELECTORS = {
+        partySize: '[data-testid="party-size-picker-overlay"]',
+        date: '[data-testid="day-picker-overlay"]',
+        time: '[data-testid="time-picker-overlay"]',
+    };
+
+    // Re-parse a raw `baseDate`/`baseTime` pair (as scraped by extractPartySizeDateTime) through
+    // parseDateAndTimes so the returned date/time are in the same normalized form used elsewhere.
+    // Extracted because handleSearchPage, handleBookingRestrefPage, and handleRestaurantPage's
+    // dropdown-menu branch each repeated this identical "if both are set, re-parse and take the
+    // first parsed time" block immediately after scraping the picker overlays.
+    const normalizeBaseDateTime = (baseDate, baseTime) => {
+        if (baseDate && baseTime) {
+            const { date, times } = parseDateAndTimes(baseDate + " " + baseTime);
+            if (times.length > 0) {
+                return { baseDate: date, baseTime: times[0] };
+            }
+        }
+        return { baseDate, baseTime };
+    };
+
     const handleNextAvailablePopup = (partySize, baseDate, baseTime) => {
         // Popup when clicking "Show next available"
         const popup = document.querySelector('[data-test="multi-day-availability-modal"]');
@@ -327,34 +381,8 @@
     };
 
     const handleSearchPage = () => {
-        let partySize = null;
-        document.querySelectorAll('[data-testid="party-size-picker-overlay"]').forEach((el) => {
-            if (isVisible(el)) {
-                partySize = parsePartySize(el.textContent);
-            }
-        });
-
-        let baseDate = null;
-        document.querySelectorAll('[data-testid="day-picker-overlay"]').forEach((el) => {
-            if (isVisible(el)) {
-                baseDate = el.textContent;
-            }
-        });
-
-        let baseTime = null;
-        document.querySelectorAll('[data-testid="time-picker-overlay"]').forEach((el) => {
-            if (isVisible(el)) {
-                baseTime = el.textContent;
-            }
-        });
-
-        if (baseDate && baseTime) {
-            const { date, times } = parseDateAndTimes(baseDate + " " + baseTime);
-            if (times.length > 0) {
-                baseDate = date;
-                baseTime = times[0];
-            }
-        }
+        let { partySize, baseDate, baseTime } = extractPartySizeDateTime(document, PICKER_OVERLAY_SELECTORS);
+        ({ baseDate, baseTime } = normalizeBaseDateTime(baseDate, baseTime));
 
         // there could be some promoted restaurants
         document.querySelectorAll('[data-test="multi-search-pop-table"] > ul > li').forEach((el) => {
@@ -513,34 +541,8 @@
             restaurantName = restaurantName.slice(11);
         }
 
-        let partySize = null;
-        document.querySelectorAll('[data-testid="party-size-picker-overlay"]').forEach((el) => {
-            if (isVisible(el)) {
-                partySize = parsePartySize(el.textContent);
-            }
-        });
-
-        let baseDate = null;
-        document.querySelectorAll('[data-testid="day-picker-overlay"]').forEach((el) => {
-            if (isVisible(el)) {
-                baseDate = el.textContent;
-            }
-        });
-
-        let baseTime = null;
-        document.querySelectorAll('[data-testid="time-picker-overlay"]').forEach((el) => {
-            if (isVisible(el)) {
-                baseTime = el.textContent;
-            }
-        });
-
-        if (baseDate && baseTime) {
-            const { date, times } = parseDateAndTimes(baseDate + " " + baseTime);
-            if (times.length > 0) {
-                baseDate = date;
-                baseTime = times[0];
-            }
-        }
+        let { partySize, baseDate, baseTime } = extractPartySizeDateTime(document, PICKER_OVERLAY_SELECTORS);
+        ({ baseDate, baseTime } = normalizeBaseDateTime(baseDate, baseTime));
 
         let availability = null;
         document.querySelectorAll('.O-z6wyHTamU-').forEach((el) => {
@@ -713,31 +715,8 @@
 
         } else {
             // Dropdown menus for party size, date, and time are shown directly
-            reservationPanel.querySelectorAll('[data-testid="party-size-picker-overlay"]').forEach((el) => {
-                if (isVisible(el)) {
-                    partySize = parsePartySize(el.textContent);
-                }
-            });
-
-            reservationPanel.querySelectorAll('[data-testid="day-picker-overlay"]').forEach((el) => {
-                if (isVisible(el)) {
-                    baseDate = el.textContent;
-                }
-            });
-
-            reservationPanel.querySelectorAll('[data-testid="time-picker-overlay"]').forEach((el) => {
-                if (isVisible(el)) {
-                    baseTime = el.textContent;
-                }
-            });
-
-            if (baseDate && baseTime) {
-                const { date, times } = parseDateAndTimes(baseDate + " " + baseTime);
-                if (times.length > 0) {
-                    baseDate = date;
-                    baseTime = times[0];
-                }
-            }
+            ({ partySize, baseDate, baseTime } = extractPartySizeDateTime(reservationPanel, PICKER_OVERLAY_SELECTORS));
+            ({ baseDate, baseTime } = normalizeBaseDateTime(baseDate, baseTime));
         }
 
         let timeSlots = null;


### PR DESCRIPTION
## Issue

`opentable_info_gathering.js`'s `handleSearchPage`, `handleBookingRestrefPage`, and `handleRestaurantPage`'s dropdown-menu branch each repeated an identical block:

1. Scan the party-size / day / time picker-overlay selectors (`[data-testid="party-size-picker-overlay"]`, `[data-testid="day-picker-overlay"]`, `[data-testid="time-picker-overlay"]`) for the visible element's `textContent`.
2. If both `baseDate` and `baseTime` came back non-empty, re-parse `baseDate + " " + baseTime` through `parseDateAndTimes` and take the first parsed time.

The three sites differed only in which root element was searched (`document` for the first two, a scoped `reservationPanel` for the third). This is the same "duplicated block, parameterize the one thing that differs" pattern already applied to this file's `pushSlotResult`/`pushRangeResult` (#183) and `extractSlotAvailabilities` (#182) — a fresh instance introduced by earlier feature work and not yet caught by those two audits.

## Improvement

Extracted two helpers:
- `extractPartySizeDateTime(root, selectors)` — the selector-scan step, parameterized by root element and a `{partySize, date, time}` selector map (`PICKER_OVERLAY_SELECTORS`, since all three call sites use the same three selectors).
- `normalizeBaseDateTime(baseDate, baseTime)` — the re-parse step.

All three call sites now delegate to both helpers instead of repeating ~26 lines of identical logic each.

## Safety verification

- `node --check navi_bench/opentable/opentable_info_gathering.js` passes.
- Wrote a standalone node harness (not committed, per this repo's convention of describing manual JS parity checks in the commit message rather than adding new JS test infra) that runs the exact old inline logic and the new extracted helpers against 5 fixtures — no visible elements, multiple visible elements per selector (verifying last-visible-wins `forEach` semantics are preserved), missing time, and a re-parse that yields zero times (verifying `baseDate`/`baseTime` fall back to the raw scraped text). All 5 produced byte-for-byte identical `{partySize, baseDate, baseTime}` output for both versions.
- Python suite: `python3 -m pytest tests/ -q` → **231 passed** both before and after (14 test files that require the private `yutori`/`playwright`/`datasets` packages unavailable in this sandbox are excluded from collection, matching prior PRs' documented sandbox limitations). `tests/test_opentable_info_gathering.py` specifically: **60 passed**, unchanged.
- `ruff check .` → all checks passed.

No behavior change; single file touched (`navi_bench/opentable/opentable_info_gathering.js`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xkNy5YQgS7qjxCT6nMbK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication in a bench DOM-scraping script; PR description reports parity checks and unchanged pytest coverage.
> 
> **Overview**
> **Refactors** repeated OpenTable picker-overlay scraping in `opentable_info_gathering.js` into shared helpers, with no intended behavior change.
> 
> Adds **`extractPartySizeDateTime(root, selectors)`** to read visible party size, date, and time from overlay elements, plus **`PICKER_OVERLAY_SELECTORS`** for the shared `data-testid` selectors. Adds **`normalizeBaseDateTime`** to re-parse scraped date/time through `parseDateAndTimes`.
> 
> **`handleSearchPage`**, **`handleBookingRestrefPage`**, and **`handleRestaurantPage`**’s dropdown branch now call those helpers instead of ~26 lines of duplicated `querySelectorAll` / visibility / normalize logic (root is `document` or scoped `reservationPanel`). **`handleRestrefPage`** adopts **`normalizeBaseDateTime`** for the same post-scrape normalization step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f93145680e64f758753d4bd8ee0f1fe7d682d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->