### PR TITLE
refactor(vis): extract _join_text_and_tool_calls for duplicated response formatting

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -285,6 +285,18 @@ def _render_stop_action_card(step_num: int, label: str, answer: str) -> str:
 """
 
 
+def _join_text_and_tool_calls(text: str, tool_call_lines: list[str]) -> str:
+    """Join assistant text with a "Tool calls:\\n<...>" block, blank-line separated when both are present.
+
+    Shared tail of ``generate_visualization_html``'s Anthropic (``tool_uses``) and OpenAI
+    (``msg["tool_calls"]``) branches, which each independently built the same
+    ``"<text>\\n\\nTool calls:\\n<summary>"`` (or, with no ``text``, bare ``"Tool calls:\\n<summary>"``)
+    combination from their own list of per-call summary lines.
+    """
+    tool_calls_block = "Tool calls:\n" + "\n".join(tool_call_lines)
+    return f"{text}\n\n{tool_calls_block}" if text else tool_calls_block
+
+
 def _render_response_section(label: str, content_html: str, *, collapsed: bool = False) -> str:
     """Render a per-step collapsible ``.response-section`` block (Actions / Text Observations / Raw Response)."""
     collapsed_class = _collapsed_class(collapsed)
@@ -409,9 +421,6 @@ def generate_visualization_html(
                 display_response = assistant_content
             elif isinstance(assistant_content, list):
                 # Anthropic format - show text and summarize tool uses
-                display_parts = []
-                if assistant_text:
-                    display_parts.append(assistant_text)
                 tool_uses = [b for b in assistant_content if _block_type(b) == "tool_use"]
                 if tool_uses:
                     tool_summary = []
@@ -432,9 +441,9 @@ def generate_visualization_html(
                                 tool_summary.append(f"{action_name}()")
                         else:
                             tool_summary.append(f"{name}({json.dumps(inp)})")
-                    display_parts.append("Tool calls:\n" + "\n".join(tool_summary))
-                if display_parts:
-                    display_response = "\n\n".join(display_parts)
+                    display_response = _join_text_and_tool_calls(assistant_text, tool_summary)
+                elif assistant_text:
+                    display_response = assistant_text
                 else:
                     display_response = json.dumps(assistant_content, indent=2)
             else:
@@ -446,10 +455,7 @@ def generate_visualization_html(
                 for tc in msg["tool_calls"]:
                     func = tc.get("function", {})
                     tool_calls_summary.append(f"{func.get('name', 'unknown')}({func.get('arguments', '{}')})")
-                if assistant_text:
-                    display_response = f"{assistant_text}\n\nTool calls:\n" + "\n".join(tool_calls_summary)
-                else:
-                    display_response = "Tool calls:\n" + "\n".join(tool_calls_summary)
+                display_response = _join_text_and_tool_calls(assistant_text, tool_calls_summary)
 
             steps.append(
                 {

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -12,12 +12,14 @@ so future changes to the shared field-check logic can be verified as behavior-pr
 
 import json
 import re
+from html import unescape
 
 from evaluation.vis import (
     generate_visualization_html,
     _block_field,
     _block_type,
     _get_action_marker_style,
+    _join_text_and_tool_calls,
     _render_response_section,
     _render_section,
     _ACTION_COLOR_CLASSES,
@@ -368,6 +370,96 @@ class TestRenderResponseSection:
         html = _render_response_section("Raw Response", "<pre>hi</pre>", collapsed=True)
         assert '<div class="response-section collapsed">' in html
         assert "<span>▼</span> Raw Response" in html
+
+
+class TestJoinTextAndToolCalls:
+    """Characterization tests for ``_join_text_and_tool_calls``, extracted from two
+    independently-written but identically-shaped "assistant text + Tool calls: block"
+    assembly sites in ``generate_visualization_html`` (the Anthropic ``tool_uses`` branch
+    and the OpenAI ``msg["tool_calls"]`` branch).
+    """
+
+    def test_with_text_joins_with_blank_line(self):
+        assert _join_text_and_tool_calls("hello", ["click()"]) == "hello\n\nTool calls:\nclick()"
+
+    def test_without_text_is_bare_tool_calls_block(self):
+        assert _join_text_and_tool_calls("", ["click()"]) == "Tool calls:\nclick()"
+
+    def test_multiple_tool_call_lines(self):
+        assert _join_text_and_tool_calls("", ["a()", "b()"]) == "Tool calls:\na()\nb()"
+
+
+def _messages_with_anthropic_tool_use(text: str | None, name: str = "left_click", tool_input: dict | None = None):
+    """Assistant message using Anthropic's content-block format: an optional leading
+    ``text`` block followed by a ``tool_use`` block."""
+    content = []
+    if text is not None:
+        content.append({"type": "text", "text": text})
+    content.append({"type": "tool_use", "name": name, "input": tool_input or {}})
+    return [
+        {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+        {"role": "assistant", "content": content},
+    ]
+
+
+def _messages_with_openai_tool_calls(text: str | None, name: str = "left_click", arguments: str = "{}"):
+    """Assistant message using OpenAI's ``tool_calls`` format, with ``content`` as the
+    (possibly ``None``) plain-text portion of the message."""
+    return [
+        {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+        {
+            "role": "assistant",
+            "content": text,
+            "tool_calls": [{"id": "t1", "type": "function", "function": {"name": name, "arguments": arguments}}],
+        },
+    ]
+
+
+def _raw_response_text(html: str) -> str:
+    """Extract the ``Raw Response`` section's ``<pre>`` content from rendered HTML."""
+    match = re.search(
+        r'<span>▼</span> Raw Response\s*</div>\s*<div class="response-section-content">\s*'
+        r"<pre>(.*?)</pre>",
+        html,
+        re.S,
+    )
+    assert match is not None, html
+    return unescape(match.group(1))
+
+
+class TestAssistantResponseToolCallSummary:
+    """End-to-end characterization of the "Raw Response" text ``generate_visualization_html``
+    builds for assistant messages that use tool calls, covering both the Anthropic
+    (``tool_uses`` content blocks) and OpenAI (``msg["tool_calls"]``) formats this function
+    supports, each with and without accompanying assistant text. Pins the exact behavior
+    before/after both branches were made to delegate to ``_join_text_and_tool_calls``.
+    """
+
+    def test_anthropic_tool_use_with_text(self):
+        html = generate_visualization_html("task1", _messages_with_anthropic_tool_use("looking at the page"), None)
+        assert _raw_response_text(html) == "looking at the page\n\nTool calls:\nleft_click({})"
+
+    def test_anthropic_tool_use_without_text(self):
+        html = generate_visualization_html("task1", _messages_with_anthropic_tool_use(None), None)
+        assert _raw_response_text(html) == "Tool calls:\nleft_click({})"
+
+    def test_anthropic_tool_use_with_params(self):
+        html = generate_visualization_html(
+            "task1", _messages_with_anthropic_tool_use(None, name="type", tool_input={"text": "hi"}), None
+        )
+        assert _raw_response_text(html) == 'Tool calls:\ntype({"text": "hi"})'
+
+    def test_openai_tool_calls_with_text(self):
+        html = generate_visualization_html(
+            "task1", _messages_with_openai_tool_calls("looking at the page", arguments='{"ref": "e1"}'), None
+        )
+        assert _raw_response_text(html) == 'looking at the page\n\nTool calls:\nleft_click({"ref": "e1"})'
+
+    def test_openai_tool_calls_without_text(self):
+        html = generate_visualization_html(
+            "task1", _messages_with_openai_tool_calls(None, arguments='{"ref": "e1"}'), None
+        )
+        assert _raw_response_text(html) == 'Tool calls:\nleft_click({"ref": "e1"})'
 
 
 def _messages_with_final_answer(text: str | None) -> list[dict]:


### PR DESCRIPTION
## What

`generate_visualization_html`'s Anthropic (`tool_uses` content-block) and OpenAI (`msg["tool_calls"]`) branches each independently built the identical `"<text>\n\nTool calls:\n<summary>"` (or, with no text, bare `"Tool calls:\n<summary>"`) combination from their own list of per-call summary lines. Extracted a shared `_join_text_and_tool_calls(text, tool_call_lines)` helper; both branches now delegate to it. The Anthropic branch's now-redundant `display_parts` list-building also collapses into a plain if/elif/else, since the `tool_uses` case was the only one that ever used the list-join tail.

## Why

Same "duplicated block, parameterize the one thing that differs" pattern this file already applies repeatedly (`_render_section`, `_render_response_section`, `_render_stop_action_card`, `_first_present`) — just not yet applied to this particular formatting tail. A future change to how assistant text and tool-call summaries are joined (e.g. tweaking the separator) previously had to be made in two places that could silently drift; now there's one.

## Why it's safe

- Debug/visualization output only — no production behavior depends on this HTML.
- Verified behavior-preservation two ways:
  1. A hand-derived case analysis (present/absent `text` × present/absent `tool_uses`) showing the new if/elif/else is exactly equivalent to the old `display_parts`-list-then-join logic for all four cases.
  2. A direct comparison against the pre-refactor implementation loaded from `git show HEAD:evaluation/vis.py` across 5 representative message shapes (Anthropic with/without text, Anthropic with tool params, OpenAI with/without text) — all byte-identical to the post-refactor output.
- This formatting path (`Raw Response` text for tool-call-bearing assistant messages) had **zero prior direct test coverage** — added `tests/test_vis.py::TestJoinTextAndToolCalls` (3 unit tests on the new helper) and `TestAssistantResponseToolCallSummary` (5 end-to-end tests covering both formats × with/without text), 8 new tests total.
- `ruff check` clean on both touched files; `ruff format --check` shows only the 2 pre-existing, unrelated baseline issues already tracked on `main` (`evaluation/eval_n1.py`, `navi_bench/dates.py`).

## Test plan

- [x] `pytest tests/` — 460 passed (up from 452 baseline; 8 new)
- [x] Manual old-vs-new parity check loading the pre-refactor module via `importlib` and diffing output for 5 representative message shapes — byte-identical
- [x] `ruff check evaluation/vis.py tests/test_vis.py` — clean
- [x] `ruff format --check evaluation/vis.py tests/test_vis.py` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tnud68AqgdHSGjHp7X2s1y)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug/visualization HTML only with characterization tests pinning prior formatting; no production eval or runtime paths depend on this refactor.
> 
> **Overview**
> Introduces **`_join_text_and_tool_calls`** so assistant text and a `Tool calls:` summary block are formatted in one place instead of two copy-pasted paths in **`generate_visualization_html`**.
> 
> The **Anthropic** (`tool_use` blocks) and **OpenAI** (`tool_calls`) branches both delegate to that helper for the **Raw Response** display string. The Anthropic path drops the old `display_parts` list and uses a simpler if/elif/else.
> 
> Adds characterization tests for the helper and for end-to-end **Raw Response** text across both message formats (with and without assistant text). **Visualization-only** change; output is intended to stay byte-identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc36ff67bbcfaea545bc01a3f7eca9fa5dc89e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->