### PR TITLE
refactor(apartments): rename IGNORED_PARAMS to IGNORE_URL_PARAMS for cross-file naming consistency

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -56,7 +56,7 @@ _APARTMENT_FEATURES_BY_LENGTH_DESC = sorted(_APARTMENT_FEATURES, key=len, revers
 
 @beartype
 class ApartmentsUrlMatch(ResetsViaState):
-    IGNORED_PARAMS = ("io", "ss")
+    IGNORE_URL_PARAMS = ("io", "ss")
 
     def __init__(self, gt_url: str | list[str]) -> None:
         super().__init__()
@@ -183,7 +183,7 @@ class ApartmentsUrlMatch(ResetsViaState):
         path_parts = [part for part in parsed.path.split("/") if part]
         path_locations, non_location_path_parts = self._extract_locations_from_path(path_parts)
 
-        query_params = parse_filtered_query_params(parsed.query, self.IGNORED_PARAMS)
+        query_params = parse_filtered_query_params(parsed.query, self.IGNORE_URL_PARAMS)
         query_locations, normalized_params = self._extract_locations_from_query(query_params)
 
         # Combine all locations and sort for canonical representation


### PR DESCRIPTION
## What

Rename the class-private constant `IGNORED_PARAMS` → `IGNORE_URL_PARAMS` in `navi_bench/apartments/apartments_url_match.py`.

## Why

`apartments_url_match.py` and its sibling `craigslist_url_match.py` both hold a tuple of URL query parameters to ignore during comparison (passed to `parse_filtered_query_params`), but named the concept differently:

- `apartments_url_match.py`: `IGNORED_PARAMS`
- `craigslist_url_match.py`: `IGNORE_URL_PARAMS`

This adopts the more descriptive `IGNORE_URL_PARAMS` name (already used by the craigslist file) so the two URL-match metrics are consistent. Only the apartments file changes, keeping the diff minimal.

## Scope / safety

- Pure identifier rename — no behavior change.
- The constant is class-private: only two occurrences (definition + the single `self.` reference), both updated.
- No external references anywhere in the repo (the characterization test in `tests/test_apartments_url_match.py` exercises the class, not the constant name).

Cleanup backlog item from `.claude/CLEANUP.md` in the yutori monorepo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ke6c5NYKEQ8r9cGUbFtiTR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier-only rename with no logic or behavior change.
> 
> **Overview**
> Renames the `ApartmentsUrlMatch` class constant **`IGNORED_PARAMS`** to **`IGNORE_URL_PARAMS`** and updates the single call site in `_normalize_url` that passes it to `parse_filtered_query_params`.
> 
> This aligns naming with **`craigslist_url_match.py`**, which already uses `IGNORE_URL_PARAMS` for the same “query params to drop during URL comparison” idea. The tuple value `("io", "ss")` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ec6c8fb1fa27767227555eb5ab0c14aec08a32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->