### PR TITLE
refactor(resy): replace hand-rolled dedup loop with dict.fromkeys in _update_query_state_visibility

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -463,16 +463,10 @@ class ResyUrlMatch(ResetsViaState):
             # Keep existing last_known_times to allow neighbor inference when the list is empty.
             return
 
-        unique_times: list[str] = []
-        seen_set: set[str] = set()
-        for slot in availabilities:
-            if slot.time not in seen_set:
-                seen_set.add(slot.time)
-                unique_times.append(slot.time)
-            if slot.is_visible:
-                state.seen_visible_times.add(slot.time)
-
-        unique_times.sort(key=_time_to_seconds)
+        # dict.fromkeys dedupes while preserving first-seen order, same as the prior
+        # manual seen-set loop, before the final sort by time-of-day.
+        unique_times = sorted(dict.fromkeys(slot.time for slot in availabilities), key=_time_to_seconds)
+        state.seen_visible_times.update(slot.time for slot in availabilities if slot.is_visible)
         state.last_known_times = unique_times
         logger.debug(
             "ResyUrlMatch._update_query_state_visibility "


### PR DESCRIPTION
## What

`ResyUrlMatch._update_query_state_visibility` built a de-duplicated, order-preserving `unique_times` list with a hand-rolled `seen_set: set[str]` + manual loop, while also updating `state.seen_visible_times` as a side effect inside the same loop. This replaces the manual dedup with the standard `dict.fromkeys(...)` idiom (order-preserving dedup over an iterable) and moves the visibility-tracking update into its own `set.update(...)` call:

```python
unique_times = sorted(dict.fromkeys(slot.time for slot in availabilities), key=_time_to_seconds)
state.seen_visible_times.update(slot.time for slot in availabilities if slot.is_visible)
```

## Why

- `dict.fromkeys` is the standard library idiom for order-preserving deduplication — no need for a manually managed `seen_set` plus append loop.
- Splitting the dedup computation from the `seen_visible_times` side effect makes each line do one clearly-named thing, instead of one loop silently doing two unrelated jobs.
- Net effect: same list of unique times, same final sort, same set of visible times — just fewer moving parts.

## Why it's safe

- Purely mechanical: the resulting `unique_times` list and `state.seen_visible_times` set are identical in content to before (dedup + sort order unchanged; visibility side effect unchanged).
- No call-site changes — `_update_query_state_visibility` is a private `staticmethod` called from one place (`ResyUrlMatch.update`).
- Full local test suite passes: 483/483 (57/57 in `tests/test_resy_url_match.py`, which exercises `update`/`_evaluate_condition` end-to-end through this code path).
- `ruff check` and `ruff format --check` both clean on the changed file.

## Test plan

- [x] `python3 -m pytest -q` — 483 passed
- [x] `ruff check .` — all checks passed
- [x] `ruff format --check navi_bench/resy/resy_url_match.py` — already formatted


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jus1wYY8Nx7xFYa4X2Ejq2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in a private helper with no API or call-site changes; conditional URL-match logic should behave the same.
> 
> **Overview**
> **Refactors** how `ResyUrlMatch._update_query_state_visibility` builds `last_known_times` and updates `seen_visible_times` when availability slots are present.
> 
> Instead of one loop with a manual `seen_set` that both dedupes times and records visible slots, it uses `sorted(dict.fromkeys(...), key=_time_to_seconds)` for order-preserving dedupe plus time-of-day sort, and a separate `state.seen_visible_times.update(...)` for visible times. Behavior is intended to be unchanged: same unique times, sort order, and accumulated visible times; only the private helper’s implementation changes (single caller in `update`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff32ad704d332d12daa9297ca8af34540d8db73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->