### PR TITLE
test(craigslist): add characterization tests for CraigslistUrlMatch

### DIFF
--- a/tests/test_craigslist_url_match.py
+++ b/tests/test_craigslist_url_match.py
@@ -1,0 +1,176 @@
+"""Characterization tests for CraigslistUrlMatch.
+
+Unlike every sibling domain matcher (apartments, resy, opentable, google_flights),
+``craigslist_url_match.py`` had zero test coverage before this file. These tests pin
+``_parse_state``'s ignored-parameter filtering and, more importantly, ``compute()``'s
+nested "AND of ORs" coverage logic: every group in ``gt_urls`` (outer list) must be
+covered, where a group counts as covered if any one of its alternatives (inner list) is
+matched by some visited URL.
+"""
+
+import asyncio
+
+from navi_bench.craigslist.craigslist_url_match import CraigslistUrlMatch
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestParseState:
+    def test_query_params_parsed_into_dict_of_lists(self):
+        state = CraigslistUrlMatch._parse_state("https://sfbay.craigslist.org/search/apa?min_bedrooms=2&pets_cat=1")
+
+        assert state == {"min_bedrooms": ["2"], "pets_cat": ["1"]}
+
+    def test_ignored_param_is_trusted_is_dropped(self):
+        state = CraigslistUrlMatch._parse_state("https://sfbay.craigslist.org/search/apa?isTrusted=true&postal=94043")
+
+        assert state == {"postal": ["94043"]}
+
+    def test_no_query_string_yields_empty_dict(self):
+        assert CraigslistUrlMatch._parse_state("https://sfbay.craigslist.org/search/apa") == {}
+
+    def test_fragment_is_not_part_of_query(self):
+        state = CraigslistUrlMatch._parse_state(
+            "https://sfbay.craigslist.org/search/apa?postal=94043#search=2~gallery~0"
+        )
+
+        assert state == {"postal": ["94043"]}
+
+
+class TestUpdate:
+    def test_new_url_is_recorded_in_intermediate_state(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=94043"))
+
+        assert metric._intermediate_url_to_state == {
+            "https://sfbay.craigslist.org/search/apa?postal=94043": {"postal": ["94043"]}
+        }
+
+    def test_repeat_url_is_not_reparsed_or_duplicated(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+        url = "https://sfbay.craigslist.org/search/apa?postal=94043"
+
+        _run(metric.update(url=url))
+        _run(metric.update(url=url))
+
+        assert list(metric._intermediate_url_to_state.keys()) == [url]
+
+    def test_multiple_distinct_urls_are_all_recorded(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=94043"))
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=10001"))
+
+        assert len(metric._intermediate_url_to_state) == 2
+
+
+class TestCompute:
+    def test_no_urls_visited_scores_zero(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+
+        result = _run(metric.compute())
+
+        assert result.score == 0.0
+        assert result.reasoning == "Covered 0 out of 1 required URLs"
+
+    def test_single_group_single_alternative_matched_scores_one(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=94043&isTrusted=true"))
+        result = _run(metric.compute())
+
+        assert result.score == 1.0
+        assert result.reasoning == "Covered 1 out of 1 required URLs"
+
+    def test_or_alternative_within_a_group_counts_as_covered(self):
+        # A single required group with two acceptable alternative URLs ("OR" semantics):
+        # visiting only the second alternative should still fully cover the group.
+        metric = CraigslistUrlMatch(
+            gt_urls=[
+                [
+                    "https://sfbay.craigslist.org/search/apa?postal=94043",
+                    "https://sfbay.craigslist.org/search/apa?postal=10001",
+                ]
+            ]
+        )
+
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=10001"))
+        result = _run(metric.compute())
+
+        assert result.score == 1.0
+
+    def test_all_groups_required_and_partial_coverage_is_fractional(self):
+        # Two required ("AND") groups; only the first is covered.
+        metric = CraigslistUrlMatch(
+            gt_urls=[
+                ["https://sfbay.craigslist.org/search/apa?postal=94043"],
+                ["https://sfbay.craigslist.org/search/apa?postal=10001"],
+            ]
+        )
+
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=94043"))
+        result = _run(metric.compute())
+
+        assert result.score == 0.5
+        assert result.reasoning == "Covered 1 out of 2 required URLs"
+
+    def test_single_visited_url_can_cover_two_distinct_groups(self):
+        # Same gt state appearing in two different AND groups; one visited URL matching
+        # that state should satisfy both groups independently (not consumed after first use).
+        metric = CraigslistUrlMatch(
+            gt_urls=[
+                ["https://sfbay.craigslist.org/search/apa?postal=94043"],
+                ["https://sfbay.craigslist.org/search/apa?postal=94043"],
+            ]
+        )
+
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=94043"))
+        result = _run(metric.compute())
+
+        assert result.score == 1.0
+        assert result.reasoning == "Covered 2 out of 2 required URLs"
+
+    def test_visited_url_with_extra_ignored_param_still_matches(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?isTrusted=true&postal=94043"))
+        result = _run(metric.compute())
+
+        assert result.score == 1.0
+
+    def test_visited_url_with_different_params_does_not_match(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=10001"))
+        result = _run(metric.compute())
+
+        assert result.score == 0.0
+
+
+class TestResetAndRepr:
+    def test_reset_clears_intermediate_state(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=94043"))
+        assert metric._intermediate_url_to_state
+
+        _run(metric.reset())
+
+        assert metric._intermediate_url_to_state == {}
+
+    def test_reset_reverts_compute_to_uncovered(self):
+        metric = CraigslistUrlMatch(gt_urls=[["https://sfbay.craigslist.org/search/apa?postal=94043"]])
+        _run(metric.update(url="https://sfbay.craigslist.org/search/apa?postal=94043"))
+        assert _run(metric.compute()).score == 1.0
+
+        _run(metric.reset())
+
+        assert _run(metric.compute()).score == 0.0
+
+    def test_repr_shows_gt_urls(self):
+        gt_urls = [["https://sfbay.craigslist.org/search/apa?postal=94043"]]
+        metric = CraigslistUrlMatch(gt_urls=gt_urls)
+
+        assert repr(metric) == f"CraigslistUrlMatch(gt_urls={gt_urls})"


### PR DESCRIPTION
## Summary

The shared cross-repo refactor backlog flagged navi-bench as saturated for mechanical duplicate-literal/duplicate-block sweeps after 15+ hourly passes, and recommended trying a different search strategy (test coverage gaps, error-handling consistency, perf, docs) instead.

Auditing test coverage turned up a real gap: `navi_bench/craigslist/craigslist_url_match.py` and `navi_bench/google_flights/google_flights_search_match.py` are the only two domain matchers with **zero** test coverage, unlike `apartments_url_match.py`, `resy_url_match.py`, and `opentable_info_gathering.py`, which all have dedicated test files.

This PR adds characterization tests for `CraigslistUrlMatch`, covering:
- `_parse_state`'s query-param parsing and `isTrusted` ignored-param filtering
- `update()`'s dedup-by-URL behavior (repeated URLs aren't reparsed/duplicated)
- `compute()`'s nested "AND of ORs" coverage logic — every group in `gt_urls` is required, any one alternative within a group is sufficient, a single visited URL can independently satisfy multiple groups that share the same normalized state, and partial coverage scores fractionally via the existing `fractional_coverage_score` helper
- `reset()` (via `ResetsViaState`) and `__repr__`

No production code was changed — this is purely additive test coverage, verified to pass against the existing implementation with no behavior assumptions needed.

(`google_flights_search_match.py`'s gap is left for a follow-up, given the added complexity of its protobuf-based `Info` comparisons.)

## Test plan

- [x] `python -m pytest tests/test_craigslist_url_match.py -v` — 17/17 new tests pass
- [x] `python -m pytest tests/` — 405 passed (388 → 405), no regressions
- [x] `ruff check .` — clean
- [x] `ruff format --check tests/test_craigslist_url_match.py` — clean (repo-wide `ruff format --check` still shows only the 2 pre-existing baseline failures in `evaluation/eval_n1.py`/`navi_bench/dates.py`, confirmed unrelated to this change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01LWS632oYgj2KMDxDJQY8Jq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition; benchmark scoring logic is unchanged and only locked in by new assertions.
> 
> **Overview**
> Adds **`tests/test_craigslist_url_match.py`** so `CraigslistUrlMatch` matches other domain matchers that already have dedicated tests. **No production code changes.**
> 
> The new suite (17 tests) documents current behavior: query parsing with **`isTrusted`** stripped, **`update()`** deduplication by URL, **`compute()`** scoring as AND-of-OR groups over normalized query state (including fractional partial coverage and one visit satisfying multiple groups), plus **`reset()`** and **`__repr__`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c55ccafbfd81ec737616cd33a78763b1b5bff16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->