### PR TITLE
fix(base): anchor DatasetItem enum regex patterns

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -416,14 +416,14 @@ class DatasetItem(BaseModel):
     )
 
     # task metadata fields
-    env: str = Field(description="Environment: real | sim", pattern=r"^real|sim$")
+    env: str = Field(description="Environment: real | sim", pattern=r"^(?:real|sim)$")
     domain: str = Field(description="Website domain: e.g., expedia, google_flights")
     l1_category: str = Field(
         description=(
             "Task first-level category / sector: realestate | food | e_commerce | social | travel. "
             "Use underscore instead of hyphen."
         ),
-        pattern=r"^realestate|food|e_commerce|social|travel$",
+        pattern=r"^(?:realestate|food|e_commerce|social|travel)$",
     )
     l2_category: str | None = Field(
         description=(
@@ -435,13 +435,13 @@ class DatasetItem(BaseModel):
 
     # suggested fields
     suggested_difficulty: str | None = Field(
-        description="Suggested task difficulty: easy | medium | hard", pattern=r"^easy|medium|hard$", default=None
+        description="Suggested task difficulty: easy | medium | hard", pattern=r"^(?:easy|medium|hard)$", default=None
     )
     suggested_hint: str | None = Field(description="Suggested hint", default=None)
     suggested_max_steps: int | None = Field(description="Suggested max steps", default=None)
     suggested_split: str | None = Field(
         description="Suggested split (while the actual split may be different): train | validation | test",
-        pattern=r"^train|validation|test$",
+        pattern=r"^(?:train|validation|test)$",
         default=None,
     )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -9,9 +9,10 @@ import asyncio
 
 import pytest
 from datasets import Value
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from navi_bench.base import (
+    DatasetItem,
     FinalResult,
     all_or_nothing_coverage_result,
     basic_pydantic_to_hf_features,
@@ -163,3 +164,58 @@ class TestBasicPydanticToHfFeatures:
 
         with pytest.raises(ValueError, match="Unexpected field type"):
             basic_pydantic_to_hf_features(Model)
+
+
+def _valid_dataset_item_kwargs(**overrides) -> dict:
+    kwargs = dict(
+        task_id="some_dataset/some_domain/1",
+        task_generation_config_json="{}",
+        env="real",
+        domain="expedia",
+        l1_category="food",
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+class TestDatasetItemEnumPatterns:
+    """DatasetItem's enum-like fields (``env``, ``l1_category``, ``suggested_difficulty``,
+    ``suggested_split``) use a regex ``pattern=`` to restrict values to a fixed set of
+    options. Each pattern used an unanchored alternation, e.g. ``r"^real|sim$"``, which
+    Python's ``re`` parses as ``(^real)|(sim$)`` rather than ``^(?:real|sim)$`` -- so any
+    string merely *starting with* "real" or *ending with* "sim" (not just the exact
+    strings) passed validation. These tests pin that invalid values are now rejected while
+    every legitimate option still validates.
+    """
+
+    def test_env_rejects_value_containing_but_not_equal_to_option(self):
+        with pytest.raises(ValidationError):
+            DatasetItem(**_valid_dataset_item_kwargs(env="realestate"))
+
+    def test_env_accepts_legitimate_values(self):
+        for value in ("real", "sim"):
+            DatasetItem(**_valid_dataset_item_kwargs(env=value))
+
+    def test_l1_category_rejects_value_containing_but_not_equal_to_option(self):
+        with pytest.raises(ValidationError):
+            DatasetItem(**_valid_dataset_item_kwargs(l1_category="xxxfoodxxx"))
+
+    def test_l1_category_accepts_legitimate_values(self):
+        for value in ("realestate", "food", "e_commerce", "social", "travel"):
+            DatasetItem(**_valid_dataset_item_kwargs(l1_category=value))
+
+    def test_suggested_difficulty_rejects_value_containing_but_not_equal_to_option(self):
+        with pytest.raises(ValidationError):
+            DatasetItem(**_valid_dataset_item_kwargs(suggested_difficulty="mediumish"))
+
+    def test_suggested_difficulty_accepts_legitimate_values(self):
+        for value in ("easy", "medium", "hard"):
+            DatasetItem(**_valid_dataset_item_kwargs(suggested_difficulty=value))
+
+    def test_suggested_split_rejects_value_containing_but_not_equal_to_option(self):
+        with pytest.raises(ValidationError):
+            DatasetItem(**_valid_dataset_item_kwargs(suggested_split="train2"))
+
+    def test_suggested_split_accepts_legitimate_values(self):
+        for value in ("train", "validation", "test"):
+            DatasetItem(**_valid_dataset_item_kwargs(suggested_split=value))


### PR DESCRIPTION
## Issue

`DatasetItem`'s four enum-like fields (`env`, `l1_category`, `suggested_difficulty`, `suggested_split`) validate with a Pydantic `Field(pattern=...)` regex written as an unanchored alternation, e.g.:

```python
env: str = Field(description="Environment: real | sim", pattern=r"^real|sim$")
```

Python's `re` parses `^real|sim$` as `(^real)|(sim$)`, not `^(?:real|sim)$` — the anchors only bind to the first/last alternative, not the whole group. So any value merely *starting with* `"real"` (e.g. `"realestate"`) or *ending with* `"sim"` (e.g. `"xsim"`) passes validation, not just the two intended literal values. Same bug shape in the other three patterns. Confirmed with a standalone repro before the fix:

```
env='realestate' -> OK (bug: passes)
env='xsim'       -> OK (bug: passes)
l1='xxxfoodxxx'  -> OK (bug: passes)
```

## Fix

Wrap each alternation in a non-capturing group so the anchors bind to the whole set of options instead of just the first/last one:

- `r"^real|sim$"` -> `r"^(?:real|sim)$"`
- `r"^realestate|food|e_commerce|social|travel$"` -> `r"^(?:realestate|food|e_commerce|social|travel)$"`
- `r"^easy|medium|hard$"` -> `r"^(?:easy|medium|hard)$"`
- `r"^train|validation|test$"` -> `r"^(?:train|validation|test)$"`

## Why this is safe

- Purely a validation-tightening bug fix, not a behavior/feature change — every legitimate literal value (`"real"`, `"sim"`, `"food"`, `"easy"`, `"train"`, etc.) still validates identically before and after.
- All real call sites in this repo already construct `DatasetItem` with exact valid values, so nothing that currently passes CI/tests relied on the loose matching.
- Added `TestDatasetItemEnumPatterns` to `tests/test_base.py`, characterizing both the rejection of near-miss strings (`"realestate"` for `env`, `"xxxfoodxxx"` for `l1_category`, `"mediumish"` for `suggested_difficulty`, `"train2"` for `suggested_split`) and continued acceptance of every legitimate option.
- Full suite: 444 passed (26 in `test_base.py`, 8 new), no regressions.
- Diff is 4 one-line regex edits in `navi_bench/base.py` plus additive tests — reviewable directly from the diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_011ADHxNugRkbZvoCTbf4EhJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only tightening; legitimate values unchanged and existing callers already use exact literals.
> 
> **Overview**
> **Tightens `DatasetItem` validation** so enum-like metadata fields only accept exact allowed literals, not partial matches.
> 
> Four `Field(pattern=...)` regexes on `env`, `l1_category`, `suggested_difficulty`, and `suggested_split` used alternations like `^real|sim$`, which Python treats as `(^real)|(sim$)`—so values such as `"realestate"` for `env` or `"train2"` for `suggested_split` incorrectly passed. Each pattern is now wrapped as `^(?:...)$` so start/end anchors apply to the full value.
> 
> Adds `TestDatasetItemEnumPatterns` in `tests/test_base.py` to reject near-miss strings and confirm every legitimate option still validates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6a7f147908190a6e854e597889cb95bc574d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->