### PR TITLE
refactor(resy): dedupe visible-unavailability-message scan in resy_no_availability_check.js

### DIFF
--- a/navi_bench/resy/resy_no_availability_check.js
+++ b/navi_bench/resy/resy_no_availability_check.js
@@ -8,30 +8,21 @@
      * this IIFE.
      */
 
-    // Look for the "no online availability" message
-    const availabilityMessages = document.querySelectorAll('.ShiftInventory__availability-message');
-    
-    for (const message of availabilityMessages) {
-        if (isVisible(message)) {
-            const text = message.textContent.trim().toLowerCase();
-            
-            // Check if this is a "no availability" message
-            if (text.includes('no online availability')) {
+    // Returns true if any element matching `selector` is visible and its text contains
+    // the "no online availability" message.
+    const hasVisibleNoAvailabilityMessage = (selector) => {
+        for (const elem of document.querySelectorAll(selector)) {
+            if (isVisible(elem) && elem.textContent.trim().toLowerCase().includes('no online availability')) {
                 return true;
             }
         }
-    }
+        return false;
+    };
 
-    // Also check for other possible unavailability indicators
-    const unavailableElements = document.querySelectorAll('[id*="unavailable"]');
-    for (const elem of unavailableElements) {
-        if (isVisible(elem)) {
-            const text = elem.textContent.trim().toLowerCase();
-            if (text.includes('no online availability')) {
-                return true;
-            }
-        }
-    }
-
-    return false;
+    // Look for the "no online availability" message, then fall back to other possible
+    // unavailability indicators.
+    return (
+        hasVisibleNoAvailabilityMessage('.ShiftInventory__availability-message') ||
+        hasVisibleNoAvailabilityMessage('[id*="unavailable"]')
+    );
 })();


### PR DESCRIPTION
## Issue

`navi_bench/resy/resy_no_availability_check.js` checked for a "no online availability" message using two separate loops:

1. Query `.ShiftInventory__availability-message` elements, and for each visible one, check whether its text includes `"no online availability"`.
2. Query `[id*="unavailable"]` elements (a fallback selector), and repeat the exact same visibility + text-match logic.

The loop bodies were byte-for-byte identical apart from the selector — the same "duplicated block, parameterize the one thing that differs" pattern this repo has extracted repeatedly elsewhere (e.g. `isVisible()` dedup in #167, `patchTargetProperty()` in #180).

## Fix

Extracted a `hasVisibleNoAvailabilityMessage(selector)` closure inside the IIFE; both checks now delegate to it with only the selector argument differing. No behavior change — the function returns `true` under exactly the same conditions the two original loops did, and `false` otherwise.

## Why it's safe

- Single file changed, 13 insertions / 22 deletions.
- No Python file touched, so the local suite is unaffected: **245/245 tests still passing** before and after (this repo has no existing test harness for the sidecar JS files — the same true for the prior `isVisible()`/`patchTargetProperty()` JS refactors).
- Verified with `node --check` (syntax) plus a DOM-stub smoke test (not committed, ad hoc) exercising 7 scenarios — no elements at all, visible/invisible match on each of the two selectors, non-matching text, fallback-selector-only match, and multiple elements where only one matches — confirming the old and new logic produce byte-identical results in every case.
- `ruff check .` clean (untouched files' pre-existing format-only diffs in `evaluation/eval_n1.py`/`navi_bench/dates.py` are unrelated to this change).

Follows this repo's established JS-refactor verification convention from #167/#180.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FSZWkFv3FtwWbcbestWYBq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file JS refactor with identical logic; no Python or test harness changes.
> 
> **Overview**
> Refactors the Resy “no online availability” sidecar script by pulling the repeated visibility + text-match loop into **`hasVisibleNoAvailabilityMessage(selector)`**, then calling it for `.ShiftInventory__availability-message` and the `[id*="unavailable"]` fallback.
> 
> **Behavior is unchanged**: the IIFE still returns `true` when any visible match includes `"no online availability"` on either selector, otherwise `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b75a402baec70024281df0c85070296cdb8e269c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->