### PR TITLE
refactor(opentable): use extractPartySizeDateTime in handleBookingPage

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -433,29 +433,17 @@
         handleNextAvailablePopup(partySize, baseDate, baseTime);
     };
 
+    // The booking-page picker selectors used by handleBookingPage below (see
+    // extractPartySizeDateTime above for the shared scrape logic these drive).
+    const BOOKING_PAGE_SELECTORS = {
+        partySize: '[data-test="icPerson-wrapper"]',
+        date: '[data-test="icCalendar-wrapper"]',
+        time: '[data-test="icClock-wrapper"]',
+    };
+
     const handleBookingPage = () => {
         const restaurantName = document.querySelector('[data-test="restaurantName"]')?.textContent;
-
-        let partySize = null;
-        document.querySelectorAll('[data-test="icPerson-wrapper"]').forEach((el) => {
-            if (isVisible(el)) {
-                partySize = parsePartySize(el.textContent);
-            }
-        });
-
-        let baseDate = null;
-        document.querySelectorAll('[data-test="icCalendar-wrapper"]').forEach((el) => {
-            if (isVisible(el)) {
-                baseDate = el.textContent;
-            }
-        });
-
-        let baseTime = null;
-        document.querySelectorAll('[data-test="icClock-wrapper"]').forEach((el) => {
-            if (isVisible(el)) {
-                baseTime = el.textContent;
-            }
-        });
+        const { partySize, baseDate, baseTime } = extractPartySizeDateTime(document, BOOKING_PAGE_SELECTORS);
 
         if (baseDate && baseTime) {
             const dateAndTimes = parseDateAndTimes(baseDate + " " + baseTime);


### PR DESCRIPTION
## What

`handleBookingPage()` in `navi_bench/opentable/opentable_info_gathering.js` hand-rolled the same "querySelectorAll -> find the visible element -> read its `textContent`" triple (once each for party size, date, time) that PR #184 already extracted into `extractPartySizeDateTime(root, selectors)` for `handleSearchPage`, `handleBookingRestrefPage`, and `handleRestaurantPage`'s dropdown branch. This fourth call site was missed in #184 because its selectors (`icPerson-wrapper`/`icCalendar-wrapper`/`icClock-wrapper`) aren't part of the shared `PICKER_OVERLAY_SELECTORS` object used by the other three.

Added a dedicated `BOOKING_PAGE_SELECTORS` constant (mirroring the existing `PICKER_OVERLAY_SELECTORS` pattern) and delegated `handleBookingPage` to `extractPartySizeDateTime`, removing the duplicated 18-line triple.

## Why this is safe

Pure structural extraction, one file touched, no logic changes:
- `extractPartySizeDateTime` performs exactly the same `querySelectorAll(selector).forEach(el => if (isVisible(el)) { assign })` sequence per field that `handleBookingPage` inlined — confirmed line-by-line before extracting.
- `node --check` passes on the modified file.
- Wrote a Node DOM-stub smoke test (`document`/`window` stand-ins with `getBoundingClientRect`-based visibility) exercising `handleBookingPage`'s URL branch across 5 scenarios: normal case, invisible party-size element, invisible date element (short-circuits to no result), missing date/time elements entirely, and multi-slot time text. Captured output via `git stash` before the change and compared to the same run after — **byte-identical JSON in all 5 scenarios**.
- Full `pytest tests/` suite passes unchanged: 247/247 (excluding `test_recorder.py`/`test_vis.py`, which require the private `yutori` package per this repo's established test-running convention).
- `ruff check .` clean. `ruff format --check .` shows the same 2 pre-existing unrelated files (`evaluation/eval_n1.py`, `navi_bench/dates.py`) needing reformatting both before and after this change (verified via `git stash`) — not touched by this PR.

## Diff summary

```
navi_bench/opentable/opentable_info_gathering.js | 30 +++++++-----------------
1 file changed, 9 insertions(+), 21 deletions(-)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_019ZFUh99vgk3ye1edSX4hZk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file structural refactor with equivalent scrape logic; no auth, data, or booking-flow changes.
> 
> **Overview**
> **`handleBookingPage`** now reads party size, date, and time through the shared **`extractPartySizeDateTime`** helper instead of three inline `querySelectorAll` / visibility loops.
> 
> A new **`BOOKING_PAGE_SELECTORS`** map holds the booking-page DOM hooks (`icPerson-wrapper`, `icCalendar-wrapper`, `icClock-wrapper`), matching the **`PICKER_OVERLAY_SELECTORS`** pattern used on other OpenTable page handlers. Slot parsing and **`pushSlotResult`** behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39edcfcf0af68de8fcf97797d2fa959044076de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->