### PR TITLE
refactor(relative_dates): extract _parse_weekdays_or_raise for duplicated weekday-guard

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -469,6 +469,21 @@ def _collect_weekdays_list(chunk: str) -> set[int] | None:
     return out or None
 
 
+def _parse_weekdays_or_raise(chunk: str) -> set[int]:
+    """Parse a weekday-list chunk (e.g. "Saturdays and Sundays"), raising if none matched.
+
+    Shared by the two ``parse_relative_dates`` branches that require a non-empty weekday
+    filter on their left-hand side ("<weekdays> in <mod> month" and "<weekdays> in
+    <month-ref> through <month-ref>"). The "from <date> through <date>" branch is *not* a
+    candidate for this helper: it deliberately treats a missing weekday filter as "no
+    filter" (``_collect_weekdays_list(...) or set()``) rather than raising.
+    """
+    wds = _collect_weekdays_list(chunk)
+    if not wds:
+        raise ValueError("Could not parse weekdays in the left-hand side")
+    return wds
+
+
 _ORDINAL_WEEK_INDEX = {
     "first": 1, "1st": 1,
     "second": 2, "2nd": 2,
@@ -609,9 +624,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
     # ------------------------------------------------------------
     m = re.fullmatch(rf"(.+?)\s+in\s+(?:the\s+)?{_MOD_GROUP}\s+month", s)
     if m:
-        wds = _collect_weekdays_list(m.group(1))
-        if not wds:
-            raise ValueError("Could not parse weekdays in the left-hand side")
+        wds = _parse_weekdays_or_raise(m.group(1))
         y, mo = _month_ref_to_year_month(m.group(2) + " month", base)
         for d in _iter_month_days(y, mo):
             if d.weekday() in wds:
@@ -625,9 +638,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
     # ------------------------------------------------------------
     m = re.fullmatch(r"(.+?)\s+in\s+(.+?)\s+through\s+(.+)", s)
     if m:
-        wds = _collect_weekdays_list(m.group(1))
-        if not wds:
-            raise ValueError("Could not parse weekdays in the left-hand side")
+        wds = _parse_weekdays_or_raise(m.group(1))
         y1, m1 = _month_ref_to_year_month(m.group(2), base)
         y2, m2 = _month_ref_to_year_month(m.group(3), base=date(y1, m1, 15))  # resolve end relative to start
         # iterate months inclusive

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -372,6 +372,34 @@ class TestFeb29YearBump:
         ]
 
 
+class TestWeekdaysRequiredBranchesRaiseOnUnparsedWeekdays:
+    """Both the "<weekdays> in <mod> month" and "<weekdays> in <month-ref> through
+    <month-ref>" branches of ``parse_relative_dates`` require a non-empty weekday filter on
+    their left-hand side and previously repeated the identical
+    ``_collect_weekdays_list(...) -> if not wds: raise ValueError(...)`` guard verbatim; now
+    both delegate to the shared ``_parse_weekdays_or_raise`` helper. Pins that an
+    unparseable left-hand side still raises the same error in both branches, and that the
+    sibling "from <date> through <date>" branch (which deliberately treats a missing
+    weekday filter as "no filter" rather than raising) is unaffected."""
+
+    def test_in_mod_month_branch_raises_on_unparsed_weekdays(self):
+        with pytest.raises(ValueError, match="Could not parse weekdays in the left-hand side"):
+            parse_relative_dates("foo in this month", BASE_DATE)
+
+    def test_month_ref_through_month_ref_branch_raises_on_unparsed_weekdays(self):
+        with pytest.raises(ValueError, match="Could not parse weekdays in the left-hand side"):
+            parse_relative_dates("foo in Jan through Mar", BASE_DATE)
+
+    def test_from_through_branch_treats_unparsed_weekdays_as_no_filter_not_a_raise(self):
+        # Sibling branch, deliberately different behavior: falls back to "no weekday
+        # filter" (every day in the span) instead of raising.
+        assert parse_relative_dates("foo from Nov 10 through Nov 12", BASE_DATE) == [
+            "2025-11-10",
+            "2025-11-11",
+            "2025-11-12",
+        ]
+
+
 class TestExpandMdRangeDirect:
     """Direct coverage for ``_expand_md_range`` (no prior direct test coverage; it was
     previously only exercised indirectly through ``parse_relative_dates``). Pins its


### PR DESCRIPTION
## Summary

- The `"<weekdays> in <mod> month"` and `"<weekdays> in <month-ref> through <month-ref>"` branches of `parse_relative_dates` in `navi_bench/relative_dates.py` each repeated the identical guard verbatim:
  ```python
  wds = _collect_weekdays_list(m.group(1))
  if not wds:
      raise ValueError("Could not parse weekdays in the left-hand side")
  ```
- Extracted `_parse_weekdays_or_raise(chunk)` into a shared helper; both call sites now delegate to it.
- The sibling `"from <date> through <date>"` branch is deliberately left untouched — it treats a missing weekday filter as "no filter" (`_collect_weekdays_list(...) or set()`) rather than raising, a genuinely different behavior.

## Verification

- Added `TestWeekdaysRequiredBranchesRaiseOnUnparsedWeekdays` characterization tests first, confirming (via manual pre-refactor run) both branches raise identically today, and pinning that the sibling branch's divergent no-raise fallback is unaffected.
- Full suite: 463 passed (460 -> 463), `ruff check` clean. `ruff format --check` shows only the two pre-existing baseline non-conformances in `evaluation/eval_n1.py`/`navi_bench/dates.py` unrelated to this change.

## Test plan

- [x] `pytest tests/` — 463/463 passing
- [x] `ruff check .` — clean
- [x] Single-file source change (`navi_bench/relative_dates.py`), test-only addition to `tests/test_relative_dates.py`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UU45LqqZkRfMxCTYrFC2mM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in date parsing with characterization tests; no auth, security, or data-path changes.
> 
> **Overview**
> Deduplicates the weekday-parse guard in **`parse_relative_dates`** by introducing **`_parse_weekdays_or_raise`**, which calls **`_collect_weekdays_list`** and raises **`ValueError("Could not parse weekdays in the left-hand side")`** when nothing matches.
> 
> The **"<weekdays> in &lt;mod&gt; month"** and **"<weekdays> in &lt;month-ref&gt; through &lt;month-ref&gt;"** branches now call that helper instead of repeating the same **`if not wds: raise`** block. The **"from &lt;date&gt; through &lt;date&gt;"** branch is unchanged—it still treats an unparseable left-hand side as no weekday filter.
> 
> Adds **`TestWeekdaysRequiredBranchesRaiseOnUnparsedWeekdays`** to lock in the raise behavior on both refactored branches and confirm the sibling **from/through** branch still returns every day in the span without raising.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac2910bf1b42e50e44c1fb7ab61d3b21b24a450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->