### PR TITLE
refactor(opentable): dedupe push-availability construction in parseTimesAndAvailabilities

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -211,6 +211,14 @@
 
         // now we can parse the availabilities
         const availabilities = [];
+        // Push a single date/time/availability entry, resolving `ts` via timestampToDateAndTime.
+        // Extracted because all four branches below repeated this identical
+        // "resolve timestamp -> push {date, time, availability}" triple, differing only in
+        // which timestamp and availability label they used.
+        const pushAvailabilityAt = (ts, availability) => {
+            const dt = timestampToDateAndTime(ts);
+            availabilities.push({ date: dt.date, time: dt.time, availability });
+        };
         let i = 0;
         while (i < n) {
             let j = i;
@@ -219,12 +227,7 @@
             }
             if (i === j) {
                 // t[i] is available
-                const dt = timestampToDateAndTime(timestamps[i]);
-                availabilities.push({
-                    date: dt.date,
-                    time: dt.time,
-                    availability: "available",
-                });
+                pushAvailabilityAt(timestamps[i], "available");
                 ++i;
             } else if (i > 0 && j < n) {
                 // t[i-1] is available, t[j] is available, t[i] ... t[j-1] are unavailable
@@ -233,12 +236,7 @@
                 const end = timestamps[j];
                 let current = start + deltaMilliseconds;
                 while (current < end) {
-                    const dt = timestampToDateAndTime(current);
-                    availabilities.push({
-                        date: dt.date,
-                        time: dt.time,
-                        availability: "unavailable",
-                    });
+                    pushAvailabilityAt(current, "unavailable");
                     current += deltaMilliseconds;
                 }
                 i = j;
@@ -247,12 +245,7 @@
                 let current = timestamps[j];
                 for (let k = j - 1; k >= i; --k) {
                     current -= deltaMilliseconds;
-                    const dt = timestampToDateAndTime(current);
-                    availabilities.push({
-                        date: dt.date,
-                        time: dt.time,
-                        availability: "unavailable",
-                    });
+                    pushAvailabilityAt(current, "unavailable");
                 }
                 i = j;
             } else {
@@ -260,12 +253,7 @@
                 let current = timestamps[i - 1];
                 for (let k = i; k < n; ++k) {
                     current += deltaMilliseconds;
-                    const dt = timestampToDateAndTime(current);
-                    availabilities.push({
-                        date: dt.date,
-                        time: dt.time,
-                        availability: "unavailable",
-                    });
+                    pushAvailabilityAt(current, "unavailable");
                 }
                 i = j;
             }


### PR DESCRIPTION
## Issue

`parseTimesAndAvailabilities` in `navi_bench/opentable/opentable_info_gathering.js` had four branches (available-slot, fill-between, leading-unavailable, trailing-unavailable) that each repeated the identical "resolve timestamp via `timestampToDateAndTime` -> push `{date, time, availability}`" triple, differing only in which timestamp and availability label they used.

## Improvement

Extracted a local `pushAvailabilityAt(ts, availability)` helper inside `parseTimesAndAvailabilities`; all four call sites now delegate to it (12 insertions, 24 deletions, single file).

Same "duplicated block, parameterize the one thing that differs" pattern already applied repeatedly in this file (`pushSlotResult`/`pushRangeResult` in #183, `extractSlotAvailabilities`, `extractPartySizeDateTime`) and elsewhere in this repo's JS (`dom_visibility.js`'s `isVisible` dedup in #167, `patchTargetProperty` in #180).

## Safety

Zero behavior change:
- `node --check` passes.
- A Node harness compared old vs. new `parseTimesAndAvailabilities` output across 16 representative `(date, timesArray)` cases covering all four branches plus quarter-hour/half-hour granularity and edge cases (empty input, all-blank, single slot, leading/trailing gaps, day-boundary crossing) — byte-identical JSON output in every case.
- Full local pytest suite unchanged: 388 passed before and after.
- `ruff check` clean. `ruff format --check` shows only the two pre-existing failures on `main` (`evaluation/eval_n1.py`, `navi_bench/dates.py`), unrelated to this change (confirmed via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K5qsKcTpjD8R15WdD1Ptvw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file mechanical refactor in benchmark scraping JS with no logic or API changes.
> 
> **Overview**
> In `parseTimesAndAvailabilities`, a local **`pushAvailabilityAt(ts, availability)`** helper now centralizes the repeated `timestampToDateAndTime` → `{ date, time, availability }` push logic.
> 
> All four existing branches (available slot, fill-between unavailable, leading unavailable, trailing unavailable) call this helper instead of inlining the same triple.
> 
> **No change** to availability inference or output shape—pure deduplication, consistent with other helpers already in `opentable_info_gathering.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9719e928abe32aedb9a003b4114d9c39b2ef640a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->