### PR TITLE
refactor(dataset): drop no-op nonlocal on _per_domain_counter

### DIFF
--- a/evaluation/dataset.py
+++ b/evaluation/dataset.py
@@ -63,7 +63,6 @@ async def build_dataset(config: DatasetBuildConfig) -> list[DatasetItem]:
         if config.dataset_include_task_ids and item["task_id"] not in config.dataset_include_task_ids:
             return False
 
-        nonlocal _per_domain_counter
         _per_domain_counter[item["domain"]] += 1
         if (
             config.dataset_max_samples_per_domain


### PR DESCRIPTION
## Summary

Removes a dead, misleading `nonlocal` declaration in `build_dataset`'s nested `_sample_fn` (`evaluation/dataset.py`).

`_per_domain_counter` is a `defaultdict(int)` bound in the enclosing scope. Inside `_sample_fn` it is only ever **mutated in place** (`_per_domain_counter[item["domain"]] += 1`) and **read** — the name itself is never rebound. Python only requires a `nonlocal` declaration to *rebind* a closed-over name; mutating a mutable object through it does not. So `nonlocal _per_domain_counter` was a no-op.

It was also actively misleading: the sibling `nonlocal _overall_counter` a few lines below **is** required, because `_overall_counter += 1` rebinds an `int` (immutable). Keeping the unnecessary declaration on the dict falsely implied that name gets reassigned too.

## Verification

- The change is purely a one-line deletion; behavior is unchanged.
- `pyflakes` flagged the line before the change (`` `nonlocal _per_domain_counter` is unused: name is never assigned in scope ``) and reports the file clean afterward.
- File still parses; no other references affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEoaLfVSmX8Xji6h4MJQjs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line cleanup with no logic changes; pyflakes/static checks only.
> 
> **Overview**
> Removes the unused `nonlocal _per_domain_counter` inside `_sample_fn` in `build_dataset` (`evaluation/dataset.py`). That counter is only mutated in place on the shared `defaultdict`, so the declaration was unnecessary and could confuse readers next to the still-required `nonlocal _overall_counter` (integer `+=` rebinds).
> 
> **No runtime behavior change** — sampling and domain/overall limits work the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f74e761427d9fb2862938aaf034fd2de416c212b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->