### PR TITLE
refactor(apartments): mark self-unused url-parsing helpers as staticmethod

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -96,7 +96,8 @@ class ApartmentsUrlMatch(ResetsViaState):
         logger.info(f"ApartmentsUrlMatch.compute result: {result}")
         return result
 
-    def _is_location_part(self, part: str) -> bool:
+    @staticmethod
+    def _is_location_part(part: str) -> bool:
         """Check if a URL part represents a location (neighborhood-city-state format)."""
         if not part or "-" not in part:
             return False
@@ -105,7 +106,8 @@ class ApartmentsUrlMatch(ResetsViaState):
             any(part.endswith(f"-{state}") for state in _STATE_ABBREVIATIONS) or len(part.split("-")[-1]) == 2
         )  # area_city_state format
 
-    def _normalize_apartment_features(self, part: str) -> str:
+    @staticmethod
+    def _normalize_apartment_features(part: str) -> str:
         """Normalize apartment features by sorting them alphabetically."""
         # Check if this part contains any apartment features
         if not any(feature in part for feature in _APARTMENT_FEATURES):
@@ -129,24 +131,26 @@ class ApartmentsUrlMatch(ResetsViaState):
         all_parts = non_features + found_features
         return "-".join(p for p in all_parts if p)
 
-    def _extract_locations_from_path(self, path_parts: list[str]) -> tuple[set[str], list[str]]:
+    @staticmethod
+    def _extract_locations_from_path(path_parts: list[str]) -> tuple[set[str], list[str]]:
         """Extract locations from URL path parts and return (locations, non_location_parts)."""
         locations = set()
         non_location_parts = []
 
         for part in path_parts:
-            if self._is_location_part(part):
+            if ApartmentsUrlMatch._is_location_part(part):
                 # Replace underscores with hyphens for consistency
                 location = part.replace("_", "-")
                 locations.add(location)
             else:
                 # Normalize apartment features if present
-                normalized_part = self._normalize_apartment_features(part)
+                normalized_part = ApartmentsUrlMatch._normalize_apartment_features(part)
                 non_location_parts.append(normalized_part)
 
         return locations, non_location_parts
 
-    def _extract_locations_from_query(self, query_params: dict) -> tuple[set[str], dict]:
+    @staticmethod
+    def _extract_locations_from_query(query_params: dict) -> tuple[set[str], dict]:
         """Extract locations from query parameters and return (locations, normalized_params)."""
         locations = set()
         normalized_params = {}


### PR DESCRIPTION
## What

`ApartmentsUrlMatch._is_location_part`, `_normalize_apartment_features`, `_extract_locations_from_path`, and `_extract_locations_from_query` never read or write instance state (`self.gt_urls`, `self._found_match`) — they're pure string/URL-parsing helpers that only happened to be declared as instance methods.

## Why

`ApartmentsUrlMatch` does have real instance state elsewhere (`self.gt_urls`, `self._found_match`), so leaving these mixed in with the stateful methods makes it harder to tell, at a glance, which methods actually matter for the object's identity. Declaring them `@staticmethod` documents that they're pure functions of their arguments.

## Why it's safe

- No behavioral change: existing call sites invoke them via `self.<method>(...)` (valid and identical for staticmethods) or, for the two calls now inside another staticmethod (`_extract_locations_from_path` calling `_is_location_part`/`_normalize_apartment_features`), via the class name `ApartmentsUrlMatch.<method>(...)`.
- No other file in the repo calls any of these methods (verified via grep).
- Ran the full existing test suite for this class: `tests/test_apartments_url_match.py` — 16 passed, 0 failed.
- `ruff check` / `ruff format --check` both pass on the changed file.

## Test plan

- [x] `pytest tests/test_apartments_url_match.py` — 16 passed
- [x] `ruff check` / `ruff format --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFasw3WKyQ97qtxnUaRSU8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to method binding; URL matching logic is unchanged and scoped to one file.
> 
> **Overview**
> Marks four **pure** URL parsing helpers on `ApartmentsUrlMatch`—`_is_location_part`, `_normalize_apartment_features`, `_extract_locations_from_path`, and `_extract_locations_from_query`—as `@staticmethod` so they are clearly separated from stateful methods that use `gt_urls` and `_found_match`.
> 
> Inside `_extract_locations_from_path`, calls to the other helpers now use `ApartmentsUrlMatch.<method>(...)` instead of `self.<method>(...)`. `_normalize_url` still invokes the extract helpers via `self`, which remains valid for staticmethods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db735d3285d26de4e7690b24a391b630b3e752d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->