### PR TITLE
refactor(vis): dedupe .markdown-content h1/h2 CSS border-bottom/padding-bottom

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -1144,16 +1144,12 @@ def generate_visualization_html(
             color: var(--text-primary);
         }}
 
-        .markdown-content h1 {{
-            font-size: 1.5rem;
+        .markdown-content h1, .markdown-content h2 {{
             border-bottom: 1px solid var(--border-color);
             padding-bottom: 0.3em;
         }}
-        .markdown-content h2 {{
-            font-size: 1.3rem;
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 0.3em;
-        }}
+        .markdown-content h1 {{ font-size: 1.5rem; }}
+        .markdown-content h2 {{ font-size: 1.3rem; }}
         .markdown-content h3 {{ font-size: 1.15rem; }}
         .markdown-content h4 {{ font-size: 1rem; }}
 

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -724,3 +724,42 @@ class TestModalEscapeKeyDelegatesToCloseModal:
         # (closeModal's own body) must appear only inside closeModal's function body, not
         # duplicated again in the Escape-key handler.
         assert html.count("getElementById('modal').classList.remove('active');") == 1
+
+
+class TestMarkdownHeadingStyleSheetDeduplication:
+    """Pins that ``.markdown-content h1`` and ``.markdown-content h2`` share their identical
+    ``border-bottom``/``padding-bottom`` declarations via the same comma-separated-selector
+    convention as ``TestStyleSheetDeduplication``, ``TestModalOverlayStyleSheetDeduplication``,
+    and ``TestModalCloseNavStyleSheetDeduplication`` above, instead of each repeating the
+    ``border-bottom: 1px solid var(--border-color); padding-bottom: 0.3em;`` rule body
+    verbatim. Each selector keeps its own rule for the ``font-size`` it doesn't share.
+    """
+
+    @staticmethod
+    def _html() -> str:
+        messages = [{"role": "user", "content": [{"type": "text", "text": "do the task"}]}]
+        return generate_visualization_html("task1", messages, None)
+
+    def test_h1_and_h2_share_one_rule_with_border_and_padding(self):
+        html = self._html()
+        match = re.search(r"\.markdown-content h1,\s*\.markdown-content h2\s*\{([^}]*)\}", html)
+        assert match is not None, html
+        body = match.group(1)
+        assert "border-bottom: 1px solid var(--border-color);" in body
+        assert "padding-bottom: 0.3em;" in body
+        # The body must appear exactly once in the stylesheet, not once per selector.
+        assert html.count("border-bottom: 1px solid var(--border-color);\n            padding-bottom: 0.3em;") == 1
+
+    def test_h1_keeps_its_own_font_size(self):
+        html = self._html()
+        match = re.search(r"\.markdown-content h1\s*\{\s*font-size: 1\.5rem;\s*\}", html)
+        assert match is not None, html
+        # .markdown-content h2 never gets h1's 1.5rem font-size.
+        assert "markdown-content h2 {\n            font-size: 1.5rem;" not in html
+
+    def test_h2_keeps_its_own_font_size(self):
+        html = self._html()
+        match = re.search(r"\.markdown-content h2\s*\{\s*font-size: 1\.3rem;\s*\}", html)
+        assert match is not None, html
+        # .markdown-content h1 never gets h2's 1.3rem font-size.
+        assert "markdown-content h1 {\n            font-size: 1.3rem;" not in html


### PR DESCRIPTION
## What

`.markdown-content h1` and `.markdown-content h2` in `generate_visualization_html()` (evaluation/vis.py) each repeated the identical `border-bottom: 1px solid var(--border-color); padding-bottom: 0.3em;` pair verbatim, differing only in `font-size`. This is the same "two selectors share a base declaration block" pattern already fixed in this file for `.section`/`.step` (#169), `.modal-overlay`/`.answer-modal-overlay` (#173), and `.modal-close`/`.modal-nav` (#188) via a comma-separated selector list — just not yet applied to this pair.

## Change

Merged the shared declarations into `.markdown-content h1, .markdown-content h2 { ... }`, with each selector keeping its own standalone rule for the `font-size` it doesn't share. Purely a CSS text reshuffle — computed styles for both selectors are unchanged.

## Testing

Following this repo's convention, added a characterization test (`TestMarkdownHeadingStyleSheetDeduplication` in `tests/test_vis.py`, mirroring the sibling `Test*StyleSheetDeduplication` classes) pinning the desired merged-selector output *before* refactoring:
- Confirmed it failed against the pre-refactor duplicated rules (red).
- Applied the CSS merge.
- Confirmed the test goes green.

Full verification:
- `pytest tests/`: 386 passed (383 pre-existing + 3 new), up from 383 on `main`.
- `ruff check .`: all checks passed.
- `ruff format --check .`: only the same 2 pre-existing failures on `main` remain (`evaluation/eval_n1.py`, `navi_bench/dates.py`), confirmed via a `git stash` baseline comparison — no new formatting failures introduced by this change.

## Test plan

- [x] `pytest tests/` passes (386 passed)
- [x] `ruff check .` passes
- [x] `ruff format --check .` shows no new failures vs. `main` baseline
- [x] Manual diff review: CSS merge preserves identical computed styles for `.markdown-content h1`/`h2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HdrJpTvRdGzSZ7mMHX7Mm


---
_Generated by [Claude Code](https://claude.ai/code/session_011HdrJpTvRdGzSZ7mMHX7Mm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only reshuffle inside static eval HTML output with tests locking output shape; no auth, data, or application logic changes.
> 
> **Overview**
> **Deduplicates embedded stylesheet rules** for markdown headings in `generate_visualization_html()`: `.markdown-content h1` and `.markdown-content h2` now share one rule for `border-bottom` and `padding-bottom`, matching the comma-separated selector pattern used elsewhere in the same `<style>` block. Each heading level keeps its own `font-size` rule (`1.5rem` vs `1.3rem`).
> 
> **Adds characterization coverage** via `TestMarkdownHeadingStyleSheetDeduplication` in `tests/test_vis.py`, asserting the merged selector, a single copy of the shared declarations, and that font sizes are not crossed between selectors.
> 
> No runtime or markup behavior change—computed styles for those headings stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc3c80ee138fe2988a0922b76d9991f1614005f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->