### PR TITLE
refactor(resy): mark self-unused _normalize_url_without_time as staticmethod

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -428,8 +428,9 @@ class ResyUrlMatch(ResetsViaState):
             result += "?" + query_string
         return result
 
-    def _normalize_url_without_time(self, url: str) -> str:
-        return self._normalize_url(url, mode="no_time")
+    @staticmethod
+    def _normalize_url_without_time(url: str) -> str:
+        return ResyUrlMatch._normalize_url(url, mode="no_time")
 
     async def _extract_availabilities(self, page: PageLike) -> list[AvailabilitySlot]:
         raw_availabilities = await safe_evaluate(


### PR DESCRIPTION
## Structural issue

`ResyUrlMatch._normalize_url_without_time` (`navi_bench/resy/resy_url_match.py`) is a one-line instance method:

```python
def _normalize_url_without_time(self, url: str) -> str:
    return self._normalize_url(url, mode="no_time")
```

It only delegates to `_normalize_url`, which is already a `@staticmethod` — the method never reads or writes any instance state (`self.gt_urls`, `self._found_match`, etc.). This is the same "self-unused helper → staticmethod" pattern already applied to `_normalize_url`, `_update_query_state_visibility`, `_get_neighbor_times`, `_extract_time_from_url`, and `_describe_conditional_reason` in this same file (#213), and to `ApartmentsUrlMatch`'s helpers (#211).

It was missed by #213's original AST-based sweep because its body still contains the token `self` — just to call the now-static `_normalize_url` via `self._normalize_url(...)` — even though it never touches instance state. A follow-up run's own AST check (looking for `Name(id="self")` at all, not for real attribute access) initially produced the same false negative; only walking the specific call (`self._normalize_url(...)`) and confirming `_normalize_url` is itself static surfaces this as a genuine instance. This exact follow-up was flagged as a safe, unbundled candidate in #215's PR description.

## Why this is an improvement

Declaring intent correctly: the method is pure URL-normalization logic with no dependency on `self`, so `@staticmethod` documents that accurately and keeps it consistent with its sibling helpers in the same class.

## Why this is safe

- Single file changed, 3-line diff.
- Both call sites (`self._normalize_url_without_time(url)` in `update()` and `self._normalize_url_without_time(gt_url)` in `compute()`) remain valid — calling a staticmethod via `self.` works identically to calling it via the class name.
- Verified via:
  - The existing `tests/test_resy_url_match.py` suite: 57/57 passed, unchanged.
  - Full repo suite: 463/463 passed.
  - `ruff check`/`ruff format --check` clean on the changed file.
  - A standalone old-vs-new equivalence check comparing `instance._normalize_url(url, mode="no_time")`, `instance._normalize_url_without_time(url)`, and the unbound `ResyUrlMatch._normalize_url_without_time(url)` across representative URLs (valid Resy URLs, a malformed URL, and a URL missing city/venue) — all three agree byte-for-byte.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y31HD29ber3owfsx3GZccJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Three-line refactor with no logic change; existing tests cover URL normalization behavior.
> 
> **Overview**
> **`_normalize_url_without_time`** on `ResyUrlMatch` is now a **`@staticmethod`**, matching other URL helpers in the same class that do not use instance state.
> 
> The body delegates to **`ResyUrlMatch._normalize_url(..., mode="no_time")`** instead of **`self._normalize_url`**. **`update()`** and **`_build_query_states()`** still call it via **`self._normalize_url_without_time(...)`**; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7252d92dd2e396201271e1320904ef38fe6c96f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->