### PR TITLE
refactor(eval_n1): consolidate three fatal-vs-retryable API-error ladders into one predicate

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -71,6 +71,25 @@ from yutori.navigator import denormalize_coordinates, estimate_messages_size_byt
 
 RETRYABLE_API_ERRORS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
+
+def _is_fatal_api_error(exc: BaseException) -> bool:
+    """Whether ``exc`` must propagate instead of being retried/recorded as a task failure.
+
+    Fatal means "the request itself is bad, so retrying it cannot help": authentication
+    failures and every other non-retryable ``APIStatusError`` subclass (``BadRequestError``,
+    ``NotFoundError``, ...). Everything else -- transport errors, rate limits, upstream 5xx,
+    and non-OpenAI exceptions -- is treated as non-fatal by every caller.
+
+    ``RETRYABLE_API_ERRORS`` must be tested *first*: ``RateLimitError`` and
+    ``InternalServerError`` are themselves ``APIStatusError`` subclasses, so checking
+    ``APIStatusError`` up front would misclassify them as fatal. This ordering hazard is
+    exactly why the equivalent inline ``except`` ladders were previously easy to get wrong.
+    """
+    if isinstance(exc, RETRYABLE_API_ERRORS):
+        return False
+    return isinstance(exc, (OpenAIAuthError, APIStatusError))
+
+
 # Per-action overrides forwarded to ``page.mouse.click`` for the click family.
 # Membership in this dict is also how ``_execute`` decides a tool call is a click.
 _CLICK_KWARGS: dict[str, dict[str, object]] = {
@@ -356,14 +375,9 @@ Today is: {dt.strftime("%A")}"""
 
                 return response.choices[0].message
 
-            except OpenAIAuthError:
-                raise
-            except RETRYABLE_API_ERRORS:
-                await _sleep_or_reraise(attempt, content)
-            except APIStatusError:
-                # Non-retryable APIStatusError subclasses (e.g. BadRequestError) should propagate.
-                raise
-            except Exception:
+            except Exception as e:
+                if _is_fatal_api_error(e):
+                    raise
                 await _sleep_or_reraise(attempt, content)
 
     while step_idx < config.eval_max_steps:
@@ -406,13 +420,9 @@ Today is: {dt.strftime("%A")}"""
         try:
             message = await _predict(messages)
             logger.info(f"[{step_idx}] {message}")
-        except OpenAIAuthError:
-            raise
-        except RETRYABLE_API_ERRORS as e:
-            return await _fail(f"Failed to get valid response: {e}", e, do_evaluator_update=True)
-        except APIStatusError:
-            raise
         except Exception as e:
+            if _is_fatal_api_error(e):
+                raise
             return await _fail(f"Failed to get valid response: {e}", e, do_evaluator_update=True)
 
         messages.append(message.model_dump(exclude_none=True))
@@ -482,16 +492,9 @@ async def run_task(
                 evaluator = instantiate(task_config.eval_config)
                 async with build_browser(config, task_config, playwright) as (_, _, page):
                     return await run_agent(config, task_config, page, evaluator, recorder, client)
-            except OpenAIAuthError:
-                raise
-            except APIStatusError as e:
-                if isinstance(e, (RateLimitError, InternalServerError)):
-                    failure = _handle_task_failure(e, attempt, config.eval_max_attempts)
-                    if failure is not None:
-                        return failure
-                    continue
-                raise
             except Exception as e:
+                if _is_fatal_api_error(e):
+                    raise
                 failure = _handle_task_failure(e, attempt, config.eval_max_attempts)
                 if failure is not None:
                     return failure

--- a/tests/test_eval_n1.py
+++ b/tests/test_eval_n1.py
@@ -1,0 +1,185 @@
+"""Characterization tests for ``evaluation.eval_n1``'s fatal-vs-retryable API-error rule.
+
+``eval_n1.py`` had three hand-rolled ``except`` ladders implementing one shared rule -- "an
+``APIStatusError`` that is not in ``RETRYABLE_API_ERRORS`` must propagate; everything else is
+non-fatal" -- spelled three different ways, one of which (``run_task``) used the narrower
+literal tuple ``(RateLimitError, InternalServerError)`` instead of ``RETRYABLE_API_ERRORS``.
+The ladders were order-dependent in a non-obvious way (``RateLimitError`` and
+``InternalServerError`` are themselves ``APIStatusError`` subclasses, so an ``except
+APIStatusError: raise`` clause placed before the retryable clause would silently turn every
+rate limit into a hard failure), which is why an earlier audit flagged them as unsafe to
+merge mechanically.
+
+These tests pin the rule itself, pin that the legacy ``run_task`` spelling agrees with it
+across the full OpenAI exception vocabulary, and exercise ``run_task``'s real retry loop --
+which had zero prior test coverage -- for both the propagate and retry-then-crash outcomes.
+"""
+
+import asyncio
+
+import httpx
+import pytest
+from openai import (
+    APIConnectionError,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    BadRequestError,
+    ConflictError,
+    InternalServerError,
+    NotFoundError,
+    OpenAIError,
+    PermissionDeniedError,
+    RateLimitError,
+    UnprocessableEntityError,
+)
+
+from evaluation.eval_n1 import RETRYABLE_API_ERRORS, Config, TimingStats, TokenUsage, _is_fatal_api_error, run_task
+from evaluation.stats import Crashed
+
+
+_REQUEST = httpx.Request("POST", "https://api.example.invalid/v1/chat/completions")
+
+
+def _status_error(cls, status_code: int):
+    return cls(cls.__name__, response=httpx.Response(status_code, request=_REQUEST), body=None)
+
+
+# Non-retryable ``APIStatusError`` subclasses: retrying an identically-bad request cannot help.
+FATAL_EXCEPTIONS = [
+    _status_error(AuthenticationError, 401),
+    _status_error(PermissionDeniedError, 403),
+    _status_error(BadRequestError, 400),
+    _status_error(NotFoundError, 404),
+    _status_error(ConflictError, 409),
+    _status_error(UnprocessableEntityError, 422),
+    _status_error(APIStatusError, 418),
+]
+
+# Transport failures, rate limits, upstream 5xx, and anything that is not an OpenAI status error.
+NON_FATAL_EXCEPTIONS = [
+    _status_error(RateLimitError, 429),
+    _status_error(InternalServerError, 500),
+    APIConnectionError(request=_REQUEST),
+    APITimeoutError(request=_REQUEST),
+    APIError("api error", _REQUEST, body=None),
+    OpenAIError("generic openai error"),
+    ValueError("plain value error"),
+    RuntimeError("plain runtime error"),
+    asyncio.TimeoutError(),
+    Exception("bare exception"),
+]
+
+
+def _legacy_run_task_ladder(exc: BaseException) -> str:
+    """The pre-refactor ``run_task`` ``except`` ladder, transcribed verbatim.
+
+    Note it tested the narrower literal ``(RateLimitError, InternalServerError)`` rather than
+    ``RETRYABLE_API_ERRORS``; ``APIConnectionError``/``APITimeoutError`` reached the same
+    "handle" outcome via the trailing ``except Exception`` clause instead.
+    """
+    try:
+        raise exc
+    except AuthenticationError:
+        return "raise"
+    except APIStatusError as e:
+        if isinstance(e, (RateLimitError, InternalServerError)):
+            return "handle"
+        return "raise"
+    except Exception:
+        return "handle"
+
+
+def _new_ladder(exc: BaseException) -> str:
+    try:
+        raise exc
+    except Exception as e:
+        return "raise" if _is_fatal_api_error(e) else "handle"
+
+
+class TestIsFatalApiError:
+    @pytest.mark.parametrize("exc", FATAL_EXCEPTIONS, ids=lambda e: type(e).__name__)
+    def test_non_retryable_status_errors_are_fatal(self, exc):
+        assert _is_fatal_api_error(exc) is True
+
+    @pytest.mark.parametrize("exc", NON_FATAL_EXCEPTIONS, ids=lambda e: type(e).__name__)
+    def test_retryable_and_non_status_errors_are_not_fatal(self, exc):
+        assert _is_fatal_api_error(exc) is False
+
+    def test_every_retryable_api_error_class_is_non_fatal(self):
+        """Pins the ordering hazard: ``RateLimitError``/``InternalServerError`` are
+        ``APIStatusError`` subclasses, so a naive ``isinstance(exc, APIStatusError)`` check
+        placed before the retryable check would misclassify them as fatal."""
+        for cls in RETRYABLE_API_ERRORS:
+            exc = cls.__new__(cls)
+            assert issubclass(cls, Exception)
+            assert _is_fatal_api_error(exc) is False, f"{cls.__name__} must stay retryable"
+
+    def test_two_retryable_classes_are_status_error_subclasses(self):
+        """Guards the premise of the test above -- if OpenAI ever restructured its hierarchy
+        so none of the retryable errors were status errors, the ordering note would be stale."""
+        assert issubclass(RateLimitError, APIStatusError)
+        assert issubclass(InternalServerError, APIStatusError)
+        assert not issubclass(APIConnectionError, APIStatusError)
+
+    @pytest.mark.parametrize("exc", FATAL_EXCEPTIONS + NON_FATAL_EXCEPTIONS, ids=lambda e: type(e).__name__)
+    def test_agrees_with_legacy_run_task_ladder(self, exc):
+        assert _new_ladder(exc) == _legacy_run_task_ladder(exc)
+
+
+class _RaisingItem:
+    """Minimal ``DatasetItem`` stand-in whose ``generate_task_config`` always raises.
+
+    ``run_task`` touches nothing else on the item before that call, so this exercises its
+    exception ladder without a browser, recorder, or API client.
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+        self.calls = 0
+
+    def generate_task_config(self):
+        self.calls += 1
+        raise self._exc
+
+
+def _run_task(item: _RaisingItem, max_attempts: int = 3):
+    config = Config(eval_max_attempts=max_attempts)
+    return asyncio.run(run_task(config, item, None, None, None))
+
+
+class TestRunTaskErrorHandling:
+    @pytest.mark.parametrize("exc", FATAL_EXCEPTIONS, ids=lambda e: type(e).__name__)
+    def test_propagates_fatal_error_without_retrying(self, exc):
+        item = _RaisingItem(exc)
+        with pytest.raises(type(exc)):
+            _run_task(item)
+        assert item.calls == 1
+
+    @pytest.mark.parametrize("exc", NON_FATAL_EXCEPTIONS, ids=lambda e: type(e).__name__)
+    def test_retries_non_fatal_error_then_returns_crashed(self, exc):
+        item = _RaisingItem(exc)
+        result, usage, timing = _run_task(item)
+
+        assert item.calls == 3
+        assert isinstance(result, Crashed)
+        assert result.score == 0.0
+        assert result.exception == str(exc)
+        assert type(exc).__name__ in result.traceback
+        assert usage == TokenUsage()
+        assert timing == TimingStats()
+
+    def test_rate_limit_is_retried_not_propagated(self):
+        """The specific regression the predicate's check order protects: ``RateLimitError``
+        is an ``APIStatusError`` subclass but must be retried, not re-raised."""
+        item = _RaisingItem(_status_error(RateLimitError, 429))
+        result, _, _ = _run_task(item)
+        assert item.calls == 3
+        assert isinstance(result, Crashed)
+
+    def test_attempt_count_follows_config(self):
+        item = _RaisingItem(ValueError("boom"))
+        result, _, _ = _run_task(item, max_attempts=1)
+        assert item.calls == 1
+        assert isinstance(result, Crashed)


### PR DESCRIPTION
## Issue

`evaluation/eval_n1.py` implemented **one** classification rule in **three** hand-rolled `except` ladders, spelled three different ways:

> An `APIStatusError` that is not in `RETRYABLE_API_ERRORS` must propagate; everything else (transport errors, rate limits, upstream 5xx, non-OpenAI exceptions) is non-fatal.

| Site | Old spelling |
|---|---|
| `_predict` (retry loop) | `except OpenAIAuthError: raise` / `except RETRYABLE_API_ERRORS: sleep` / `except APIStatusError: raise` / `except Exception: sleep` |
| step loop around `_predict` | same 4-clause shape, but with `_fail(...)` as the non-fatal action (the two non-fatal clauses had **byte-identical bodies**) |
| `run_task` | `except OpenAIAuthError: raise` / `except APIStatusError as e:` + inner `isinstance(e, (RateLimitError, InternalServerError))` / `except Exception: handle` |

Note the third site used the narrower **literal tuple** `(RateLimitError, InternalServerError)` instead of `RETRYABLE_API_ERRORS`, relying on the trailing `except Exception` to catch `APIConnectionError`/`APITimeoutError`. Three spellings of one rule, with no single place stating it.

## Improvement

Extracted a module-level predicate next to the constant it consumes:

```python
def _is_fatal_api_error(exc: BaseException) -> bool:
    if isinstance(exc, RETRYABLE_API_ERRORS):
        return False
    return isinstance(exc, (OpenAIAuthError, APIStatusError))
```

All three sites collapse to the same two lines:

```python
except Exception as e:
    if _is_fatal_api_error(e):
        raise
    <site-specific non-fatal action>
```

The docstring records the **ordering hazard** that made the inline ladders fragile: `RateLimitError` and `InternalServerError` are themselves `APIStatusError` subclasses, so testing `APIStatusError` before the retryable set would silently turn every rate limit into a hard failure. That implicit, easy-to-break clause ordering is now one explicit, tested, documented check.

Net: `-23/+26` in source (12 `except` clauses across 3 ladders → 3 clauses + 1 predicate).

## Safety case

This is behavior-sensitive control flow, so it was verified three independent ways rather than by inspection.

**1. Exhaustive old-vs-new parity sweep.** All three old ladders were transcribed verbatim into a harness and compared against the predicate across a 22-exception vocabulary (all 9 `APIStatusError` subclasses, `APIConnectionError`, `APITimeoutError`, `APIError`, `OpenAIError`, plus 9 plain exceptions). **66/66 comparisons agree — zero divergence.** This includes confirming that `run_task`'s differently-spelled retryable set was already equivalent to the general rule.

**2. Real-path characterization tests, run against both revisions.** `run_task` had zero prior test coverage. Added `tests/test_eval_n1.py` (55 tests) which exercises `run_task`'s actual retry loop via a minimal `DatasetItem` stand-in whose `generate_task_config` raises — no browser, recorder, or API client needed, since `run_task` touches nothing else before that call. Pins propagate-without-retrying for every fatal error, retry-then-`Crashed` for every non-fatal one (asserting attempt counts, `score`, `exception`, `traceback`, and empty usage/timing), plus a dedicated `test_rate_limit_is_retried_not_propagated` for the ordering regression. The 19 behavior-only tests **pass identically against the pre-refactor and post-refactor source** (verified via `git stash`).

**3. Bare-`raise` mechanics.** `_predict`'s `_sleep_or_reraise` helper does a bare `raise` when out of retries, and is now invoked from an `except Exception as e:` clause instead of `except RETRYABLE_API_ERRORS:`. Smoke-tested the exact nested-async shape: the in-flight exception is re-raised with **identity preserved**, and the `as e` binding (deleted at block exit) does not interfere, since bare `raise` reads `sys.exc_info()`.

**Deliberately left untouched:** `main`'s `_eval` guard (`except OpenAIAuthError: raise` / `except Exception: return _crashed_result(e)`). It applies a genuinely *narrower* rule — only auth errors abort the whole eval run; every other terminal failure is recorded as `Crashed` for that one task and the run continues. Folding the predicate in there would change behavior, so it was left alone.

## Verification

- `pytest tests/` → **383 passed** (328 baseline + 55 new)
- `ruff check .` → clean
- `ruff format --check` → clean on both touched files (2 unrelated pre-existing failures in `navi_bench/dates.py` and an untouched slice in `eval_n1.py` are present on `main` too)

## Context

Resolves a lead the 2026-07-14 refactor audit explicitly rejected as unsafe ("an intervening `except APIStatusError: raise` clause makes them order-dependent — not safe to merge"). That read was correct about the *mechanical* merge of two adjacent clauses; the safe route is to name the rule as a predicate that encodes the ordering, then verify equivalence exhaustively — which also surfaced the third, differently-spelled copy in `run_task` that the earlier audit hadn't connected to the same rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126BGesadgXMjCrXjju5iZH

---
_Generated by [Claude Code](https://claude.ai/code/session_0126BGesadgXMjCrXjju5iZH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior-sensitive retry/propagate control flow in the eval agent path; changes are intended to be equivalent but affect how failed API calls are retried or crash tasks.
> 
> **Overview**
> **eval_n1** previously encoded the same OpenAI error rule in three separate `except` ladders (`_predict`, the step loop around it, and `run_task`), with inconsistent spelling and fragile clause ordering (rate limits are `APIStatusError` subclasses and must be checked before a blanket status-error propagate).
> 
> This PR introduces **`_is_fatal_api_error`** next to `RETRYABLE_API_ERRORS` and routes all three sites through the same `except Exception` + fatal check pattern, with a docstring that documents the ordering hazard. **`main`’s `_eval` handler is unchanged** — it still only aborts the whole run on auth errors.
> 
> Adds **`tests/test_eval_n1.py`** to pin the predicate across the OpenAI exception vocabulary, assert parity with the legacy `run_task` ladder, and cover `run_task` retries vs immediate propagate (including rate limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd44eba65fdc258efa0f518c14436b458a622739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->