### PR TITLE
test: dedupe remaining asyncio.run(coro) call sites onto conftest.run_async

### DIFF
--- a/tests/test_opentable_info_gathering.py
+++ b/tests/test_opentable_info_gathering.py
@@ -9,10 +9,10 @@ shared branch logic can be verified as behavior-preserving without hand-tracing 
 from scratch.
 """
 
-import asyncio
 from datetime import datetime, timezone
 
 import pytest
+from conftest import run_async as _run
 
 from navi_bench.opentable.opentable_info_gathering import (
     DATE_OPTIONS,
@@ -297,7 +297,7 @@ class TestSkipsAlreadyCoveredQueries:
         gathering._is_query_covered[0] = True  # simulate already covered by a prior update()
 
         info = _info(info=_PLAIN_UNAVAILABLE_INFO, date="2025-07-10", time="19:00:00")
-        asyncio.run(gathering.update(page=_FakePage([info])))
+        _run(gathering.update(page=_FakePage([info])))
 
         # Query 0 was skipped entirely: no evidence recorded despite matching date/time.
         assert gathering._unavailable_evidences[0][0] == []
@@ -316,7 +316,7 @@ class TestSkipsAlreadyCoveredQueries:
             _info(date="2025-07-10", time="19:00:00", info=_PLAIN_UNAVAILABLE_INFO)
         ]
 
-        result = asyncio.run(gathering.compute())
+        result = _run(gathering.compute())
 
         assert gathering._is_query_covered == [True, True]
         assert result.n_covered == 2

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -14,15 +14,15 @@ strict URL match, the "no availability" relaxed-matching mode, and the condition
 branch (``_evaluate_condition``) used when the time slot differs but everything else about
 the URL matches. This is navi-bench's largest and most conditionally complex domain matcher,
 and previously had no direct test coverage of these methods at all (only the placeholder
-helpers above were tested). The ``_FakePage``/``asyncio.run`` approach mirrors the existing
+helpers above were tested). The ``_FakePage``/``run_async`` approach mirrors the existing
 precedent for exercising an async ``update()`` without a real browser, established for
 ``OpenTableInfoGathering.update`` in ``test_opentable_info_gathering.py``.
 """
 
-import asyncio
 from datetime import date
 
 import pytest
+from conftest import run_async as _run
 
 from navi_bench.resy import resy_url_match
 from navi_bench.resy.resy_url_match import (
@@ -422,7 +422,7 @@ _GT_URL = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&se
 
 
 def _run_update(match: ResyUrlMatch, *, url: str, has_no_availability: bool, availabilities: list[dict]) -> None:
-    asyncio.run(match.update(url=url, page=_FakePage([has_no_availability, availabilities])))
+    _run(match.update(url=url, page=_FakePage([has_no_availability, availabilities])))
 
 
 class TestUpdateStrictAndRelaxedMatch:
@@ -529,7 +529,7 @@ class TestCompute:
         match = ResyUrlMatch(queries=[[_GT_URL], [_GT_URL]])
         match._is_query_covered = [True, True]
 
-        result = asyncio.run(match.compute())
+        result = _run(match.compute())
 
         assert result.score == 1.0
 
@@ -537,6 +537,6 @@ class TestCompute:
         match = ResyUrlMatch(queries=[[_GT_URL], [_GT_URL]])
         match._is_query_covered = [True, False]
 
-        result = asyncio.run(match.compute())
+        result = _run(match.compute())
 
         assert result.score == 0.0


### PR DESCRIPTION
## What

`tests/test_resy_url_match.py` and `tests/test_opentable_info_gathering.py` each imported `asyncio` solely to call `asyncio.run(coro)` inline at their `update()`/`compute()` call sites (3 call sites in the resy file, 2 in the opentable file).

This is the exact same duplication mechanism PR #202 already fixed for `tests/test_apartments_url_match.py`, `tests/test_craigslist_url_match.py`, and `tests/test_google_flights_search_match.py`: each of those files had a byte-identical local `_run(coro): return asyncio.run(coro)` helper, which #202 extracted once into `tests/conftest.py` as `run_async`, imported as `from conftest import run_async as _run`. The resy/opentable files use a slightly different shape (resy wraps it in a local `_run_update` helper; opentable calls `asyncio.run(...)` directly), which is presumably why #202's sweep didn't catch them, but the underlying pattern is identical.

This PR imports `run_async` as `_run` in both files (matching the established convention exactly) and replaces every `asyncio.run(...)` call site with `_run(...)`, dropping the now-unused `import asyncio`.

## Why this is an improvement

- Removes the last two `import asyncio` / inline `asyncio.run(...)` occurrences that exist purely to await a coroutine in a test, completing the sweep #202 started.
- Keeps all coroutine-running test scaffolding in this suite going through one shared helper, so a future change to how tests run async code (e.g. switching to `pytest-asyncio`) only needs to touch `conftest.py`.

## Why this is safe

- Test-only change; no production code touched.
- `run_async` is a direct, unmodified `asyncio.run(coro)` wrapper (see `tests/conftest.py`), so behavior is identical by construction.
- Full suite: 452/452 tests pass, unchanged from before this diff.
- `ruff check` and `ruff format --check` are clean on both touched files (repo-wide `ruff format --check` shows only two pre-existing, unrelated baseline diffs in `evaluation/eval_n1.py` and `navi_bench/dates.py` that predate this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CxQQDVSxijvhZdrUvawQod)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production changes; `run_async` is a thin `asyncio.run` wrapper so behavior is unchanged.
> 
> **Overview**
> Finishes the test-suite sweep started in PR #202 by routing the last inline **`asyncio.run`** call sites through the shared **`conftest.run_async`** helper (imported as **`_run`**).
> 
> In **`test_opentable_info_gathering.py`** and **`test_resy_url_match.py`**, every **`update()`** / **`compute()`** invocation now uses **`_run(...)`** instead of **`asyncio.run(...)`**, and the unused **`import asyncio`** is removed. The Resy module docstring is updated to describe the **`_FakePage`/`run_async`** pattern consistently with the other matcher tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29d08f20472c3fc1f14c2a99c6c7ae97551ae83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->