### PR TITLE
chore(pyproject): remove dead [tool.isort]/[tool.black] config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["navi_bench"]
 
-[tool.isort]
-profile = "black"
-
-[tool.black]
-line-length = 120
-
 [tool.ruff]
 line-length = 120
 


### PR DESCRIPTION
## What

Removes the stale `[tool.isort]` and `[tool.black]` tables from `pyproject.toml`.

## Why

This repo formats and lints exclusively through Ruff:
- `[tool.ruff]` / `[tool.ruff.format]` already pin `line-length = 120` and `quote-style = "double"`.
- `[tool.ruff.lint.isort]` already owns import sorting (`known-first-party`, `combine-as-imports`, `lines-after-imports`).

There is no pre-commit config, CI workflow, Makefile target, or doc anywhere in this repo that invokes `black` or `isort` directly — a full-tree grep for `black`/`isort` turns up nothing but these two now-removed sections (plus an unrelated CSS `color: 'black'` string in a JS asset).

Leaving dead config like this around risks becoming a second, driftable source of truth (e.g. `[tool.black]`'s `line-length` silently diverging from `[tool.ruff]`'s if one gets edited and not the other), and could mislead a contributor into running `black`/`isort` locally expecting them to matter.

## Safety

- Config-only change; no Python source touched, no behavior change.
- `pytest tests/` — 452 passed, 0 failed (full suite, verified after the change).
- Diff is a single 6-line deletion in `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01A9ETmmxkC83sHXKUfe9DJt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only deletion with no Python or runtime behavior changes.
> 
> **Overview**
> Removes unused **`[tool.isort]`** and **`[tool.black]`** blocks from **`pyproject.toml`**, so formatting and import-sorting settings live only under **Ruff** (`[tool.ruff]`, `[tool.ruff.format]`, `[tool.ruff.lint.isort]`).
> 
> This avoids a second, unused config that could drift from Ruff (e.g. duplicate `line-length`) or suggest contributors should run Black/isort when the project does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e366a0da7355ed89f1b9f493b0e85abad3100f01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->