### PR TITLE
refactor(apartments): reuse all_or_nothing_coverage_result in ApartmentsUrlMatch.compute

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -10,6 +10,7 @@ from navi_bench.base import (
     FinalResult,
     ResetsViaState,
     UrlMetricInput,
+    all_or_nothing_coverage_result,
     basic_normalize_url,
     build_task_config,
     parse_filtered_query_params,
@@ -91,10 +92,7 @@ class ApartmentsUrlMatch(ResetsViaState):
         logger.info(f"ApartmentsUrlMatch.update did not find match: {url}")
 
     async def compute(self) -> FinalResult:
-        score = 1.0 if self._found_match else 0.0
-        result = FinalResult(score=score)
-        logger.info(f"ApartmentsUrlMatch.compute result: {result}")
-        return result
+        return all_or_nothing_coverage_result("ApartmentsUrlMatch", [self._found_match])
 
     @staticmethod
     def _is_location_part(part: str) -> bool:

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -397,7 +397,8 @@ def all_or_nothing_coverage_result(class_name: str, is_covered: list[bool]) -> F
     domain matchers requiring every ground-truth query/info to be covered (e.g. resy's
     and google_flights') each repeated verbatim, differing only in the class name used
     in the log message. Contrast with :func:`fractional_coverage_score`, which scores
-    partial coverage instead of requiring all-or-nothing.
+    partial coverage instead of requiring all-or-nothing. Also used by apartments' single-URL
+    match, passed as a length-1 ``is_covered`` list since it only ever tracks one boolean.
     """
     n_covered = sum(is_covered)
     result = FinalResult(score=1.0 if all(is_covered) else 0.0)


### PR DESCRIPTION
## What

`ApartmentsUrlMatch.compute()` hand-rolled the exact `all(...) -> score -> FinalResult -> log` tail that `base.py`'s `all_or_nothing_coverage_result()` already centralizes for the two other all-or-nothing domain matchers (`ResyUrlMatch`, `GoogleFlightsSearchMatch`) — just specialized to a single boolean (`self._found_match`) instead of a `list[bool]`. This is the same "duplicated tail, differs only in the one input shape" pattern this repo's history already applies elsewhere (`fractional_coverage_score`, `_save_model`/`_load_model`, etc.).

## Why it's safe

Passing `[self._found_match]` as the length-1 `is_covered` list produces a byte-identical `FinalResult`:
- `all([self._found_match])` == `self._found_match`
- `1.0 if all(...) else 0.0` == the original `1.0 if self._found_match else 0.0`
- `reasoning` stays `None` in both versions

The only observable change is the diagnostic log line, which now gains the same `"(N/1 queries covered)"` suffix its two siblings already emit — not a verifier-semantics change (score/reasoning, which is all callers/tests observe, is unchanged).

Verification performed:
- Full local `pytest` suite: 463/463 passing, unchanged
- `ruff check` clean; `ruff format --check` shows only the two pre-existing, unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`)
- Standalone old-vs-new equivalence script comparing `.score`/`.reasoning` for both the matched and unmatched case — identical

## Scope

2 files touched, 4 insertions / 5 deletions. No call-site or verifier-behavior changes.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01QiMSA5Gun3gjPidQ61SvQe)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deduplication refactor with equivalent scoring; only compute log formatting changes.
> 
> **Overview**
> **`ApartmentsUrlMatch.compute`** no longer inlines the all-or-nothing score and log path; it calls shared **`all_or_nothing_coverage_result`** with `[self._found_match]`, matching Resy and Google Flights matchers.
> 
> **`score`** and **`reasoning`** stay the same (`1.0`/`0.0` from the single match flag). The only behavioral delta is logging: compute logs now include the **`(N/1 queries covered)`** suffix from the helper.
> 
> **`base.py`** docstring for **`all_or_nothing_coverage_result`** now documents this apartments single-boolean case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac921f535ccdfad0d718c2003abbde6cf76bbdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->