### PR TITLE
refactor(vis): separate message parsing from HTML rendering

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -310,16 +310,66 @@ def _render_response_section(label: str, content_html: str, *, collapsed: bool =
                     </div>"""
 
 
-def generate_visualization_html(
-    task_id: str,
-    messages: list[dict],
-    result: object | None,
-    coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
-    coord_space_height: int = NAVIGATOR_COORDINATE_SCALE,
-) -> str:
-    """Generate a static HTML file for visualizing the evaluation messages and result."""
+def _extract_observation_blocks(content: list[dict]) -> list[dict]:
+    """Normalize a user-role content list into the observation blocks a step renders from.
 
-    # Build step data
+    Recognizes the three screenshot/text carriers that appear in an evaluation history --
+    Anthropic ``tool_result`` blocks (whose nested content holds the screenshots and text
+    results), standalone Anthropic ``image`` blocks, and OpenAI ``image_url`` blocks -- and
+    returns them as a flat list in the shape the step renderer consumes: every image first
+    as ``{"type": "image_url", ...}``, then every text as ``{"type": "text", ...}``.
+
+    Returns an empty list when ``content`` carries no observation at all, which callers use
+    to distinguish "this user message is an observation" from "this user message is just the
+    task query" (only the former replaces the pending observation).
+    """
+    observation_images: list[str] = []
+    observation_texts: list[str] = []
+    for c in content:
+        c_type = c.get("type")
+        if c_type == "tool_result":
+            # Anthropic tool_result format
+            tool_content = c.get("content", [])
+            if isinstance(tool_content, list):
+                for tc in tool_content:
+                    if isinstance(tc, dict):
+                        if tc.get("type") == "image":
+                            data_url = _anthropic_image_to_data_url(tc)
+                            if data_url is not None:
+                                observation_images.append(data_url)
+                        elif tc.get("type") == "text":
+                            observation_texts.append(tc.get("text", ""))
+        elif c_type == "image":
+            # Standalone Anthropic image block
+            data_url = _anthropic_image_to_data_url(c)
+            if data_url is not None:
+                observation_images.append(data_url)
+        elif c_type == "image_url":
+            # OpenAI format
+            observation_images.append(c.get("image_url", {}).get("url", ""))
+
+    return [{"type": "image_url", "image_url": {"url": img_url}} for img_url in observation_images] + [
+        {"type": "text", "text": txt} for txt in observation_texts
+    ]
+
+
+def _build_steps(
+    messages: list[dict],
+    coord_space_width: int,
+    coord_space_height: int,
+) -> tuple[list[dict], str | None, str | None]:
+    """Parse an evaluation message history into the step model the HTML renderer consumes.
+
+    Returns ``(steps, system_prompt, user_query)``. Each step pairs one assistant message
+    with the observation that preceded it and carries everything the renderer needs:
+    ``step_num``, ``screenshot_url``, ``text_observations``, ``assistant_response``,
+    ``actions``, ``action_markers``, ``is_final_answer``, and ``final_answer_content``.
+
+    Split out of ``generate_visualization_html`` so the two phases it used to interleave --
+    normalizing a heterogeneous OpenAI/Anthropic message log into this step model, and
+    rendering that model to HTML -- are separately readable and separately testable; the
+    parse phase previously could only be exercised by scraping the rendered HTML.
+    """
     steps = []
     system_prompt = None
     user_query = None
@@ -336,41 +386,11 @@ def generate_visualization_html(
                 if user_query is None:
                     user_query = next((c.get("text", "") for c in content if c.get("type") == "text"), None)
 
-                # Check for Anthropic tool_result format (contains screenshots for observations)
-                # Extract images from tool_result content and standalone image blocks
-                observation_images = []
-                observation_texts = []
-                for c in content:
-                    c_type = c.get("type")
-                    if c_type == "tool_result":
-                        # Anthropic tool_result format
-                        tool_content = c.get("content", [])
-                        if isinstance(tool_content, list):
-                            for tc in tool_content:
-                                if isinstance(tc, dict):
-                                    if tc.get("type") == "image":
-                                        data_url = _anthropic_image_to_data_url(tc)
-                                        if data_url is not None:
-                                            observation_images.append(data_url)
-                                    elif tc.get("type") == "text":
-                                        observation_texts.append(tc.get("text", ""))
-                    elif c_type == "image":
-                        # Standalone Anthropic image block
-                        data_url = _anthropic_image_to_data_url(c)
-                        if data_url is not None:
-                            observation_images.append(data_url)
-                    elif c_type == "image_url":
-                        # OpenAI format
-                        observation_images.append(c.get("image_url", {}).get("url", ""))
-
-                if observation_images or observation_texts:
-                    # Build observation content
-                    obs_content = []
-                    for img_url in observation_images:
-                        obs_content.append({"type": "image_url", "image_url": {"url": img_url}})
-                    for txt in observation_texts:
-                        obs_content.append({"type": "text", "text": txt})
-                    current_observation = obs_content
+                # A user message may also carry the observation (screenshots/text) for the
+                # next step, in which case it supersedes the pending one.
+                observation_blocks = _extract_observation_blocks(content)
+                if observation_blocks:
+                    current_observation = observation_blocks
             else:
                 if user_query is None:
                     user_query = content
@@ -470,6 +490,20 @@ def generate_visualization_html(
                 }
             )
             current_observation = None
+
+    return steps, system_prompt, user_query
+
+
+def generate_visualization_html(
+    task_id: str,
+    messages: list[dict],
+    result: object | None,
+    coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
+    coord_space_height: int = NAVIGATOR_COORDINATE_SCALE,
+) -> str:
+    """Generate a static HTML file for visualizing the evaluation messages and result."""
+
+    steps, system_prompt, user_query = _build_steps(messages, coord_space_width, coord_space_height)
 
     # Generate HTML
     result_score = getattr(result, "score", None) if result else None

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -18,6 +18,8 @@ from evaluation.vis import (
     generate_visualization_html,
     _block_field,
     _block_type,
+    _build_steps,
+    _extract_observation_blocks,
     _get_action_marker_style,
     _join_text_and_tool_calls,
     _render_response_section,
@@ -857,3 +859,183 @@ class TestModalCloseAnswerModalCloseHoverStyleSheetDeduplication:
         assert match is not None, html
         # .modal-close:hover never gets answer-modal-close's white hover color as a standalone rule.
         assert re.search(r"(?<!answer-)\.modal-close:hover\s*\{\s*color: white;\s*\}", html) is None
+
+
+_ANTHROPIC_PNG_BLOCK = {
+    "type": "image",
+    "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"},
+}
+
+
+class TestExtractObservationBlocks:
+    """Characterization tests for ``_extract_observation_blocks``, the user-role content
+    normalizer extracted from ``_build_steps``' deeply nested ``observation_images`` /
+    ``observation_texts`` accumulation. Pins the three recognized carriers (Anthropic
+    ``tool_result``, standalone Anthropic ``image``, OpenAI ``image_url``), the
+    images-before-texts ordering the step renderer relies on, and the empty-list result that
+    tells the caller a user message is not an observation.
+    """
+
+    def test_no_observation_content_returns_empty_list(self):
+        assert _extract_observation_blocks([{"type": "text", "text": "just the task"}]) == []
+
+    def test_openai_image_url_block(self):
+        content = [{"type": "image_url", "image_url": {"url": "shot"}}]
+
+        assert _extract_observation_blocks(content) == [{"type": "image_url", "image_url": {"url": "shot"}}]
+
+    def test_standalone_anthropic_image_block_becomes_data_url(self):
+        result = _extract_observation_blocks([_ANTHROPIC_PNG_BLOCK])
+
+        assert result == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}]
+
+    def test_non_base64_anthropic_image_block_is_skipped(self):
+        content = [{"type": "image", "source": {"type": "url", "url": "http://example.com/x.png"}}]
+
+        assert _extract_observation_blocks(content) == []
+
+    def test_tool_result_nested_images_and_texts(self):
+        content = [
+            {
+                "type": "tool_result",
+                "content": [_ANTHROPIC_PNG_BLOCK, {"type": "text", "text": "page text"}],
+            }
+        ]
+
+        assert _extract_observation_blocks(content) == [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            {"type": "text", "text": "page text"},
+        ]
+
+    def test_non_list_tool_result_content_is_ignored(self):
+        assert _extract_observation_blocks([{"type": "tool_result", "content": "not-a-list"}]) == []
+
+    def test_non_dict_entries_inside_tool_result_are_ignored(self):
+        assert _extract_observation_blocks([{"type": "tool_result", "content": ["not-a-dict"]}]) == []
+
+    def test_all_images_precede_all_texts_regardless_of_input_order(self):
+        content = [
+            {"type": "tool_result", "content": [{"type": "text", "text": "first text"}]},
+            {"type": "image_url", "image_url": {"url": "shot"}},
+        ]
+
+        assert _extract_observation_blocks(content) == [
+            {"type": "image_url", "image_url": {"url": "shot"}},
+            {"type": "text", "text": "first text"},
+        ]
+
+
+class TestBuildSteps:
+    """Characterization tests for ``_build_steps``, the message-history parser extracted from
+    ``generate_visualization_html`` so the parse phase is testable without scraping rendered
+    HTML (as the end-to-end tests above must). Pins the system-prompt/user-query capture, the
+    "pair each assistant message with the preceding observation" behavior, and the
+    final-answer flags carried on each step.
+    """
+
+    def test_empty_history_yields_nothing(self):
+        assert _build_steps([], 1000, 1000) == ([], None, None)
+
+    def test_system_prompt_and_user_query_captured(self):
+        messages = [
+            {"role": "system", "content": "sys prompt"},
+            {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+        ]
+
+        steps, system_prompt, user_query = _build_steps(messages, 1000, 1000)
+
+        assert steps == []
+        assert system_prompt == "sys prompt"
+        assert user_query == "do the task"
+
+    def test_non_string_system_content_is_json_dumped(self):
+        messages = [{"role": "system", "content": [{"type": "text", "text": "structured"}]}]
+
+        _, system_prompt, _ = _build_steps(messages, 1000, 1000)
+
+        assert system_prompt == json.dumps([{"type": "text", "text": "structured"}], indent=2)
+
+    def test_only_first_user_message_sets_the_query(self):
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "first"}]},
+            {"role": "user", "content": [{"type": "text", "text": "second"}]},
+        ]
+
+        _, _, user_query = _build_steps(messages, 1000, 1000)
+
+        assert user_query == "first"
+
+    def test_assistant_message_pairs_with_preceding_observation(self):
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "look"}]},
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "shot1"}},
+                    {"type": "text", "text": "page text"},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "left_click", "arguments": json.dumps({"coordinates": [500, 250]})},
+                    }
+                ],
+            },
+        ]
+
+        steps, _, _ = _build_steps(messages, 1000, 1000)
+
+        assert len(steps) == 1
+        step = steps[0]
+        assert step["step_num"] == 1
+        assert step["screenshot_url"] == "shot1"
+        assert step["text_observations"] == ["page text"]
+        assert step["actions"] == [{"action_type": "left_click", "coordinates": [500, 250]}]
+        assert step["action_markers"] == [{"type": "left_click", "x": 50.0, "y": 25.0, "has_point": True}]
+        assert step["is_final_answer"] is False
+        assert step["final_answer_content"] is None
+
+    def test_observation_is_consumed_by_one_step_only(self):
+        messages = [
+            {"role": "tool", "content": [{"type": "image_url", "image_url": {"url": "shot1"}}]},
+            {"role": "assistant", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+
+        steps, _, _ = _build_steps(messages, 1000, 1000)
+
+        assert [s["step_num"] for s in steps] == [1, 2]
+        assert steps[0]["screenshot_url"] == "shot1"
+        assert steps[1]["screenshot_url"] is None
+
+    def test_assistant_without_tool_calls_is_a_final_answer(self):
+        messages = [{"role": "assistant", "content": "  the answer  "}]
+
+        steps, _, _ = _build_steps(messages, 1000, 1000)
+
+        assert steps[0]["is_final_answer"] is True
+        assert steps[0]["final_answer_content"] == "the answer"
+
+    def test_markers_use_the_given_coordinate_space(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "left_click", "arguments": json.dumps({"coordinates": [640, 400]})},
+                    }
+                ],
+            }
+        ]
+
+        steps, _, _ = _build_steps(messages, 1280, 800)
+
+        assert steps[0]["action_markers"] == [{"type": "left_click", "x": 50.0, "y": 50.0, "has_point": True}]


### PR DESCRIPTION
## The structural issue

`evaluation/vis.py::generate_visualization_html` did two unrelated jobs in one ~1,300-line function:

1. **Parse** — walk a heterogeneous message history (OpenAI `tool_calls` / Anthropic `tool_use` + `tool_result` / plain-string / `observation` + `tool` roles) and normalize it into a per-step model, threading eight mutable locals (`steps`, `system_prompt`, `user_query`, `current_observation`, `observation_images`, `observation_texts`, `assistant_text`, `display_response`) through ~150 lines, five levels deep in places.
2. **Render** — turn that model into HTML.

Two consequences:

- The parse phase had **no callable seam**. Every existing test of parsing behavior has to render the whole page and then regex-scrape the output to get at it — e.g. `_render_action_details()` in `tests/test_vis.py` does `re.search(r'<div class="action-details">(.*?)</div>', html)` just to assert on a parsed action field.
- The observation-extraction block was the deepest part of the function (a 4-level `for`/`if isinstance`/`for`/`if` nest inside the user-role branch) purely because it was inlined.

## The refactor

Pure code motion, one source file:

- Extract the parse phase into `_build_steps(messages, coord_space_width, coord_space_height) -> (steps, system_prompt, user_query)`.
- Extract the nested observation accumulation inside it into `_extract_observation_blocks(content) -> list[dict]`, which now names the contract explicitly: the three recognized screenshot/text carriers, the images-before-texts ordering the renderer relies on, and the empty-list return that tells the caller "this user message is the task query, not an observation".
- `generate_visualization_html` keeps its exact signature and is now just the render phase, starting with one call to `_build_steps`.

Both phases are now separately readable, and the parse phase is directly unit-testable without going through HTML.

Also adds characterization tests for the two new helpers (the repo's established convention for extracted helpers): the three observation carriers, non-base64 image skip, non-list / non-dict `tool_result` content, images-before-texts ordering, system-prompt JSON-dumping, first-user-message-wins query capture, observation-to-step pairing and single consumption, final-answer flags, and coordinate-space scaling of markers.

## Why it is safe

No behavior change — the moved code is byte-identical apart from the list-comprehension form of the final `obs_content` assembly (same elements, same order) and the loop-local names.

Verified:

- **Output-preserving on 60 renders.** A throwaway harness rendered `generate_visualization_html` over 15 message-history shapes (empty; system-as-string and system-as-list; OpenAI `tool_calls` incl. drag / ref-only / form-recording / malformed-JSON arguments; `tool`-role observations; scalar `observation` role; Anthropic `tool_result` with nested + standalone + non-base64 images and non-list/non-dict content; Anthropic text-only and no-text blocks; dict and `None` assistant content; `Finished` and `call_user` stop actions; a multi-step history; a second user message) × with/without a result object × two coordinate spaces (1000×1000, 1280×800), and SHA-256'd each page. **All 60 digests are identical before and after.**
- **Full suite passes:** `python3 -m pytest -q` → 479 passed (463 pre-existing + 16 new). Baseline before the change was 463 passed.
- **Lint clean:** `ruff check .` → all checks passed; `ruff format --check evaluation/vis.py tests/test_vis.py` → both already formatted. (`ruff format --check .` also flags `evaluation/eval_n1.py` and `navi_bench/dates.py`, both pre-existing and untouched by this PR.)

No verifier is touched — `evaluation/vis.py` is the HTML trajectory visualizer only, and nothing under `navi_bench/` changed. Verifier accept/reject semantics are bit-identical.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nn1DmtDNAp5x1aLGoc2GVC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn1DmtDNAp5x1aLGoc2GVC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of the HTML visualizer only; public signature and parse/render behavior are intended to stay the same.
> 
> **Overview**
> Splits eval visualization into a parse phase and a render phase so message-history handling can be unit-tested without scraping HTML.
> 
> `_extract_observation_blocks` normalizes Anthropic `tool_result` / `image` and OpenAI `image_url` content into the image-then-text blocks a step uses. `_build_steps` walks the mixed OpenAI/Anthropic log and returns `(steps, system_prompt, user_query)`. `generate_visualization_html` keeps its signature and now only renders that model.
> 
> Adds characterization tests for the three observation carriers, empty vs observation user messages, observation-to-step pairing, final-answer flags, and coordinate-space marker scaling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 343de88e2b7230875516a1db42d6ab2737a8e159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->