### PR TITLE
refactor(base): move PageLike next to safe_evaluate and use it instead of `page: Any`

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import Any, TypedDict, TypeVar, Union, get_args, get_origin
+from typing import Any, Protocol, TypedDict, TypeVar, Union, get_args, get_origin, runtime_checkable
 from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value
@@ -35,8 +35,22 @@ def read_sidecar_with_shared_js_prefix(
     return f"{read_sidecar(module_file, shared_filename)}\n{read_sidecar(module_file, filename)}"
 
 
+@runtime_checkable
+class PageLike(Protocol):
+    """Protocol for page-like objects that can evaluate JavaScript.
+
+    This is exactly the contract :func:`safe_evaluate` requires of its ``page`` argument, so it
+    lives next to it rather than in one of the domain-matcher modules that consume it (it used to
+    be defined in ``navi_bench.resy.resy_url_match``, which is imported by neither the shared
+    helper nor the other call sites). Call sites pass either a live Playwright ``Page`` or one of
+    the lighter-weight doubles the verifiers are exercised against.
+    """
+
+    async def evaluate(self, script: str) -> Any: ...
+
+
 async def safe_evaluate(
-    page: Any,
+    page: PageLike,
     script: str,
     *,
     default: Any,

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -4,7 +4,7 @@ import random
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
+from typing import Any, Literal, TypedDict
 from urllib.parse import parse_qs, urlparse
 
 from beartype import beartype
@@ -14,6 +14,7 @@ from playwright.async_api import Page
 from navi_bench.base import (
     BaseTaskConfig,
     FinalResult,
+    PageLike,
     ResetsViaState,
     all_or_nothing_coverage_result,
     basic_normalize_url,
@@ -33,13 +34,6 @@ from navi_bench.dates import (
     render_task_statement,
     resolve_city_now,
 )
-
-
-@runtime_checkable
-class PageLike(Protocol):
-    """Protocol for page-like objects that can evaluate JavaScript"""
-
-    async def evaluate(self, script: str) -> Any: ...
 
 
 class InputDict(TypedDict):

--- a/tests/test_safe_evaluate.py
+++ b/tests/test_safe_evaluate.py
@@ -8,7 +8,7 @@ throw a JS error mid-evaluation.
 import pytest
 from playwright.async_api import Error as PlaywrightError
 
-from navi_bench.base import safe_evaluate
+from navi_bench.base import PageLike, safe_evaluate
 
 
 class _FakePage:
@@ -22,6 +22,13 @@ class _FakePage:
         if self._error is not None:
             raise self._error
         return self._result
+
+
+def test_page_like_is_the_contract_safe_evaluate_requires():
+    """``PageLike`` (annotating ``safe_evaluate``'s ``page``) is satisfied by exactly the
+    "has an ``evaluate`` method" duck type the helper calls into, nothing more."""
+    assert isinstance(_FakePage(), PageLike)
+    assert not isinstance(object(), PageLike)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The structural issue

`navi_bench/base.py::safe_evaluate` is the shared "run `page.evaluate(script)`, log and return a default on `PlaywrightError`" helper. It declares its first parameter as `page: Any`, even though the exact structural contract it requires — an object with an async `evaluate(script)` — was already written down in this repo as a `runtime_checkable` `PageLike` Protocol.

That Protocol lived in `navi_bench/resy/resy_url_match.py`: one of the three modules that *call* `safe_evaluate` (the others being `navi_bench/opentable/opentable_info_gathering.py` and `evaluation/browser.py`), and one that `base.py` cannot import. So the type describing the shared helper's requirement sat in a leaf domain matcher, while the helper itself fell back to `Any`.

## Why this is an improvement

- The precise type replaces `Any` at the one place that defines the requirement, so the contract is stated where it is enforced instead of being re-discoverable only by reading the body.
- `PageLike` now sits directly above its only reason for existing, in the module every consumer already imports from — the same "shared contract belongs in `base.py`" placement as `UrlMetricInput`, `BaseMetric`, `FinalResult`, and the other helpers there.
- `resy_url_match.py` loses a locally-defined type and two now-unused `typing` imports (`Protocol`, `runtime_checkable`), picking `PageLike` up from the same `navi_bench.base` import block it already uses for a dozen shared helpers.

## Why it is safe

- **`safe_evaluate` is not `@beartype`-decorated**, so its annotation is documentation only — no runtime check is added at any of its four call sites (which pass a live Playwright `Page` in three cases and a `PageLike` in the fourth).
- **The one runtime-enforced use of `PageLike` is preserved exactly.** `ResyUrlMatch._extract_availabilities(self, page: PageLike)` is covered by the class-level `@beartype`, so its annotation *is* checked at call time. The Protocol was moved verbatim (still `runtime_checkable`, same single method) and is imported back into `resy_url_match.py`, so `navi_bench.resy.resy_url_match.PageLike` remains importable and is the identical object. Verified directly: `_extract_availabilities` still accepts a duck-typed page and still raises `BeartypeCallHintParamViolation` for an object without `evaluate`.
- Full suite green: **482 passed before → 483 after**, the one addition being a contract test (`test_page_like_is_the_contract_safe_evaluate_requires`) that pins `PageLike`'s membership rule at its new home — the moved Protocol previously had no direct coverage.
- `ruff check` clean repo-wide; `python -m py_compile` clean on all touched files; `ruff format --check` reports only the two pre-existing unrelated deviations (`evaluation/eval_n1.py`, `navi_bench/dates.py`), neither touched here.
- No functional code paths changed — the diff is one moved class, one annotation, one import swap, and one test. 3 files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAf2ckWLpYZMsztaiAhreR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only move and annotation; no functional paths change. `safe_evaluate` is not beartype-checked, and Resy’s existing runtime PageLike check is preserved via the same protocol.
> 
> **Overview**
> Moves the `runtime_checkable` `PageLike` protocol from `resy_url_match.py` into `base.py` next to `safe_evaluate`, and annotates that helper’s `page` argument as `PageLike` instead of `Any`.
> 
> `resy_url_match` now imports `PageLike` from `base` (still used on `_extract_availabilities`). Adds a small isinstance contract test so the duck type is pinned at its new home. No runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ee1b0f23c0311b63162f99458bb3ec502c67b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->