### PR TITLE
test(eval_n1): dedupe stray asyncio.run(coro) call site onto conftest.run_async

### DIFF
--- a/tests/test_eval_n1.py
+++ b/tests/test_eval_n1.py
@@ -19,6 +19,7 @@ import asyncio
 
 import httpx
 import pytest
+from conftest import run_async as _run
 from openai import (
     APIConnectionError,
     APIError,
@@ -146,7 +147,7 @@ class _RaisingItem:
 
 def _run_task(item: _RaisingItem, max_attempts: int = 3):
     config = Config(eval_max_attempts=max_attempts)
-    return asyncio.run(run_task(config, item, None, None, None))
+    return _run(run_task(config, item, None, None, None))
 
 
 class TestRunTaskErrorHandling:


### PR DESCRIPTION
## Day-over-day pattern

Looking at the last few days of merged PRs in this repo (#202, #203, #204, #205, #206), there's a clear, ongoing pattern of test-file cleanup: repeated fakes/helpers introduced independently across test files get swept into one shared `tests/conftest.py` helper. Specifically for `asyncio.run(coro)`:

- #202 extracted `conftest.run_async()` for the apartments/craigslist/google_flights tests.
- #203 migrated the `test_resy_url_match.py`/`test_opentable_info_gathering.py` stragglers.
- #205 migrated the `test_base.py`/`test_custom_task.py` stragglers, calling them "the remaining stragglers."

`tests/test_eval_n1.py` (added in #191, before #202 even introduced `run_async`) was never touched by any of those sweeps and still called `asyncio.run(coro)` directly in `_run_task()` — the exact same duplicated pattern the prior three PRs were cleaning up elsewhere.

## The fix

- Import `run_async as _run` from `conftest` (matching the established convention in every other migrated file).
- Replace the one `asyncio.run(...)` call site with `_run(...)`.
- Keep the top-level `import asyncio`, since this file also uses `asyncio.TimeoutError()` elsewhere (unlike the other migrated files, which could drop the import entirely).

No behavior change: `run_async` is a straight `asyncio.run(coro)` wrapper. All 452 tests pass identically before and after, and `ruff check`/`ruff format --check` are clean on the touched file.

## Test plan

- [x] `python3 -m pytest tests/` — 452 passed (same count as before the change)
- [x] `python3 -m ruff check tests/test_eval_n1.py` — clean
- [x] `python3 -m ruff format --check tests/test_eval_n1.py` — already formatted

cc @dhruvbatra — you authored #191 (which introduced this call site) and #202/#203/#205 (the run_async migration sweeps), so flagging this straggler your way.

---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production or eval logic changes; `run_async` preserves the same asyncio execution semantics.
>
> **Overview**
> Continues the test-suite cleanup of direct `asyncio.run` call sites by routing `_run_task()` in `tests/test_eval_n1.py` through the shared `conftest.run_async` helper (imported as `_run`), matching other migrated tests.
>
> The top-level `import asyncio` stays because this file still constructs `asyncio.TimeoutError()` in fixtures; behavior is unchanged because `run_async` is a thin `asyncio.run` wrapper.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 355183136234b03d2fc1dbbae9b831b5e0147a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
