### PR TITLE
refactor(resy): replace hand-rolled accumulation loops with comprehensions in placeholder rendering

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -899,13 +899,7 @@ def _render_placeholders_in_queries(
     queries: list[list[str]], template_string: str, rendered_value: str
 ) -> list[list[str]]:
     """Replace placeholder tokens inside every URL in the nested queries list."""
-    new_queries = []
-    for group in queries:
-        new_group = []
-        for url in group:
-            new_group.append(url.replace(template_string, rendered_value))
-        new_queries.append(new_group)
-    return new_queries
+    return [[url.replace(template_string, rendered_value) for url in group] for group in queries]
 
 
 def _validate_placeholder_dates_and_get_template_string(
@@ -1100,8 +1094,7 @@ def _render_placeholders_in_queries_all(
         template_string = _validate_placeholder_dates_and_get_template_string(
             dates, placeholder_key, base_date, booking_window
         )
-        for d in dates:
-            queries.append([template_url.replace(template_string, d)])
+        queries.extend([template_url.replace(template_string, d)] for d in dates)
 
     return queries
 


### PR DESCRIPTION
## What

`navi_bench/resy/resy_url_match.py` had two hand-rolled accumulation loops where a comprehension is the standard idiom:

- `_render_placeholders_in_queries` built its nested result via a manual `new_group.append(...)` / `new_queries.append(new_group)` double loop instead of a nested list comprehension.
- `_render_placeholders_in_queries_all`'s inner per-date loop used `queries.append([...])` instead of `queries.extend(...)` with a generator expression.

Both were flagged independently by an extended `ruff check --select ALL` scan (this repo's configured lint set is `E`/`W`/`F` only, so `PERF401` doesn't fire in the normal `ruff check`) as "use a list comprehension / `list.extend` to create a transformed list." Same category as the recently-merged `dict.fromkeys` (#225) and `sum(start=...)` (#223) idiom swaps — replacing a hand-rolled loop with the stdlib-idiomatic equivalent, zero behavior change.

## Why safe

- Both loop bodies are pure (`str.replace`), no side effects, so reordering into a comprehension/`extend` is behavior-identical by construction.
- `_render_placeholders_in_queries` is exercised indirectly via `_render_placeholders_in_queries_any` in `tests/test_resy_url_match.py`; `_render_placeholders_in_queries_all` has direct test coverage in the same file.

## Verification

- `python -m pytest -q` — 483/483 passing, unchanged from baseline (before and after the change).
- `ruff check navi_bench/resy/resy_url_match.py` — clean; the two `PERF401` findings from the extended scan are resolved.
- `ruff format --check .` — same 2 pre-existing baseline spots as `main` (`evaluation/eval_n1.py`, `navi_bench/dates.py`), nothing new introduced.
- Standalone 2000-trial randomized old-vs-new parity script comparing the pre- and post-refactor implementations of both functions directly — 0 mismatches.

No functional change, no call sites touched, 1 file.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01UNp1qd4G67kz4mMxt5Z6u3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of pure string-replacement logic with existing tests; no call-site or API changes.
> 
> **Overview**
> This PR refactors two placeholder-rendering helpers in `resy_url_match.py` to use standard Python collection idioms instead of manual accumulation loops, with **no intended behavior change**.
> 
> **`_render_placeholders_in_queries`** now returns a nested list comprehension that applies `str.replace` on every URL in each query group, replacing the previous double loop that built `new_queries` / `new_group` with `append`.
> 
> **`_render_placeholders_in_queries_all`** builds the expanded query list with `queries.extend(...)` over a generator of single-URL groups per date, instead of appending one group at a time in an inner loop.
> 
> These functions still feed deterministic task config generation (`mode='any'` / `mode='all'`) and remain covered by `tests/test_resy_url_match.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11b8f132e50f492c526481f349138b9fc4bcb57e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->