### PR TITLE
test: dedupe remaining asyncio.run(coro) call sites onto conftest.run_async

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,9 +5,8 @@ the class name baked into the log message). These pin the scoring semantics so t
 helper can be verified as behavior-preserving for both call sites.
 """
 
-import asyncio
-
 import pytest
+from conftest import run_async as _run
 from datasets import Value
 from pydantic import BaseModel, ValidationError
 
@@ -50,14 +49,14 @@ class TestResyUrlMatchComputeUsesSharedHelper:
         metric = ResyUrlMatch(queries=[["https://resy.com/cities/sf/venues/foo?date=2025-07-15&seats=2"]])
         metric._is_query_covered = [True]
 
-        result = asyncio.run(metric.compute())
+        result = _run(metric.compute())
 
         assert result.score == 1.0
 
     def test_uncovered_query_scores_zero(self):
         metric = ResyUrlMatch(queries=[["https://resy.com/cities/sf/venues/foo?date=2025-07-15&seats=2"]])
 
-        result = asyncio.run(metric.compute())
+        result = _run(metric.compute())
 
         assert result.score == 0.0
 
@@ -75,7 +74,7 @@ class TestGoogleFlightsSearchMatchComputeUsesSharedHelper:
     def test_no_matching_url_scores_zero(self):
         metric = GoogleFlightsSearchMatch(gt_info=self._GT_INFO)
 
-        result = asyncio.run(metric.compute())
+        result = _run(metric.compute())
 
         assert result.score == 0.0
 
@@ -85,7 +84,7 @@ class TestGoogleFlightsSearchMatchComputeUsesSharedHelper:
         # resolves to, mirroring what `update()` would store after decoding a matching URL.
         metric._url_to_flight_info["https://www.google.com/travel/flights?tfs=fake"] = metric._gt_base_info[0]
 
-        result = asyncio.run(metric.compute())
+        result = _run(metric.compute())
 
         assert result.score == 1.0
 

--- a/tests/test_custom_task.py
+++ b/tests/test_custom_task.py
@@ -8,8 +8,7 @@ hand-written as a literal string that could drift if the class is renamed or mov
 pins ``CustomTaskCaptureMetric``'s reset/update/compute score semantics.
 """
 
-import asyncio
-
+from conftest import run_async as _run
 from evaluation.custom_task import CustomTaskCaptureMetric, CustomTaskResult, generate_task_config
 from navi_bench.base import UserMetadata
 
@@ -52,31 +51,31 @@ class TestCustomTaskCaptureMetric:
     def test_no_answer_message_scores_zero(self):
         metric = CustomTaskCaptureMetric()
 
-        result = asyncio.run(metric.compute())
+        result = _run(metric.compute())
 
         assert result == CustomTaskResult(score=0.0, final_answer=None)
 
     def test_answer_message_scores_one(self):
         metric = CustomTaskCaptureMetric()
-        asyncio.run(metric.update(answer_message="the final answer"))
+        _run(metric.update(answer_message="the final answer"))
 
-        result = asyncio.run(metric.compute())
+        result = _run(metric.compute())
 
         assert result == CustomTaskResult(score=1.0, final_answer="the final answer")
 
     def test_update_without_answer_message_kwarg_is_a_noop(self):
         metric = CustomTaskCaptureMetric()
-        asyncio.run(metric.update(other_kwarg="ignored"))
+        _run(metric.update(other_kwarg="ignored"))
 
-        result = asyncio.run(metric.compute())
+        result = _run(metric.compute())
 
         assert result == CustomTaskResult(score=0.0, final_answer=None)
 
     def test_reset_clears_previously_captured_answer(self):
         metric = CustomTaskCaptureMetric()
-        asyncio.run(metric.update(answer_message="first"))
-        asyncio.run(metric.reset())
+        _run(metric.update(answer_message="first"))
+        _run(metric.reset())
 
-        result = asyncio.run(metric.compute())
+        result = _run(metric.compute())
 
         assert result == CustomTaskResult(score=0.0, final_answer=None)


### PR DESCRIPTION
## Summary

Daily holistic review of the last 24h of merged commits found that #202 and #203 (both landed today) extracted a shared `run_async()` helper in `tests/conftest.py` and migrated the apartments/craigslist/google_flights/resy/opentable test files off their own `asyncio.run(coro)` call sites — but two files were missed:

- `tests/test_base.py` (`TestResyUrlMatchComputeUsesSharedHelper`, `TestGoogleFlightsSearchMatchComputeUsesSharedHelper`) — 4 direct `asyncio.run(...)` call sites
- `tests/test_custom_task.py` (`TestCustomTaskCaptureMetric`) — 8 direct `asyncio.run(...)` call sites

This pattern was only visible by diffing today's commits against the rest of the test suite, not from either PR in isolation. Both files now `from conftest import run_async as _run` (matching the convention `test_resy_url_match.py`/`test_opentable_info_gathering.py` already use) and call `_run(...)` instead, dropping the now-unused `import asyncio`.

## Test plan

- [x] `uv run pytest -q` — full suite: 452 passed
- [x] `uv run ruff check tests/test_base.py tests/test_custom_task.py` — clean
- [x] `uv run ruff format --check tests/test_base.py tests/test_custom_task.py` — already formatted
- [x] No behavioral change: `run_async` is a straight `asyncio.run(coro)` wrapper, so this is a pure mechanical import + call-site swap

cc @dhruvbatra (sole author/maintainer of this repo's recent commit history, including #202/#203 which this PR completes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9kAtf7Dkyi3m5GCc9Adyx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mechanical import/call-site swap with no production code or semantics change.
> 
> **Overview**
> Completes the test-suite migration started in #202/#203 by routing the last direct **`asyncio.run`** usages through the shared **`conftest.run_async`** helper (imported as **`_run`**).
> 
> **`tests/test_base.py`** and **`tests/test_custom_task.py`** drop **`import asyncio`** and swap **`asyncio.run(...)`** for **`_run(...)`** on metric **`compute`**, **`update`**, and **`reset`** calls—same pattern as the other matcher tests. No production or assertion changes; behavior stays **`asyncio.run`** under the hood.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec482b47e4615d8f9ba6011236332d93bb409f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->