### PR TITLE
refactor(resy): mark self-unused _evaluate_condition as staticmethod

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -486,8 +486,8 @@ class ResyUrlMatch(ResetsViaState):
             f"seen_visible={sorted(state.seen_visible_times)}"
         )
 
+    @staticmethod
     def _evaluate_condition(
-        self,
         *,
         state: ResyQueryState,
         url_time: str | None,
@@ -519,7 +519,7 @@ class ResyUrlMatch(ResetsViaState):
 
         # Ground-truth time is not available; check neighbor visibility.
         sorted_times = state.last_known_times or sorted(availability_map.keys(), key=_time_to_seconds)
-        prev_time, next_time = self._get_neighbor_times(state.gt_time, sorted_times)
+        prev_time, next_time = ResyUrlMatch._get_neighbor_times(state.gt_time, sorted_times)
         neighbor_times = [t for t in (prev_time, next_time) if t is not None]
 
         if prev_time is None and next_time is None:


### PR DESCRIPTION
`_evaluate_condition` only calls the already-static `_get_neighbor_times` and never reads/writes instance state on `ResyUrlMatch` — same category as #211/#213/#216's "self-unused helper -> staticmethod" cleanups. It was missed by #213's AST check (and by #216's own follow-up) because the method body still contains the token `self` (to call `_get_neighbor_times` via `self._get_neighbor_times(...)`), even though it never touches instance state.

No behavior change - the sole call site (`self._evaluate_condition(...)` in `update()`) remains valid for a staticmethod. The internal `self._get_neighbor_times` call is rewritten to `ResyUrlMatch._get_neighbor_times` per the #216 convention for statics calling statics.

Verified via `tests/test_resy_url_match.py` (57 passed) and the full suite (463 passed), `ruff check`/`ruff format --check` clean on the touched file (the two pre-existing baseline `ruff format --check` failures in `evaluation/eval_n1.py`/`navi_bench/dates.py` are unrelated and untouched).

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjiUQqmMhAyfSkYjA5dReB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature and dispatch style only; conditional URL-match logic is untouched.
> 
> **Overview**
> Marks **`ResyUrlMatch._evaluate_condition`** as a **`@staticmethod`** and drops the unused **`self`** parameter, matching earlier Resy URL-match cleanups for helpers that only use arguments and other static methods.
> 
> Inside the method, the neighbor lookup is updated from **`self._get_neighbor_times`** to **`ResyUrlMatch._get_neighbor_times`**. **`update()`** still calls **`self._evaluate_condition(...)`**; conditional coverage behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b63e7218e555a39a037e9e7bd2b5755e1ee1bf08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->