### PR TITLE
test: dedupe identical _run(coro) asyncio helper into tests/conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Shared pytest fixtures and helpers for the navi-bench test suite."""
+
+import asyncio
+
+
+def run_async(coro):
+    """Run an async coroutine to completion and return its result.
+
+    Shared by the domain-matcher characterization tests (apartments, craigslist,
+    google_flights), which otherwise each defined an identical local ``_run`` helper.
+    """
+    return asyncio.run(coro)

--- a/tests/test_apartments_url_match.py
+++ b/tests/test_apartments_url_match.py
@@ -11,13 +11,9 @@ no direct test coverage of ``update``/``compute`` at all, only of the ``_normali
 helper they call internally.
 """
 
-import asyncio
+from conftest import run_async as _run
 
 from navi_bench.apartments.apartments_url_match import ApartmentsUrlMatch
-
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def _normalize(url: str) -> str:

--- a/tests/test_craigslist_url_match.py
+++ b/tests/test_craigslist_url_match.py
@@ -8,13 +8,9 @@ covered, where a group counts as covered if any one of its alternatives (inner l
 matched by some visited URL.
 """
 
-import asyncio
+from conftest import run_async as _run
 
 from navi_bench.craigslist.craigslist_url_match import CraigslistUrlMatch
-
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 class TestParseState:

--- a/tests/test_google_flights_search_match.py
+++ b/tests/test_google_flights_search_match.py
@@ -10,10 +10,10 @@ decoding and its guard clauses, ``_create_base_info``'s dict-to-``Info`` constru
 direct/indexed placeholder substitution, and ``generate_task_config``'s end-to-end wiring.
 """
 
-import asyncio
 import base64
 
 import pytest
+from conftest import run_async as _run
 
 from navi_bench.google_flights import google_flights_pb2 as gf
 from navi_bench.google_flights.google_flights_pb2 import Info
@@ -21,10 +21,6 @@ from navi_bench.google_flights.google_flights_search_match import (
     GoogleFlightsSearchMatch,
     resolve_date_references,
 )
-
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def _encode_tfs(info: Info) -> str:


### PR DESCRIPTION
## What

`tests/test_apartments_url_match.py`, `tests/test_craigslist_url_match.py`, and
`tests/test_google_flights_search_match.py` each independently defined a byte-identical
helper:

```python
def _run(coro):
    return asyncio.run(coro)
```

plus an `import asyncio` used solely to support it. This is extracted once as `run_async`
in a new `tests/conftest.py`, and each file now does `from conftest import run_async as _run`
instead — call sites (`_run(...)`) are unchanged everywhere.

## Why this is an improvement

Three copies of the same trivial wrapper is unnecessary duplication that a shared test
helper removes cleanly. `tests/` has no `pytest.ini`/`[tool.pytest.ini_options]` config and
no `__init__.py`, so pytest's default "prepend" import mode puts `tests/` on `sys.path`,
making the plain `from conftest import ...` import work without any package-layout changes.

## Why this is safe

No behavioral change — verified by existing tests:
- `pytest tests/test_apartments_url_match.py tests/test_craigslist_url_match.py tests/test_google_flights_search_match.py -v` passes all 54 tests, identically before and after this change (confirmed by running against both the pre-change and post-change tree).
- Full suite `pytest tests/` passes 311/311 collectible tests (the 3 files that fail to collect — `test_eval_n1.py`, `test_recorder.py`, `test_vis.py` — fail identically before this change too, due to an unrelated missing internal `yutori` package dependency in this sandbox, not anything touched here).
- `ruff check` and `ruff format --check` are clean on all touched/added files.

Scope: 4 files touched (1 new, 3 modified), test-only, no production code paths affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F4EtW84K6f17EFiyyaNL3x)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code touched; behavior should be identical because the helper is the same `asyncio.run` wrapper.
> 
> **Overview**
> Consolidates three identical `asyncio.run` wrappers in the apartments, craigslist, and google flights matcher tests into a single **`run_async`** helper in new **`tests/conftest.py`**.
> 
> Each of those files now uses `from conftest import run_async as _run` and drops its local `_run` plus the `asyncio` import that existed only for that helper. **`_run(...)` call sites are unchanged**, so this is a test-only deduplication with no intended behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc8f5a2ad073855a33c8dcb0533ac3d1774801ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->