### PR TITLE
refactor(stats): replace TimingStats.merge fold loop with sum(start=TimingStats())

### DIFF
--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -57,6 +57,9 @@ class TimingStats(BaseModel):
     def merge(self, other: "TimingStats") -> "TimingStats":
         return TimingStats(times_ms=self.times_ms + other.times_ms)
 
+    def __add__(self, other: "TimingStats") -> "TimingStats":
+        return self.merge(other)
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def call_count(self) -> int:
@@ -97,9 +100,7 @@ class TimingStats(BaseModel):
 
 
 def show_timing_summary(timings: list[TimingStats]) -> None:
-    total_timing = TimingStats()
-    for timing in timings:
-        total_timing = total_timing.merge(timing)
+    total_timing = sum(timings, start=TimingStats())
 
     if total_timing.call_count == 0:
         log_section_header("Timing Summary: No API calls recorded")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -13,7 +13,7 @@ entries) -> list`` helper.
 import json
 
 from navi_bench.base import DatasetItem, FinalResult
-from evaluation.stats import Crashed, show_results
+from evaluation.stats import Crashed, TimingStats, show_results, show_timing_summary
 
 
 def _item(task_id: str, domain: str, difficulty: str | None) -> DatasetItem:
@@ -71,3 +71,60 @@ class TestShowResultsSummaryTable:
         )
         assert "  [  2] t/resy/0                                                     | easy   | score = 0.50" in logged
         assert "  [  3] t/resy/1                                                     | unknown | score = 0.00" in logged
+
+
+class TestShowTimingSummary:
+    """Pins ``show_timing_summary`` before replacing its hand-rolled ``TimingStats.merge`` fold
+    loop with ``sum(timings, start=TimingStats())``, matching ``TokenUsage.show_summary``'s
+    existing ``sum(usages, start=TokenUsage())`` convention.
+    """
+
+    def test_summary_pinned(self, monkeypatch):
+        logged: list[str] = []
+        monkeypatch.setattr("evaluation.stats.logger.info", logged.append)
+
+        t1 = TimingStats()
+        t1.add_call(100.0)
+        t1.add_call(200.0)
+        t2 = TimingStats()
+        t2.add_call(300.0)
+
+        show_timing_summary([t1, t2])
+
+        assert logged == [
+            "",
+            "=" * 60,
+            "Timing Summary",
+            "=" * 60,
+            "  Total API calls:                      3",
+            "  Total time:                         600 ms (0.6 s)",
+            "-" * 60,
+            "  Avg time per call:                  200 ms",
+            "  Median time per call:               200 ms",
+            "  Min time per call:                  100 ms",
+            "  Max time per call:                  300 ms",
+            "  P95 time per call:                  300 ms",
+            "-" * 60,
+            "  Avg calls per task:                 1.5",
+            "  Avg time per task:                  300 ms (0.3 s)",
+            "  Tasks with API calls:                 2",
+        ]
+
+    def test_no_calls_recorded(self, monkeypatch):
+        logged: list[str] = []
+        monkeypatch.setattr("evaluation.stats.logger.info", logged.append)
+
+        show_timing_summary([])
+
+        assert logged == [
+            "",
+            "=" * 60,
+            "Timing Summary: No API calls recorded",
+            "=" * 60,
+        ]
+
+    def test_add_matches_merge(self):
+        t1 = TimingStats(times_ms=[100.0, 200.0])
+        t2 = TimingStats(times_ms=[300.0])
+
+        assert (t1 + t2) == t1.merge(t2)


### PR DESCRIPTION
## What

`evaluation/stats.py::show_timing_summary` hand-rolled a fold loop to total a list of `TimingStats`:

```python
total_timing = TimingStats()
for timing in timings:
    total_timing = total_timing.merge(timing)
```

Its sibling `TokenUsage.show_summary` (in `evaluation/eval_n1.py`, same repo, same "sum a list of pydantic models" shape) already uses the standard-library idiom:

```python
total_usage = sum(usages, start=TokenUsage())
```

`TimingStats` couldn't use that idiom because it only defined `merge()`, not `__add__`. This inconsistency was previously logged in this repo's refactor-audit history as "real but cosmetic, not worth a PR on its own" — re-examined here because it's a clean instance of "replace a hand-rolled utility with a standard-library call," and the diff is a genuinely small, single-purpose, single-file change.

## Why it's safe (no behavioral change)

- Added `TimingStats.__add__` that delegates to the existing `merge()` (kept as the single source of truth `__add__` calls into — `merge()` is left in place unchanged).
- `sum(timings, start=TimingStats())` computes `TimingStats() + timings[0] + timings[1] + ...`, which is exactly the same left-to-right fold `merge` already performed — `merge` just concatenates `times_ms` lists, so order/associativity don't matter for the result.
- Grepped for other callers of `.merge(` — `show_timing_summary` is the only call site, so nothing else could observe a difference.
- `show_timing_summary` (and `TimingStats.merge`) had **zero prior test coverage**. Per this repo's established convention (see `tests/test_stats.py`'s existing `TestShowResultsSummaryTable` docstring), added characterization tests *first*, pinning the exact log output for a populated-timings case and the empty-timings case, plus a direct `t1 + t2 == t1.merge(t2)` test. Confirmed the new direct-equality test fails against the pre-refactor code (no `__add__` existed) and all other new tests pass unchanged against both the pre- and post-refactor source.

## Verification

- `pytest tests/` (full local suite, deps installed via `pip install -e ".[dev,eval]"`): **479 → 482 passed** (3 new tests), no regressions.
- `ruff check .`: clean.
- `ruff format --check .`: only the same 2 pre-existing, unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`) that predate this change — confirmed via `git stash` that they exist on `main` too.

## Scope

2 files touched (`evaluation/stats.py`, `tests/test_stats.py`), no call-site changes elsewhere, no verifier/scoring logic touched — this is debug/summary logging plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAav5x8va7JZ8E1LmLYQKy)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic refactor of debug timing aggregation plus tests; no scoring, auth, or data-path changes.
> 
> **Overview**
> Lets `show_timing_summary` total timings with `sum(timings, start=TimingStats())` instead of a hand-rolled `merge` loop, matching `TokenUsage.show_summary`.
> 
> `TimingStats.__add__` delegates to existing `merge()`. Characterization tests pin populated and empty summary logs and that `+` equals `merge`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95fbc69f93dfbbbfb18b2edef26366d247f23b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->