### PR TITLE
refactor(browser): reuse the module's URL-substring helper for blocked-URL routing

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -42,8 +42,15 @@ GEOLOCATION_REQUIRED_DOMAINS = ("apartments.com", "opentable.com", "resy.com")
 CDP_REQUIRED_DOMAINS = ("apartments.com", "resy.com")
 
 
-def _url_matches_domain(url: str, domains: tuple[str, ...]) -> bool:
-    return any(domain in url for domain in domains)
+def _url_contains_any(url: str, needles: tuple[str, ...]) -> bool:
+    """Whether ``url`` contains any of ``needles`` as a plain substring.
+
+    Named for what it actually does rather than for one of its callers: the same substring
+    test drives the domain tuples above (``GEOLOCATION_REQUIRED_DOMAINS``,
+    ``CDP_REQUIRED_DOMAINS``) and ``BLOCKED_URL_KEYWORDS``, whose entries include a path
+    (``www.facebook.com/tr``) and so are not domains at all.
+    """
+    return any(needle in url for needle in needles)
 
 
 @functools.cache
@@ -93,10 +100,10 @@ async def build_browser(
 
     try:
         viewport = {"width": config.browser_viewport_width, "height": config.browser_viewport_height}
-        need_to_set_location = _url_matches_domain(task_config.url, GEOLOCATION_REQUIRED_DOMAINS)
+        need_to_set_location = _url_contains_any(task_config.url, GEOLOCATION_REQUIRED_DOMAINS)
 
         force_cdp = getattr(task_config, "use_cdp", False)
-        use_local_browser = not force_cdp and not _url_matches_domain(task_config.url, CDP_REQUIRED_DOMAINS)
+        use_local_browser = not force_cdp and not _url_contains_any(task_config.url, CDP_REQUIRED_DOMAINS)
         if not use_local_browser and not os.getenv("BROWSER_CDP_URL"):
             if force_cdp:
                 raise ValueError("BROWSER_CDP_URL must be set when the task config enables use_cdp")
@@ -132,7 +139,7 @@ async def build_browser(
         context.on("dialog", handle_dialog)
 
         async def route_handler(route, request):
-            if any(k in request.url for k in BLOCKED_URL_KEYWORDS):
+            if _url_contains_any(request.url, BLOCKED_URL_KEYWORDS):
                 await route.abort()
             else:
                 await route.continue_()


### PR DESCRIPTION
## The structural issue

`evaluation/browser.py` already centralizes "does this URL contain any of these substrings" in a module-level helper, used for `GEOLOCATION_REQUIRED_DOMAINS` and `CDP_REQUIRED_DOMAINS`:

```python
def _url_matches_domain(url: str, domains: tuple[str, ...]) -> bool:
    return any(domain in url for domain in domains)
```

But the request-routing closure inside `build_browser` hand-rolled the identical expression inline against a third such tuple:

```python
if any(k in request.url for k in BLOCKED_URL_KEYWORDS):
```

So one file had both a named helper for this test and an un-deduplicated copy of it a few dozen lines below.

## Why it's an improvement

- Routes the fourth call site through the existing shared helper, so the substring-match predicate lives in exactly one place.
- Renames the helper `_url_matches_domain` → `_url_contains_any(url, needles)` so its name describes what it does rather than one of its callers. This matters for honesty at the new call site: `BLOCKED_URL_KEYWORDS` entries are not all domains (`www.facebook.com/tr` includes a path), so `_url_matches_domain(request.url, BLOCKED_URL_KEYWORDS)` would have read misleadingly.
- Adds a docstring recording that all three tuples share the same plain-substring semantics.

Same spirit as #219 (naming consistency) and #220 (reuse an existing helper at a call site that hand-rolled it).

## Why it's safe

- Purely behavior-preserving: `_url_contains_any(url, needles)` is byte-for-byte the same `any(needle in url for needle in needles)` expression the call site inlined. No verifier, scoring, or matching semantics are touched — this is browser plumbing only.
- The rename is confined to one private, module-local helper and its three call sites. `grep -rn "_url_matches_domain"` across the repo (source, tests, docs) returns zero remaining references.
- Verified: `ruff check .` clean; `ruff format --check evaluation/browser.py` clean (the two pre-existing repo-wide format spots in `eval_n1.py` / `dates.py` are untouched and unchanged); `python -m py_compile evaluation/browser.py` clean; full `pytest -q` → **463 passed**, identical to the pre-change baseline on `main`.
- Diff is 4 lines of real change plus a docstring — verifiable by reading it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCjrHU3qPdo1bdmAYchKnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCjrHU3qPdo1bdmAYchKnM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper rename and call-site dedup with identical substring logic; no matching or browser-control behavior change.
> 
> **Overview**
> Renames `_url_matches_domain` to `_url_contains_any` so the helper describes substring matching rather than “domains,” and routes blocked-URL request aborting through that same helper instead of an inline `any(...)` check.
> 
> Behavior is unchanged: geolocation, CDP, and tracker blocking still use the same `needle in url` test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f450945a8921eaad5c373695e1958f3505ab25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->