### PR TITLE
refactor(resy): mark self-unused url/time helpers as staticmethod

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -349,7 +349,8 @@ class ResyUrlMatch(ResetsViaState):
             states.append(group_states)
         return states
 
-    def _normalize_url(self, url: str, mode: Literal["full", "no_time", "date_only"] = "full") -> str:
+    @staticmethod
+    def _normalize_url(url: str, mode: Literal["full", "no_time", "date_only"] = "full") -> str:
         """
         Normalize Resy URL for comparison.
 
@@ -461,7 +462,8 @@ class ResyUrlMatch(ResetsViaState):
         )
         return slots
 
-    def _update_query_state_visibility(self, state: ResyQueryState, availabilities: list[AvailabilitySlot]) -> None:
+    @staticmethod
+    def _update_query_state_visibility(state: ResyQueryState, availabilities: list[AvailabilitySlot]) -> None:
         if not availabilities:
             # Keep existing last_known_times to allow neighbor inference when the list is empty.
             return
@@ -562,7 +564,8 @@ class ResyUrlMatch(ResetsViaState):
         )
         return False, f"neighbors_not_seen:{','.join(unseen_neighbors)}"
 
-    def _get_neighbor_times(self, gt_time: str, sorted_times: list[str]) -> tuple[str | None, str | None]:
+    @staticmethod
+    def _get_neighbor_times(gt_time: str, sorted_times: list[str]) -> tuple[str | None, str | None]:
         previous: str | None = None
         next_time: str | None = None
         gt_seconds = _time_to_seconds(gt_time)
@@ -577,7 +580,8 @@ class ResyUrlMatch(ResetsViaState):
 
         return previous, next_time
 
-    def _extract_time_from_url(self, url: str) -> str | None:
+    @staticmethod
+    def _extract_time_from_url(url: str) -> str | None:
         if not url:
             return None
         parsed = urlparse(url)
@@ -606,8 +610,8 @@ class ResyUrlMatch(ResetsViaState):
             "detail": detail,
         }
 
+    @staticmethod
     def _describe_conditional_reason(
-        self,
         *,
         reason: str,
         state: ResyQueryState,


### PR DESCRIPTION
## What

`_normalize_url`, `_update_query_state_visibility`, `_get_neighbor_times`, `_extract_time_from_url`, and `_describe_conditional_reason` on `ResyUrlMatch` (`navi_bench/resy/resy_url_match.py`) never read or write instance state — they're pure URL/time-parsing helpers that only happened to be declared as instance methods. Marked all five `@staticmethod`.

This is the same category of change already landed for `apartments_url_match.py` in #211 (`_is_location_part`, `_normalize_apartment_features`, etc.), which covered `ApartmentsUrlMatch`'s sibling helpers but never reached these methods in the sibling `resy_url_match.py` file.

## Why it's safe

- Verified via AST inspection that none of the five methods reference `self` anywhere in their bodies.
- No behavioral change: existing call sites invoke them via `self._method(...)`, which remains valid and behaves identically once the methods are `@staticmethod`.
- Verified by the existing `tests/test_resy_url_match.py` suite (57 passed).

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `tests/test_resy_url_match.py` — 57/57 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PKxTph7v6ipGM5oXu6Fad2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKxTph7v6ipGM5oXu6Fad2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only signature change with no logic edits; existing Resy URL-match tests cover the helpers.
> 
> **Overview**
> Marks five **`ResyUrlMatch`** helpers in `resy_url_match.py` as **`@staticmethod`** because they never touch instance state: **`_normalize_url`**, **`_update_query_state_visibility`**, **`_get_neighbor_times`**, **`_extract_time_from_url`**, and **`_describe_conditional_reason`**.
> 
> This mirrors the same cleanup already done on **`ApartmentsUrlMatch`** in #211. **`self._…`** call sites stay the same; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d2de79d9ebc4eeba282d7cc3cf6520be22fb3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->