### PR TITLE
refactor(opentable): extract findFirstVisibleValue for duplicated timeSlots lookup

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.js
+++ b/navi_bench/opentable/opentable_info_gathering.js
@@ -297,6 +297,23 @@
         return value;
     };
 
+    // Scan `container` for elements matching `selector` and return the value derived (via
+    // `extract`, default: the raw element) from the FIRST visible match, stopping as soon as one
+    // is found, or null if none are visible. Extracted because
+    // handleRestaurantPageWithFullAvailabilityPopup and handleRestaurantPage each repeated this
+    // identical "querySelectorAll -> for...of -> if isVisible, capture and break" loop for their
+    // `timeSlots` lookup, differing only in the container and how the matched element's value was
+    // derived. This is the "first-visible-with-break" pattern the extractVisibleValue comment
+    // above calls out as deliberately different (last-visible-wins, no break) and left untouched.
+    const findFirstVisibleValue = (container, selector, extract = (el) => el) => {
+        for (const el of container.querySelectorAll(selector)) {
+            if (isVisible(el)) {
+                return extract(el);
+            }
+        }
+        return null;
+    };
+
     // Scan `root` for the visible party-size/date/time picker-overlay elements and return
     // their raw text content. Extracted because handleSearchPage, handleBookingRestrefPage,
     // and handleRestaurantPage's dropdown-menu branch each repeated this identical
@@ -553,14 +570,7 @@
         );
         const baseDate = extractVisibleValue(popup, '.sEh3MIECg10-', (el) => parseDateAndTimes(el.textContent).date);
 
-        let timeSlots = null;
-        const elements = popup.querySelectorAll('[data-test="time-slots"]');
-        for (const el of elements) {
-            if (isVisible(el)) {
-                timeSlots = el;
-                break;
-            }
-        }
+        const timeSlots = findFirstVisibleValue(popup, '[data-test="time-slots"]');
 
         if (timeSlots && timeSlots.textContent.includes("no online availability on the selected day")) {
             pushRangeResult(restaurantName, partySize, baseDate, "00:00:00", getNextDate(baseDate), "00:00:00", "unavailable");
@@ -667,14 +677,7 @@
             ({ baseDate, baseTime } = normalizeBaseDateTime(baseDate, baseTime));
         }
 
-        let timeSlots = null;
-        const elements = reservationPanel.querySelectorAll('[data-test="time-slots"]');
-        for (const el of elements) {
-            if (isVisible(el)) {
-                timeSlots = el.textContent;
-                break;
-            }
-        }
+        const timeSlots = findFirstVisibleValue(reservationPanel, '[data-test="time-slots"]', (el) => el.textContent);
 
         if (timeSlots && (timeSlots.includes("no online availability") || timeSlots.includes("Unfortunately"))) {
             pushSlotResult(restaurantName, partySize, baseDate, baseTime, timeSlots);


### PR DESCRIPTION
## Issue

`navi_bench/opentable/opentable_info_gathering.js` had the same "first-visible-element" lookup hand-rolled twice:

- `handleRestaurantPageWithFullAvailabilityPopup` (around what is now line ~570): loops `popup.querySelectorAll('[data-test="time-slots"]')`, breaks on the first `isVisible(el)` match, capturing the **element**.
- `handleRestaurantPage` (around what is now line ~677): the identical loop over `reservationPanel.querySelectorAll('[data-test="time-slots"]')`, breaking on the first visible match, but capturing `el.textContent` instead.

Both are the same "querySelectorAll -> for...of -> if isVisible, capture and break" control flow, differing only in the container searched and what's captured from the matched element. This exact "first-visible-with-break" pattern was previously *noticed but deliberately left untouched* in a comment on the neighboring `extractVisibleValue` helper (which implements the different last-visible-wins/no-break semantics used by 11 other call sites in the same file) — so this closes out that explicitly-flagged gap.

## Improvement

Extracted `findFirstVisibleValue(container, selector, extract = (el) => el)`, mirroring the existing `extractVisibleValue` helper's `extract`-callback convention already established in this file. Both call sites now delegate:

```js
const timeSlots = findFirstVisibleValue(popup, '[data-test="time-slots"]');
// ...
const timeSlots = findFirstVisibleValue(reservationPanel, '[data-test="time-slots"]', (el) => el.textContent);
```

No logic change — `timeSlots` was never reassigned after the original loops, so switching `let` -> `const` is also safe.

## Safety / Verification

- `node --check navi_bench/opentable/opentable_info_gathering.js` passes.
- Wrote a standalone Node smoke test reproducing both original inline loops verbatim alongside the new helper, and compared outputs across 5 scenarios (no elements, no visible elements, first-visible, second-only-visible, single visible element) — all matched, including exact element-reference identity for the popup call site (not just equal `textContent`).
- Full local `pytest tests/`: 452/452 passed (unchanged from baseline; this diff touches only JS).
- `ruff check .`: clean. `ruff format --check .`: only the same 2 pre-existing, unrelated baseline failures (`evaluation/eval_n1.py`, `navi_bench/dates.py`), confirmed via `git stash` against `main`.
- Single file changed, no behavior change, no new dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9FSJcSXAybh3sveLY8huU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication in bench scraping JS with equivalent first-visible semantics; no auth, data, or API surface changes.
> 
> **Overview**
> Adds **`findFirstVisibleValue`**, a small DOM helper that returns the first visible match for a selector (optional `extract` callback), complementing the existing last-visible **`extractVisibleValue`** helper.
> 
> **`handleRestaurantPageWithFullAvailabilityPopup`** and **`handleRestaurantPage`** now use it for their `[data-test="time-slots"]` lookups instead of duplicating the same `querySelectorAll` → `isVisible` → break loop. One call site still needs the DOM element; the other uses `el.textContent` via `extract`.
> 
> No intended behavior change; `timeSlots` assignments are now `const`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d65818a50c709323d118be7575a9dcb9bd0edf8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->