### PR TITLE
fix(opentable): dedupe deltaMinutes inference, fix missing :45: check

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -172,6 +172,19 @@
         return `${nextHours.toString().padStart(2, "0")}:${nextMinutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
     };
 
+    // Infer whether a list of already-parsed "HH:mm:ss" time strings falls on a 15- or
+    // 30-minute grid, by checking for a quarter-hour (":15:" or ":45:") minute component.
+    // Extracted because handleRestaurantPageWithFullAvailabilityPopup and handleRestaurantPage
+    // each repeated this inference, but handleRestaurantPageWithFullAvailabilityPopup's copy
+    // only checked ":15:" and silently missed ":45:" -- so a restaurant whose only quarter-hour
+    // available slots landed on the ":45" minute (no ":15" slot present) was misclassified as
+    // 30-minute granularity there, corrupting the getNextTime()-driven unavailable-slot fill.
+    // Not reused by parseTimesAndAvailabilities's own delta-minutes inference above, which
+    // operates on raw, not-yet-parsed display text (e.g. "8:15 PM") rather than "HH:mm:ss".
+    const inferDeltaMinutes = (times) => {
+        return times.some(t => t.includes(":15:") || t.includes(":45:")) ? 15 : 30;
+    };
+
     const parseTimesAndAvailabilities = (date, timesArray) => {
         // input `date` is in YYYY-MM-DD format
         // input `timesArray` is an array of strings like ["", "", "8:30 PM", "9:00 PM", ""]
@@ -629,7 +642,7 @@
             //      c) L < a and b == R: then all the info after a is accessible by the agent
             //      d) L < a and b < R: then the info between a and b is accessible by the agent
 
-            const deltaMinutes = timesAndVisibilities.some(t => t.time.includes(":15:")) ? 15 : 30;
+            const deltaMinutes = inferDeltaMinutes(timesAndVisibilities.map(t => t.time));
 
             const L = timesAndVisibilities[0].time;
             const R = timesAndVisibilities[timesAndVisibilities.length - 1].time;
@@ -718,8 +731,7 @@
 
             if (availableTimes.length > 0) {
                 // infer the delta minutes between times
-                const isQuarterHour = availableTimes.some(time => time.includes(":15:") || time.includes(":45:"));
-                const deltaMinutes = isQuarterHour ? 15 : 30;
+                const deltaMinutes = inferDeltaMinutes(availableTimes);
                 const deltaMilliseconds = deltaMinutes * 60 * 1000;
 
                 // convert the available times from string to timestamps


### PR DESCRIPTION
`handleRestaurantPageWithFullAvailabilityPopup` and `handleRestaurantPage` each independently inferred whether a restaurant's available times fall on a 15- or 30-minute grid by checking for a quarter-hour minute component, but `handleRestaurantPageWithFullAvailabilityPopup`'s copy only checked `":15:"` and silently missed `":45:"` — so a restaurant whose only quarter-hour slots landed on `":45"` (no `":15"` slot present) was misclassified as 30-minute granularity there, corrupting the `getNextTime()`-driven unavailable-slot fill for that page path. `handleRestaurantPage`'s copy already checked both.

Extracted a shared `inferDeltaMinutes(times)` helper (checking both `":15:"` and `":45:"`) that both call sites now delegate to, fixing the first site's bug in the process. Left `parseTimesAndAvailabilities`'s similarly-shaped inference alone since it operates on raw, not-yet-parsed display text (e.g. `"8:15 PM"`) rather than `"HH:mm:ss"`, so it isn't the same duplication.

**Verification**: `node --check` plus a node harness comparing the old inline logic against the new helper across representative fixtures (half-hour-only, contains `:15`, contains only `:45` with no `:15`, empty, single time) — the already-correct `handleRestaurantPage` call site sees no behavior change, while the buggy call site now correctly infers 15-minute granularity in the ":45 only" case. Full pytest suite (247 passed) and `ruff check` are unaffected by this JS-only change.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01GkUGw7Vrs8ds5EBwsLwx6J)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JS-only change in OpenTable bench scraping logic; behavior fix is localized to availability granularity inference with no security or data-pipeline impact.
> 
> **Overview**
> Fixes incorrect **unavailable-slot** inference on the full-availability popup path when a restaurant only exposes quarter-hour times on **:45** (no **:15** slot).
> 
> Adds shared **`inferDeltaMinutes`** for parsed `HH:mm:ss` times, checking both **`:15:`** and **`:45:`**, and wires **`handleRestaurantPageWithFullAvailabilityPopup`** and **`handleRestaurantPage`** to use it. The popup handler previously only looked for **`:15:`**, so it treated those grids as 30-minute and skewed **`getNextTime()`**-based fill. **`parseTimesAndAvailabilities`** keeps its own logic on raw display strings (e.g. `"8:15 PM"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e7800ba3615c6cbc0463661b01fba5070a8868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->