### PR TITLE
test(vis): dedupe _messages_with_action onto _messages_with_openai_tool_calls

### DIFF
--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -83,16 +83,7 @@ class TestBlockTypeAndField:
 
 
 def _messages_with_action(action_args: dict, name: str = "left_click") -> list[dict]:
-    return [
-        {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {"id": "t1", "type": "function", "function": {"name": name, "arguments": json.dumps(action_args)}}
-            ],
-        },
-    ]
+    return _messages_with_openai_tool_calls(None, name, json.dumps(action_args))
 
 
 def _render_action_details(action_args: dict, name: str = "left_click") -> str:


### PR DESCRIPTION
## Day-over-day pattern

Looking at the last day of merged commits together (#211, #212, #213, #214), several are the recurring "self-unused helper -> staticmethod" and "duplicated block -> extracted helper" cleanups this cronjob has been running for a while. #212 in particular (`refactor(vis): extract _join_text_and_tool_calls for duplicated response formatting`) added a new test helper, `_messages_with_openai_tool_calls`, to `tests/test_vis.py` for building an OpenAI-style `tool_calls` assistant message.

That file already had an older helper, `_messages_with_action` (pre-dating today), that builds the exact same message shape: `content=None`, a single `tool_calls` entry with `id="t1"`, same `function.name`/`function.arguments` fields. Concretely, `_messages_with_action(args, name)` produced byte-identical output to `_messages_with_openai_tool_calls(None, name, json.dumps(args))`. #212's own diff didn't reuse the pre-existing helper, so the file ended up with two independently-written builders for the same message shape sitting a few hundred lines apart.

## What this PR does

Collapses `_messages_with_action` to delegate to `_messages_with_openai_tool_calls` instead of duplicating the literal message-construction dict/list. Pure test-only refactor:
- No behavior change — verified the two builders produce identical output, and `_messages_with_action` keeps its existing (dict-args) signature so none of its callers (`_render_action_details`, `_render_action_card`, etc.) need to change.
- `tests/test_vis.py`: 87 passed.
- `ruff check` / `ruff format --check` clean on the changed file.

## Owner

Tagging @dhruvbatra as the sole author of `tests/test_vis.py` and `evaluation/vis.py`, and the author of the #212 commit that introduced the duplicate.

## Other opportunities noticed (not implemented — backlog)

- `navi_bench/resy/resy_url_match.py::_normalize_url_without_time` is a one-line instance method (`return self._normalize_url(url, mode="no_time")`) that never reads/writes instance state — same category as #213's "self-unused -> staticmethod" pattern, but the AST check in #213 evidently didn't flag it (it does contain the token `self`, just to call an already-static method). Small, safe follow-up but felt too close to "redo the same refactor a 4th time" to bundle into this PR.
- Naming inconsistency between `navi_bench/apartments/apartments_url_match.py`'s `IGNORED_PARAMS` and `navi_bench/craigslist/craigslist_url_match.py`'s `IGNORE_URL_PARAMS` — same concept (query params to ignore when comparing URLs), different names. Pre-dates today's commits, so left out of scope here, but worth a naming-consistency pass across the `*_url_match.py` files.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WNK4xNu8zGAM6Rbz5BFk1F)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test helper consolidation only; no production code or runtime behavior changes.
> 
> **Overview**
> **Test-only refactor** in `tests/test_vis.py`: `_messages_with_action` no longer inlines the user + OpenAI `tool_calls` assistant message list. It now returns `_messages_with_openai_tool_calls(None, name, json.dumps(action_args))`, matching the shape that helper already builds.
> 
> The `(action_args, name)` signature is unchanged, so callers like `_render_action_details`, `_render_action_card`, and `_messages_with_stop_tool_call` are untouched. Intended to be behavior-preserving deduplication after `_messages_with_openai_tool_calls` was added elsewhere in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5510a70699eed7df23aa806dd1d6e6dae97e396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->