### PR TITLE
refactor(opentable): extract pushAvailabilities() JS helper

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -18,6 +18,17 @@
         results.push({ url, restaurantName, partySize, startDate, startTime, endDate, endTime, info });
     };
 
+    // Push a `pushSlotResult` call for every entry in an `availabilities` array (as returned by
+    // extractSlotAvailabilities/parseTimesAndAvailabilities). Extracted because handleSearchPage,
+    // handleRestrefPage, and handleBookingRestrefPage each repeated this identical
+    // `for (const a of availabilities) { pushSlotResult(...) }` loop verbatim after computing
+    // `availabilities`, differing only in the `restaurantName`/`partySize` closed-over values.
+    const pushAvailabilities = (availabilities, restaurantName, partySize) => {
+        for (const a of availabilities) {
+            pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
+        }
+    };
+
     const isRecorded = (el) => {
         return el.getAttribute("__recorded") === "true";
     };
@@ -399,9 +410,7 @@
                     pushSlotResult(restaurantName, partySize, baseDate, baseTime, timeSlots);
                 } else {
                     const availabilities = extractSlotAvailabilities(el, 'li', baseDate);
-                    for (const a of availabilities) {
-                        pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
-                    }
+                    pushAvailabilities(availabilities, restaurantName, partySize);
                 }
             }
         });
@@ -419,9 +428,7 @@
                     setIsRecorded(el);
                 } else {
                     const availabilities = extractSlotAvailabilities(el, 'li', baseDate);
-                    for (const a of availabilities) {
-                        pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
-                    }
+                    pushAvailabilities(availabilities, restaurantName, partySize);
                     if (availabilities.length > 0) {
                         setIsRecorded(el);
                     }
@@ -497,10 +504,7 @@
         document.querySelectorAll('.styled__AvailabilityDayWrapper-sc-1xhoeow-5').forEach((el) => {
             if (isVisible(el)) {
                 const availabilities = extractSlotAvailabilities(el, 'li', baseDate, false);
-
-                for (const a of availabilities) {
-                    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
-                }
+                pushAvailabilities(availabilities, restaurantName, partySize);
             }
         });
 
@@ -510,10 +514,7 @@
                 const dateText = el.querySelector('p')?.textContent;
                 const { date, _ } = parseDateAndTimes(dateText);
                 const availabilities = extractSlotAvailabilities(el, 'li', date, false);
-
-                for (const a of availabilities) {
-                    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
-                }
+                pushAvailabilities(availabilities, restaurantName, partySize);
             }
         });
     };
@@ -542,10 +543,7 @@
         document.querySelectorAll('[data-test="searched-day-slots"]').forEach((el) => {
             if (isVisible(el)) {
                 const availabilities = extractSlotAvailabilities(el, '[data-test="slot"]', baseDate);
-
-                for (const a of availabilities) {
-                    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
-                }
+                pushAvailabilities(availabilities, restaurantName, partySize);
             }
         });
 
@@ -555,10 +553,7 @@
                 const dateText = el.querySelector('p')?.textContent;
                 const { date, _ } = parseDateAndTimes(dateText);
                 const availabilities = extractSlotAvailabilities(el, '[data-test="slot"]', date);
-
-                for (const a of availabilities) {
-                    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
-                }
+                pushAvailabilities(availabilities, restaurantName, partySize);
             }
         });
     };


### PR DESCRIPTION
## Issue

`navi_bench/opentable/opentable_info_gathering.js`'s `handleSearchPage`, `handleRestrefPage`, and `handleBookingRestrefPage` each repeated the identical block immediately after computing `availabilities` via `extractSlotAvailabilities`:

```js
for (const a of availabilities) {
    pushSlotResult(restaurantName, partySize, a.date, a.time, a.availability);
}
```

This exact 3-line block appeared byte-for-byte identically at 6 call sites across the file.

## Improvement

Extracted a shared `pushAvailabilities(availabilities, restaurantName, partySize)` helper (placed next to the existing `pushSlotResult`/`pushRangeResult` family it wraps); all 6 sites now delegate to it. No other logic touched — the surrounding `extractSlotAvailabilities` calls, `availabilities.length` checks, and branch structure are untouched.

## Safety

- `node --check` passes.
- No behavior change: built a minimal fake-DOM Node harness driving `handleSearchPage` and `handleBookingRestrefPage` through multi-slot branches (exercising 4 of the 6 modified call sites, including the "searched day slots"/"future availability" paths), and diffed output before (`git stash`) vs. after — byte-identical.
- Full local `pytest` suite passes unchanged: 247/247 (excluding `test_vis.py`/`test_recorder.py`, which require the private `yutori` package not installed in this sandbox — consistent with this repo's established baseline per prior PRs, e.g. #174).
- `ruff check` clean (this is a JS-only change; the two pre-existing `ruff format` diffs in `eval_n1.py`/`dates.py` are unrelated to this PR and untouched).
- Single file, mechanical extraction, matches this repo's established "duplicated block → shared helper" convention already used repeatedly in this same file (`isVisible`, `extractSlotAvailabilities`, `extractPartySizeDateTime`, `normalizeBaseDateTime`, `pushSlotResult`/`pushRangeResult`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0171qwkUZXWhrWvyN37gcUVa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in bench scraping JS only; logic is unchanged and matches existing helper-extraction patterns in the same file.
> 
> **Overview**
> Adds **`pushAvailabilities(availabilities, restaurantName, partySize)`** next to the existing `pushSlotResult` / `pushRangeResult` helpers in `opentable_info_gathering.js`, encapsulating the repeated loop that pushes each scraped slot into `results`.
> 
> **Six call sites** in `handleSearchPage`, `handleRestrefPage`, and `handleBookingRestrefPage` now call the helper after `extractSlotAvailabilities` instead of inlining the same `for (const a of availabilities)` block. Surrounding branches, selectors, and `setIsRecorded` / length checks are unchanged; `handleNextAvailablePopup` still uses its own loop because it updates prev/next available while pushing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b03027033ca4a847046f500902a17ffd8f166a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->