### PR TITLE
test(resy): add characterization tests for ResyUrlMatch.update/.compute

### DIFF
--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -1,6 +1,6 @@
-"""Characterization tests for ResyUrlMatch's placeholder-rendering helpers.
+"""Characterization tests for ResyUrlMatch.
 
-These tests pin the behavior of ``_render_placeholders_in_queries_any`` and
+The placeholder-rendering tests pin the behavior of ``_render_placeholders_in_queries_any`` and
 ``_render_placeholders_in_queries_all``, including their shared per-placeholder validation
 preamble (build the ``{key}`` template string, reject empty resolved dates via
 ``ensure_resolved_dates``, reject dates beyond the booking window via
@@ -8,8 +8,18 @@ preamble (build the ``{key}`` template string, reject empty resolved dates via
 ``_any`` additionally requires exactly one resolved date, checked *between* the other two
 validations — a couple of these tests exist specifically to pin that ordering (which error
 wins when a placeholder is both multi-valued and out of the booking window).
+
+The ``update``/``compute`` tests below pin ``ResyUrlMatch``'s core matching lifecycle — the
+strict URL match, the "no availability" relaxed-matching mode, and the conditional-success
+branch (``_evaluate_condition``) used when the time slot differs but everything else about
+the URL matches. This is navi-bench's largest and most conditionally complex domain matcher,
+and previously had no direct test coverage of these methods at all (only the placeholder
+helpers above were tested). The ``_FakePage``/``asyncio.run`` approach mirrors the existing
+precedent for exercising an async ``update()`` without a real browser, established for
+``OpenTableInfoGathering.update`` in ``test_opentable_info_gathering.py``.
 """
 
+import asyncio
 from datetime import date
 
 import pytest
@@ -388,3 +398,145 @@ class TestGenerateTaskConfigRandomDaysAheadCapping:
         )
 
         assert captured["date_range"] == (1, 14)
+
+
+class _FakePage:
+    """Minimal stand-in for playwright's ``Page``. ``ResyUrlMatch.update`` issues two
+    sequential ``page.evaluate`` calls (the no-availability check, then the availability
+    extractor); this returns canned results in that order, mirroring the ``_FakePage``
+    convention established for ``OpenTableInfoGathering.update``
+    (test_opentable_info_gathering.py).
+    """
+
+    def __init__(self, results: list) -> None:
+        self._results = list(results)
+
+    async def evaluate(self, _script: str):
+        return self._results.pop(0)
+
+
+# A ground-truth URL whose `time` param is in raw "HHMM" form, so a browser URL using
+# colon-separated time (e.g. "19:00") normalizes to the same time-of-day but fails the
+# strict raw-string URL comparison -- the setup the conditional-match tests below rely on.
+_GT_URL = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=2&time=1900"
+
+
+def _run_update(match: ResyUrlMatch, *, url: str, has_no_availability: bool, availabilities: list[dict]) -> None:
+    asyncio.run(match.update(url=url, page=_FakePage([has_no_availability, availabilities])))
+
+
+class TestUpdateStrictAndRelaxedMatch:
+    def test_strict_url_match_covers_query(self):
+        match = ResyUrlMatch(queries=[[_GT_URL]])
+
+        _run_update(match, url=_GT_URL, has_no_availability=False, availabilities=[])
+
+        assert match._is_query_covered == [True]
+        assert match._coverage_reasons[0]["reason_code"] == "strict_url_match"
+
+    def test_mismatched_date_does_not_cover_query(self):
+        match = ResyUrlMatch(queries=[[_GT_URL]])
+        other_date_url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-16&seats=2&time=1900"
+
+        _run_update(match, url=other_date_url, has_no_availability=False, availabilities=[])
+
+        assert match._is_query_covered == [False]
+        assert match._coverage_reasons[0] is None
+
+    def test_no_availability_relaxes_match_to_date_only(self):
+        # Different seats/time than ground truth, but "no availability" detected -> the whole
+        # day is unavailable regardless of party size or time, so only the date needs to match.
+        match = ResyUrlMatch(queries=[[_GT_URL]])
+        relaxed_url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=4&time=20:00"
+
+        _run_update(match, url=relaxed_url, has_no_availability=True, availabilities=[])
+
+        assert match._is_query_covered == [True]
+        assert match._coverage_reasons[0]["reason_code"] == "relaxed_url_match"
+
+    def test_no_availability_relax_still_requires_matching_date(self):
+        match = ResyUrlMatch(queries=[[_GT_URL]])
+        wrong_date_url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-16&seats=2&time=1900"
+
+        _run_update(match, url=wrong_date_url, has_no_availability=True, availabilities=[])
+
+        assert match._is_query_covered == [False]
+
+
+class TestUpdateConditionalMatch:
+    def test_conditional_success_when_url_time_matches_ground_truth_time(self):
+        # Time params differ in raw form ("1900" vs "19:00") so the strict full-URL comparison
+        # fails, but both normalize to the same time-of-day -> conditional success via
+        # "gt_time_in_url", even though the slot itself isn't visible (url-time match takes
+        # precedence over visibility once the ground-truth time is a known slot).
+        match = ResyUrlMatch(queries=[[_GT_URL]])
+        colon_time_url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=2&time=19:00"
+
+        _run_update(
+            match,
+            url=colon_time_url,
+            has_no_availability=False,
+            availabilities=[{"time_24": "1900", "is_visible": False}],
+        )
+
+        assert match._is_query_covered == [True]
+        assert match._coverage_reasons[0]["reason_code"] == "gt_time_in_url"
+
+    def test_conditional_success_when_ground_truth_time_is_visible(self):
+        # No time param in the browser URL at all, but the ground-truth time slot is visible
+        # in the extracted availabilities -> conditional success via "gt_time_visible".
+        match = ResyUrlMatch(queries=[[_GT_URL]])
+        no_time_url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=2"
+
+        _run_update(
+            match,
+            url=no_time_url,
+            has_no_availability=False,
+            availabilities=[{"time_24": "1900", "is_visible": True}],
+        )
+
+        assert match._is_query_covered == [True]
+        assert match._coverage_reasons[0]["reason_code"] == "gt_time_visible"
+
+    def test_conditional_failure_when_ground_truth_time_not_visible(self):
+        # Same setup as above, but the ground-truth slot is present without being visible and
+        # has no neighboring slots recorded -> not covered.
+        match = ResyUrlMatch(queries=[[_GT_URL]])
+        no_time_url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=2"
+
+        _run_update(
+            match,
+            url=no_time_url,
+            has_no_availability=False,
+            availabilities=[{"time_24": "1900", "is_visible": False}],
+        )
+
+        assert match._is_query_covered == [False]
+        assert match._coverage_reasons[0] is None
+
+    def test_already_covered_group_is_not_reprocessed(self):
+        match = ResyUrlMatch(queries=[[_GT_URL]])
+        match._is_query_covered[0] = True  # simulate already covered by a prior update()
+
+        # Would otherwise cover the group via a strict match; verify it's skipped instead.
+        _run_update(match, url=_GT_URL, has_no_availability=False, availabilities=[])
+
+        assert match._coverage_reasons[0] is None
+
+
+class TestCompute:
+    def test_score_is_one_when_all_queries_covered(self):
+        match = ResyUrlMatch(queries=[[_GT_URL], [_GT_URL]])
+        match._is_query_covered = [True, True]
+
+        result = asyncio.run(match.compute())
+
+        assert result.score == 1.0
+
+    def test_score_is_zero_when_any_query_uncovered(self):
+        match = ResyUrlMatch(queries=[[_GT_URL], [_GT_URL]])
+        match._is_query_covered = [True, False]
+
+        result = asyncio.run(match.compute())
+
+        assert result.score == 0.0


### PR DESCRIPTION
## What

`ResyUrlMatch` (`navi_bench/resy/resy_url_match.py`) is navi-bench's largest and most conditionally complex domain matcher — async page interaction, "no availability" relaxed matching, and preceding/following-slot conditional coverage. Unlike the other four matchers (`CraigslistUrlMatch`, `ApartmentsUrlMatch`, `GoogleFlightsSearchMatch`, `OpenTableInfoGathering`), it had **zero direct test coverage** of its core `update()`/`compute()` lifecycle — `tests/test_resy_url_match.py` only covered the placeholder-rendering helpers (its own docstring said so explicitly).

This adds characterization tests for:
- The strict URL match (`strict_url_match`)
- The "no availability" relaxed-matching mode (`relaxed_url_match`, date-only comparison)
- The conditional-success branch (`_evaluate_condition`) when the time slot differs but everything else matches — both the `gt_time_in_url` and `gt_time_visible` reasons, plus a conditional-failure case
- The already-covered-group skip in `update()`
- `compute()`'s all-or-nothing scoring

Uses a `_FakePage` stand-in returning canned `page.evaluate()` results in sequence, mirroring the existing precedent established for `OpenTableInfoGathering.update` in `test_opentable_info_gathering.py` (no real browser/event loop needed).

## Why this is safe

- **Pure test addition — no production code changes.** Zero behavioral change is true by construction.
- Scoped to 1 file, well under the repo's 5-file cap for this class of change.
- Verified: `python -m pytest tests/test_resy_url_match.py -q` → 57 passed; full suite (`python -m pytest tests/ -q`, excluding 4 pre-existing modules that fail to import due to unrelated missing optional extras — `tabulate`, `yutori` — in this sandbox, confirmed unrelated by inspection) → 293 passed. `ruff format --diff` / `ruff check` clean.

## Scope

This fills a genuine test-coverage gap per the repo's hourly refactor-bot scope (this repo's own backlog explicitly called for trying a different search strategy — test coverage gaps — after 15+ consecutive duplicate-scan passes found nothing new). No functionality change, no new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A5iiRN5kYWXpfAnr4EaKzR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds **characterization tests** for `ResyUrlMatch.update()` and `compute()` in `tests/test_resy_url_match.py`, which previously only exercised placeholder-rendering helpers.
> 
> The new coverage uses a **`_FakePage`** stub (sequential canned `page.evaluate` results) and **`asyncio.run`** to drive `update()` without Playwright, following the OpenTable tests pattern. Cases pinned include **strict URL match** (`strict_url_match`), **no-availability relaxed matching** (date-only, `relaxed_url_match`), **conditional coverage** when time formatting or visibility differs (`gt_time_in_url`, `gt_time_visible`, and a non-covered invisible slot), **skipping groups already marked covered**, and **`compute()`’s all-or-nothing score** (1.0 vs 0.0).
> 
> The module docstring is expanded to document this scope alongside the existing placeholder tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595e6358d7ca9fbcc80a04d628d53b36aef42f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->