### PR TITLE
refactor(base): remove redundant get_origin pre-check in basic_pydantic_to_hf_features

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -282,12 +282,15 @@ def basic_pydantic_to_hf_features(model_class: type[BaseModel]) -> Features:
     for name, field in model_class.model_fields.items():
         field_type = field.annotation
 
-        # unwrap the optional field
-        if get_origin(field_type) in (Union, types.UnionType):
-            unwrapped, is_optional = unwrap_optional_type(field_type)
-            if not is_optional:
-                raise ValueError(f"Unexpected union type: {field_type}")
+        # Unwrap a simple optional (T | None). unwrap_optional_type() already performs its own
+        # get_origin() union check internally and is a no-op for non-union types, so gating this
+        # call on a duplicate get_origin() check (as this function used to) was redundant; any
+        # union it doesn't consider a simple optional is unsupported here.
+        unwrapped, is_optional = unwrap_optional_type(field_type)
+        if is_optional:
             field_type = unwrapped
+        elif get_origin(field_type) in (Union, types.UnionType):
+            raise ValueError(f"Unexpected union type: {field_type}")
 
         # recursive if the field is a pydantic model
         if issubclass(field_type, BaseModel):


### PR DESCRIPTION
## Summary

`basic_pydantic_to_hf_features` gated its call to `unwrap_optional_type(field_type)` on an outer `get_origin(field_type) in (Union, types.UnionType)` check, duplicating the exact same check `unwrap_optional_type` already performs internally (and is already a documented no-op for non-union types). `evaluation/cli.py::_build_argparse_kwargs` — the other call site of the same helper — already calls `unwrap_optional_type` unconditionally without this redundant pre-check, so this brings both call sites in line with each other.

- Removed the outer `get_origin(...)` gate; `unwrap_optional_type` is now called directly, and the "not a simple optional" raise is now driven by `is_optional` with the union check only needed to decide *why* the field is unsupported.
- Behavior-preserving by construction/case-analysis across all 4 shapes `unwrap_optional_type` distinguishes: plain type, `T | None`, non-optional multi-member union, and 3-member union with `None`.

## Test plan

- [x] `pytest tests/` — 463/463 passing (unchanged from baseline), including `tests/test_base.py::TestBasicPydanticToHfFeatures` which already exercises the optional-unwrap and non-optional-union-raises paths for this exact function.
- [x] `ruff check .` — clean.
- [x] `ruff format --check .` — only the 2 pre-existing, unrelated baseline failures remain (`evaluation/eval_n1.py`, `navi_bench/dates.py`), confirmed present on `main` before this change too. `navi_bench/base.py` itself is clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013DGEZ8mkqA5aAuXJnTiTnv


---
_Generated by [Claude Code](https://claude.ai/code/session_013DGEZ8mkqA5aAuXJnTiTnv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow refactor in Pydantic-to-HuggingFace feature conversion with existing tests; no security or data-path changes.
> 
> **Overview**
> **`basic_pydantic_to_hf_features`** now always calls **`unwrap_optional_type`** on each field annotation instead of first checking whether the type is a union.
> 
> Simple optionals (`T | None`) are still unwrapped via **`is_optional`**; unsupported multi-member unions still raise **`ValueError`**, with the union **`get_origin`** check only used to distinguish “not optional” from “unsupported union.” This matches how **`evaluation/cli.py`** already uses the same helper and drops a redundant duplicate union gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f02225ad755669f29cdcd93fdfea4e51c590729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->