### PR TITLE
docs(tests): make run_async docstring consumer-agnostic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ import asyncio
 def run_async(coro):
     """Run an async coroutine to completion and return its result.
 
-    Shared by the domain-matcher characterization tests (apartments, craigslist,
-    google_flights), which otherwise each defined an identical local ``_run`` helper.
+    Shared across the test suite so individual test modules don't each redefine
+    an identical local ``_run`` helper.
     """
     return asyncio.run(coro)
 


### PR DESCRIPTION
## What

Rewrites the `run_async()` docstring in `tests/conftest.py` so it no longer enumerates a fixed list of consumers.

## Why

The docstring claimed the helper was "Shared by the domain-matcher characterization tests (apartments, craigslist, google_flights)", but `run_async()` has since been adopted by many more test modules (resy, opentable, base, custom_task, and most recently `test_eval_n1.py`). Each new call site that adopts the helper makes that enumerated list staler. Describing the helper's purpose without naming specific consumers keeps the docstring accurate as usage grows.

## Change

Docstring-only edit — no behavior change.

Before:
> Shared by the domain-matcher characterization tests (apartments, craigslist, google_flights), which otherwise each defined an identical local `_run` helper.

After:
> Shared across the test suite so individual test modules don't each redefine an identical local `_run` helper.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjFPHnroPqfgdjqCiJYayg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code or test logic modified.
> 
> **Overview**
> **Docstring-only** update to `run_async()` in `tests/conftest.py`.
> 
> The helper’s description no longer names specific test modules (apartments, craigslist, google_flights). It now states that the function is shared suite-wide so modules avoid duplicating a local `_run` helper—keeping the comment accurate as more tests import it.
> 
> **No runtime or test behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92636e91920e5446fbc7548b72e5849debdeb035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->