### PR TITLE
refactor(vis): dedupe modal-close Escape-key handler onto closeModal()

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -1549,7 +1549,10 @@ def generate_visualization_html(
         }}
 
         function closeModal(event) {{
-            if (event.target.closest('.modal-content') || event.target.closest('.modal-nav')) return;
+            // `event` is optional (falsy when called from the Escape-key handler below,
+            // which has no click target to check against) -- mirrors closeAnswerModal's
+            // `event &&` guard so both close functions are safe to call with no arguments.
+            if (event && (event.target.closest('.modal-content') || event.target.closest('.modal-nav'))) return;
             document.getElementById('modal').classList.remove('active');
             setBodyScrollLocked(false);
         }}
@@ -1638,8 +1641,7 @@ def generate_visualization_html(
 
             if (isModalOpen) {{
                 if (e.key === 'Escape') {{
-                    modal.classList.remove('active');
-                    setBodyScrollLocked(false);
+                    closeModal();
                 }} else if (e.key === 'ArrowLeft') {{
                     prevModalStep(e);
                 }} else if (e.key === 'ArrowRight') {{

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -673,7 +673,11 @@ class TestModalScrollLockDeduplication:
 
     def test_close_handlers_call_helper_with_false(self):
         html = self._html()
-        assert html.count("setBodyScrollLocked(false);") == 3
+        # Only closeModal's and closeAnswerModal's own function bodies call the helper
+        # directly with `false`; the modal-open Escape-key handler now delegates to
+        # closeModal() instead of repeating this call inline (see
+        # TestModalEscapeKeyDelegatesToCloseModal below).
+        assert html.count("setBodyScrollLocked(false);") == 2
 
     def test_no_inline_overflow_assignment_remains_outside_helper(self):
         html = self._html()
@@ -683,3 +687,40 @@ class TestModalScrollLockDeduplication:
         assert html.count("document.body.style.overflow = locked ?") == 1
         assert "document.body.style.overflow = 'hidden';" not in html
         assert "document.body.style.overflow = '';" not in html
+
+
+class TestModalEscapeKeyDelegatesToCloseModal:
+    """Pins that the modal-open Escape-key handler closes the lightbox by calling the
+    existing ``closeModal()`` function (with no arguments) instead of repeating
+    ``closeModal``'s ``modal.classList.remove('active'); setBodyScrollLocked(false);`` body
+    inline, mirroring how the answer-modal's Escape branch already calls
+    ``closeAnswerModal()`` with no arguments.
+
+    This requires ``closeModal`` to guard its ``event.target.closest(...)`` check behind an
+    ``event &&`` truthiness check (like ``closeAnswerModal`` already does), since the
+    Escape-key handler has no click event/target to check against.
+    """
+
+    @staticmethod
+    def _html() -> str:
+        messages = [{"role": "user", "content": [{"type": "text", "text": "do the task"}]}]
+        return generate_visualization_html("task1", messages, None)
+
+    def test_close_modal_guards_event_with_truthiness_check(self):
+        html = self._html()
+        match = re.search(r"function closeModal\(event\) \{\s*(?://[^\n]*\n\s*)*if \(([^)]*)\)", html)
+        assert match is not None, html
+        assert match.group(1).strip().startswith("event &&")
+
+    def test_escape_handler_calls_close_modal_with_no_arguments(self):
+        html = self._html()
+        match = re.search(r"if \(isModalOpen\) \{\s*if \(e\.key === 'Escape'\) \{\s*([^\n]*)\n", html)
+        assert match is not None, html
+        assert match.group(1).strip() == "closeModal();"
+
+    def test_escape_handler_no_longer_repeats_close_modal_body_inline(self):
+        html = self._html()
+        # The literal "getElementById('modal').classList.remove('active');" line
+        # (closeModal's own body) must appear only inside closeModal's function body, not
+        # duplicated again in the Escape-key handler.
+        assert html.count("getElementById('modal').classList.remove('active');") == 1


### PR DESCRIPTION
## What

`evaluation/vis.py`'s generated visualization HTML has a `document.addEventListener('keydown', ...)` handler that closes the step-detail lightbox modal on `Escape`. Instead of calling the existing `closeModal()` function, it repeated `closeModal()`'s own body inline:

```js
if (isModalOpen) {
    if (e.key === 'Escape') {
        modal.classList.remove('active');
        setBodyScrollLocked(false);
    } else if (e.key === 'ArrowLeft') {
```

The reason it couldn't just call `closeModal()` is that `closeModal(event)` unconditionally dereferenced `event.target`:

```js
function closeModal(event) {
    if (event.target.closest('.modal-content') || event.target.closest('.modal-nav')) return;
    ...
}
```

which throws if called with no `event`, as the Escape-key handler would need to do. The sibling "answer modal" already solved this: `closeAnswerModal(event)` guards the same check behind `event && ...`, so its own Escape branch just calls `closeAnswerModal()` with no arguments.

This PR gives `closeModal()` the same `event &&` truthiness guard, and updates the Escape-key handler to call `closeModal()` directly, removing the duplicated body.

## Why this is an improvement

Same "consolidate duplicated logic" pattern as the last ~20 refactor PRs in this repo (e.g. #187's `setBodyScrollLocked()` extraction, which this builds directly on top of). One less copy of "close the modal + unlock scroll" to keep in sync if that logic ever changes again, and it makes `closeModal`/`closeAnswerModal` symmetric (both are now safely callable with or without a click event).

## Why it's safe

No behavior change:
- Both real `onclick="closeModal(event)"` call sites (the modal overlay and the `×` close button) still pass a genuine event, so the new `event &&` check is a no-op for them — the `event.target.closest(...)` check still runs exactly as before.
- The only new call site (`closeModal()` with no arguments, from the Escape-key handler) now takes the same "always close" path the inline duplicate previously took explicitly.

Verified by:
- Three new characterization tests in `tests/test_vis.py` (`TestModalEscapeKeyDelegatesToCloseModal`) pinning the `event &&` guard, the `closeModal();` call site, and that the duplicated close-modal body no longer appears twice.
- Updated an existing test (`test_close_handlers_call_helper_with_false`) whose literal occurrence count of `setBodyScrollLocked(false);` naturally dropped from 3 to 2 now that the Escape branch calls through `closeModal()` instead of inlining the call.
- Full local suite: 328/328 passing.
- `ruff check` / `ruff format --check`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NDmqGABNX2g1vzu5boMnQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of generated viz HTML keyboard/close paths with characterization tests; click-to-close behavior unchanged when `event` is passed.
> 
> **Overview**
> **Screenshot lightbox Escape handling** now calls `closeModal()` instead of inlining remove-active + `setBodyScrollLocked(false)`, matching the answer modal’s `closeAnswerModal()` pattern.
> 
> `closeModal(event)` guards the click-target check with **`event &&`**, so it’s safe when Escape invokes it with no event (same idea as `closeAnswerModal`).
> 
> Tests add **`TestModalEscapeKeyDelegatesToCloseModal`** (guard, `closeModal();` on Escape, no duplicated close body) and adjust the expected count of direct `setBodyScrollLocked(false)` call sites from 3 to 2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2adeb8c397de63e00c51b520878233654d45a13e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->