### PR TITLE
refactor(opentable): extract extractVisibleValue() JS helper

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -276,6 +276,27 @@
         return parseTimesAndAvailabilities(baseDateForSlots, timesArray);
     };
 
+    // Scan `container` for elements matching `selector` and return the value derived (via
+    // `extract`, default: raw textContent) from the last visible match, or null if none are
+    // visible. Extracted because eleven call sites across extractPartySizeDateTime,
+    // handleRestrefPage, handleBookingRestrefPage, handleRestaurantPageWithFullAvailabilityPopup,
+    // and handleRestaurantPage each repeated this identical "querySelectorAll -> forEach -> if
+    // isVisible, (re)assign" loop, differing only in the selector and how the visible element's
+    // value was derived. Deliberately keeps the original "last visible element wins" semantics
+    // (a plain forEach that keeps overwriting, not a break-on-first-match loop) -- unrelated to
+    // the first-visible-with-break loops in handleRestaurantPage/
+    // handleRestaurantPageWithFullAvailabilityPopup's timeSlots lookups, which are a different
+    // pattern and left untouched.
+    const extractVisibleValue = (container, selector, extract = (el) => el.textContent) => {
+        let value = null;
+        container.querySelectorAll(selector).forEach((el) => {
+            if (isVisible(el)) {
+                value = extract(el);
+            }
+        });
+        return value;
+    };
+
     // Scan `root` for the visible party-size/date/time picker-overlay elements and return
     // their raw text content. Extracted because handleSearchPage, handleBookingRestrefPage,
     // and handleRestaurantPage's dropdown-menu branch each repeated this identical
@@ -283,27 +304,9 @@
     // times in a row (once per field), differing only in which element (`document` vs a
     // scoped `reservationPanel`) is searched.
     const extractPartySizeDateTime = (root, selectors) => {
-        let partySize = null;
-        root.querySelectorAll(selectors.partySize).forEach((el) => {
-            if (isVisible(el)) {
-                partySize = parsePartySize(el.textContent);
-            }
-        });
-
-        let baseDate = null;
-        root.querySelectorAll(selectors.date).forEach((el) => {
-            if (isVisible(el)) {
-                baseDate = el.textContent;
-            }
-        });
-
-        let baseTime = null;
-        root.querySelectorAll(selectors.time).forEach((el) => {
-            if (isVisible(el)) {
-                baseTime = el.textContent;
-            }
-        });
-
+        const partySize = extractVisibleValue(root, selectors.partySize, (el) => parsePartySize(el.textContent));
+        const baseDate = extractVisibleValue(root, selectors.date);
+        const baseTime = extractVisibleValue(root, selectors.time);
         return { partySize, baseDate, baseTime };
     };
 
@@ -467,35 +470,20 @@
             restaurantName = restaurantName.slice(15);
         }
 
-        let partySize = null;
-        document.querySelectorAll('.styled__PartySizeSelectorWrapper-sc-d8dhde-1').forEach((el) => {
-            if (isVisible(el)) {
-                partySize = parsePartySize(el.textContent);
-            }
-        });
-
-        let baseDate = null;
-        document.querySelectorAll('.styled__DatePickerWrapper-sc-d8dhde-2').forEach((el) => {
-            if (isVisible(el)) {
-                baseDate = el.textContent;
-            }
-        });
-
-        let baseTime = null;
-        document.querySelectorAll('.styled__TimeSelectorWrapper-sc-d8dhde-3').forEach((el) => {
-            if (isVisible(el)) {
-                baseTime = el.querySelector('.styled__Label-sc-7ysqo8-0')?.textContent;
-            }
-        });
+        const partySize = extractVisibleValue(
+            document, '.styled__PartySizeSelectorWrapper-sc-d8dhde-1', (el) => parsePartySize(el.textContent)
+        );
+        let baseDate = extractVisibleValue(document, '.styled__DatePickerWrapper-sc-d8dhde-2');
+        let baseTime = extractVisibleValue(
+            document, '.styled__TimeSelectorWrapper-sc-d8dhde-3',
+            (el) => el.querySelector('.styled__Label-sc-7ysqo8-0')?.textContent
+        );
 
         ({ baseDate, baseTime } = normalizeBaseDateTime(baseDate, baseTime));
 
-        let availability = null;
-        document.querySelectorAll('.styled__AvailabilityDayWrapper-sc-1xhoeow-5').forEach((el) => {
-            if (isVisible(el)) {
-                availability = el.querySelector('p')?.textContent;
-            }
-        });
+        const availability = extractVisibleValue(
+            document, '.styled__AvailabilityDayWrapper-sc-1xhoeow-5', (el) => el.querySelector('p')?.textContent
+        );
 
         if (availability) {
             pushSlotResult(restaurantName, partySize, baseDate, baseTime, availability);
@@ -529,12 +517,7 @@
         let { partySize, baseDate, baseTime } = extractPartySizeDateTime(document, PICKER_OVERLAY_SELECTORS);
         ({ baseDate, baseTime } = normalizeBaseDateTime(baseDate, baseTime));
 
-        let availability = null;
-        document.querySelectorAll('.O-z6wyHTamU-').forEach((el) => {
-            if (isVisible(el)) {
-                availability = el.textContent;
-            }
-        });
+        const availability = extractVisibleValue(document, '.O-z6wyHTamU-');
 
         if (availability) {
             pushSlotResult(restaurantName, partySize, baseDate, baseTime, availability);
@@ -565,19 +548,10 @@
 
         const restaurantName = popup.querySelector('h2')?.textContent;
 
-        let partySize = null;
-        popup.querySelectorAll('[data-testid="party-size-picker-overlay"]').forEach((el) => {
-            if (isVisible(el)) {
-                partySize = parsePartySize(el.textContent);
-            }
-        });
-
-        let baseDate = null;
-        popup.querySelectorAll('.sEh3MIECg10-').forEach((el) => {
-            if (isVisible(el)) {
-                baseDate = parseDateAndTimes(el.textContent).date;
-            }
-        });
+        const partySize = extractVisibleValue(
+            popup, '[data-testid="party-size-picker-overlay"]', (el) => parsePartySize(el.textContent)
+        );
+        const baseDate = extractVisibleValue(popup, '.sEh3MIECg10-', (el) => parseDateAndTimes(el.textContent).date);
 
         let timeSlots = null;
         const elements = popup.querySelectorAll('[data-test="time-slots"]');
@@ -665,12 +639,7 @@
         const restaurantName = document.querySelector('h1')?.textContent;
 
         // Locate the side panel for reservation of the restaurant
-        let reservationPanel = null;
-        document.querySelectorAll('[data-testid="bookable-cta"]').forEach((el) => {
-            if (isVisible(el)) {
-                reservationPanel = el;
-            }
-        });
+        const reservationPanel = extractVisibleValue(document, '[data-testid="bookable-cta"]', (el) => el);
         if (!reservationPanel) return;
 
         let partySize = null;


### PR DESCRIPTION
## Issue

`navi_bench/opentable/opentable_info_gathering.js` had eleven call sites (across `extractPartySizeDateTime`, `handleRestrefPage`, `handleBookingRestrefPage`, `handleRestaurantPageWithFullAvailabilityPopup`, and `handleRestaurantPage`) that each repeated the identical `querySelectorAll(...).forEach(el => { if (isVisible(el)) { value = ...; } })` loop, differing only in the selector searched and how the visible element's value was derived:

- raw `el.textContent`
- `parsePartySize(el.textContent)`
- a nested `el.querySelector(...)?.textContent`
- `parseDateAndTimes(el.textContent).date`
- the element itself (`reservationPanel`)

This is the same "duplicated block, parameterize the one thing that differs" shape this file (and this repo's JS more broadly) has been mechanically deduped along before — `pushSlotResult`/`pushRangeResult` (#183), `pushAvailabilityAt` (#194), `dom_visibility.js`'s shared `isVisible` (#167), `patchTargetProperty` (#180).

## Fix

Extracted a single `extractVisibleValue(container, selector, extract = el => el.textContent)` helper; all eleven sites now delegate to it, passing a custom `extract` only where the value isn't plain `textContent`.

Deliberately preserves the original **"last visible element wins"** semantics — the loop is a plain `forEach` that keeps overwriting `value` for every visible match, not a break-on-first-match loop. I left the two *different* patterns in this file untouched: `handleRestaurantPage`'s and `handleRestaurantPageWithFullAvailabilityPopup`'s `timeSlots` lookups use a `for...of` loop with `break` on the first visible match — a genuinely different selection rule, so merging them into `extractVisibleValue` would be a behavior change, not a refactor.

Net: 113 lines touched, 41 insertions / 72 deletions in a single file.

## Safety verification

- `node --check navi_bench/opentable/opentable_info_gathering.js` — passes.
- Standalone Node parity harness (not committed, matching this file's established ad-hoc-verification convention from #167/#180/#183/#194) comparing the OLD inline loop against the NEW `extractVisibleValue` call across representative fixtures — no elements, one visible, one not-visible, multiple with last-visible-wins, none visible — for every extractor shape touched (`parsePartySize`, plain `textContent`, nested-selector, identity): **19/19 comparisons agree, byte-identical output.**
- Full local `pytest tests/`: **388 passed**, unchanged from baseline (this repo's Python tests stub `page.evaluate()` with canned results, so they don't exercise this JS file directly — parity was verified at the JS level instead, per this file's established convention).
- `ruff check .`: clean. (`ruff format --check` has two pre-existing, unrelated failures on `main` in `evaluation/eval_n1.py` and `navi_bench/dates.py`, confirmed via `git stash` before touching anything — not introduced by this change, not touched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016s6UgBH4Cxwgd5AG2PGNDb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication in OpenTable DOM scraping with explicit preservation of last-visible-wins semantics; no auth, data, or API surface changes.
> 
> **Overview**
> Introduces **`extractVisibleValue(container, selector, extract?)`** in `opentable_info_gathering.js` and routes **eleven** duplicated “`querySelectorAll` → visible check → assign value” loops through it.
> 
> **`extractPartySizeDateTime`** now uses the helper for party size, date, and time. **Restref, booking restref, full-availability popup, and restaurant** handlers use it for picker fields, availability text, parsed dates, nested labels, and resolving the visible **`bookable-cta`** panel (identity `extract` where the element itself is needed). Optional **`extract`** callbacks cover `parsePartySize`, nested `querySelector` text, and `parseDateAndTimes(...).date` where plain `textContent` is not enough.
> 
> Behavior is unchanged: **last visible match wins** (overwrite on each visible hit). **`timeSlots`** lookups that **break on the first visible** match are intentionally **not** folded into this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067e8c7ae687bca27c04017d9779d9c3d09a0cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->