### PR TITLE
refactor(vis): dedupe .modal-close:hover/.answer-modal-close:hover CSS

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -984,7 +984,7 @@ def generate_visualization_html(
             font-size: 1.5rem;
         }}
 
-        .modal-close:hover {{
+        .modal-close:hover, .answer-modal-close:hover {{
             background: var(--accent-red);
             border-color: var(--accent-red);
         }}
@@ -1117,8 +1117,6 @@ def generate_visualization_html(
         }}
 
         .answer-modal-close:hover {{
-            background: var(--accent-red);
-            border-color: var(--accent-red);
             color: white;
         }}
 

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -763,3 +763,39 @@ class TestMarkdownHeadingStyleSheetDeduplication:
         assert match is not None, html
         # .markdown-content h1 never gets h2's 1.3rem font-size.
         assert "markdown-content h1 {\n            font-size: 1.3rem;" not in html
+
+
+class TestModalCloseAnswerModalCloseHoverStyleSheetDeduplication:
+    """Pins that ``.modal-close:hover`` (the lightbox close button) and
+    ``.answer-modal-close:hover`` (the final-answer modal close button) share their identical
+    ``background``/``border-color`` declarations via the same comma-separated-selector
+    convention as ``TestStyleSheetDeduplication``, ``TestModalOverlayStyleSheetDeduplication``,
+    ``TestModalCloseNavStyleSheetDeduplication``, and ``TestMarkdownHeadingStyleSheetDeduplication``
+    above, instead of each repeating the ``background: var(--accent-red);
+    border-color: var(--accent-red);`` rule body verbatim. ``.answer-modal-close:hover`` keeps
+    its extra ``color: white;`` declaration in its own rule since ``.modal-close:hover`` does
+    not share it.
+    """
+
+    @staticmethod
+    def _html() -> str:
+        messages = [{"role": "user", "content": [{"type": "text", "text": "do the task"}]}]
+        return generate_visualization_html("task1", messages, None)
+
+    def test_close_hovers_share_one_rule_with_background_and_border_color(self):
+        html = self._html()
+        match = re.search(r"\.modal-close:hover,\s*\.answer-modal-close:hover\s*\{([^}]*)\}", html)
+        assert match is not None, html
+        body = match.group(1)
+        assert "background: var(--accent-red);" in body
+        assert "border-color: var(--accent-red);" in body
+        assert "color: white;" not in body
+        # The body must appear exactly once in the stylesheet, not once per selector.
+        assert html.count("background: var(--accent-red);\n            border-color: var(--accent-red);") == 1
+
+    def test_answer_modal_close_hover_keeps_its_own_color(self):
+        html = self._html()
+        match = re.search(r"\.answer-modal-close:hover\s*\{\s*color: white;\s*\}", html)
+        assert match is not None, html
+        # .modal-close:hover never gets answer-modal-close's white hover color as a standalone rule.
+        assert re.search(r"(?<!answer-)\.modal-close:hover\s*\{\s*color: white;\s*\}", html) is None


### PR DESCRIPTION
## Day-over-day pattern

The last 24h saw two merged refactor PRs from this recurring cleanup job: #191 (consolidating three fatal-vs-retryable API-error `except` ladders in `evaluation/eval_n1.py`) and #192 (merging `.markdown-content h1`/`h2`'s duplicated `border-bottom`/`padding-bottom` CSS into a comma-separated selector).

#192's own commit message noted it was applying an established convention ("two selectors share a base declaration block") that had already been swept incrementally across `evaluation/vis.py` in #169, #173, and #188 — but each of those PRs fixed exactly one instance rather than auditing the whole stylesheet at once. That's the cross-cutting signal: this pattern class keeps getting fixed one pair at a time. A fresh full read of `evaluation/vis.py`'s `<style>` block (all ~90 selectors) turned up exactly one more untouched instance of the identical shape.

## The fix

`.modal-close:hover` (lightbox close button) and `.answer-modal-close:hover` (final-answer modal close button) repeated the identical

```css
background: var(--accent-red);
border-color: var(--accent-red);
```

verbatim, with `.answer-modal-close:hover` adding one extra `color: white;` declaration on top — the exact same shape #192 just fixed for `h1`/`h2` (shared base declarations + one selector keeps its own extra property).

Merged into `.modal-close:hover, .answer-modal-close:hover { background: ...; border-color: ...; }`, leaving `.answer-modal-close:hover` with only its own `color: white;` rule. Pure CSS text reshuffle — computed styles are unchanged (the two blocks touch disjoint properties, so declaration order doesn't matter).

## Verification

- Added `TestModalCloseAnswerModalCloseHoverStyleSheetDeduplication` in `tests/test_vis.py` first, confirmed via `git stash` that both new tests fail against the pre-refactor duplicated rules and pass after the change.
- Full suite: 388 passed (386 pre-existing + 2 new), up from 386.
- `ruff check`: all checks passed on touched files.
- `ruff format --check`: touched files (`evaluation/vis.py`, `tests/test_vis.py`) already formatted; only the same 2 pre-existing failures on `main` (`evaluation/eval_n1.py`, `navi_bench/dates.py`) remain, confirmed unaffected via a stashed-baseline comparison.

Scanned the rest of the stylesheet for further instances of this pattern and found none remaining.

cc @dhruvbatra (recent owner of `evaluation/vis.py`)


---
_Generated by [Claude Code](https://claude.ai/code/session_012acphMjSWc4xrLDw2VQost)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only refactor in static eval visualization HTML with characterization tests; no runtime logic or security impact.
> 
> **Overview**
> **Deduplicates hover styles** for the lightbox close button (`.modal-close:hover`) and the final-answer modal close button (`.answer-modal-close:hover`) in the embedded `evaluation/vis.py` stylesheet.
> 
> Both selectors now share one rule for `background` and `border-color` on hover (red accent), matching the existing comma-separated-selector cleanup used elsewhere in that file. `.answer-modal-close:hover` keeps a separate rule with only `color: white;`, since the lightbox close control does not use that property.
> 
> Adds `TestModalCloseAnswerModalCloseHoverStyleSheetDeduplication` in `tests/test_vis.py` so the shared rule appears once and the answer-modal-only hover color stays isolated. **Rendered hover appearance is unchanged**—stylesheet text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3b701bce4630592258f00d204ec7280093463e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->