### PR TITLE
refactor(vis): extract _get_tool_calls for duplicated OpenAI tool_calls guard

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -99,14 +99,17 @@ def _parse_tool_calls_from_openai_format(tool_calls: list[dict]) -> list[dict]:
     return actions
 
 
+def _get_tool_calls(msg: dict) -> list[dict]:
+    """Return the message's OpenAI-format ``tool_calls`` list, or ``[]`` if absent/falsy."""
+    return msg.get("tool_calls") or []
+
+
 def _parse_tool_calls(msg: dict) -> list[dict]:
     """Parse tool calls from an assistant message in OpenAI format.
 
     Returns a list of dicts with 'action_type' and other parameters extracted from arguments.
     """
-    if "tool_calls" in msg and msg["tool_calls"]:
-        return _parse_tool_calls_from_openai_format(msg["tool_calls"])
-    return []
+    return _parse_tool_calls_from_openai_format(_get_tool_calls(msg))
 
 
 def _anthropic_image_to_data_url(block: dict) -> str | None:
@@ -470,9 +473,10 @@ def _build_steps(
                 display_response = json.dumps(assistant_content, indent=2) if assistant_content else ""
 
             # If OpenAI format with tool_calls, show a more readable format
-            if "tool_calls" in msg and msg["tool_calls"]:
+            tool_calls = _get_tool_calls(msg)
+            if tool_calls:
                 tool_calls_summary = []
-                for tc in msg["tool_calls"]:
+                for tc in tool_calls:
                     func = tc.get("function", {})
                     tool_calls_summary.append(f"{func.get('name', 'unknown')}({func.get('arguments', '{}')})")
                 display_response = _join_text_and_tool_calls(assistant_text, tool_calls_summary)


### PR DESCRIPTION
## What

`evaluation/vis.py` had the same guard duplicated in two places:

```python
if "tool_calls" in msg and msg["tool_calls"]:
```

followed by indexing `msg["tool_calls"]` again — once in `_parse_tool_calls` (feeds the structured per-step `actions` list) and once in `generate_visualization_html`'s per-step display-text branch (feeds the human-readable `display_response` summary). Extracted a shared `_get_tool_calls(msg) -> msg.get("tool_calls") or []` helper and routed both call sites through it.

## Why it's an improvement

- Same "duplicated guard + repeated dict lookup" shape this file has already extracted elsewhere (`_first_present`, `_join_text_and_tool_calls`, `_render_section`/`_render_response_section` — see prior PRs #109/#111/#122/#123/#212).
- Also resolves ruff's `RUF019` ("unnecessary key check before dictionary access") at both sites — surfaced by an extended `ruff check --select ALL` scan (this repo's configured lint set is E/W/F only).

## Why it's safe

- Behavior-preserving: `msg.get("tool_calls") or []` returns `[]` in exactly the cases the old guard was `False` (key missing, or present but falsy — `None`/`[]`/etc.), and returns the actual list otherwise.
- Both call sites are already exercised by `tests/test_vis.py` — `_parse_tool_calls` via the action-parsing fixtures, the display-text branch via `test_openai_tool_calls_with_text`/`test_openai_tool_calls_without_text`.
- 483/483 tests pass unchanged, `ruff check` clean, `ruff format --check` shows only the same 2 pre-existing unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`).
- Single file, 9 insertions / 5 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5SrmyMFrBJAWuLXCswRiT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file, behavior-preserving refactor in evaluation visualization parsing with existing test coverage; no auth, data, or runtime path changes.
> 
> **Overview**
> Introduces **`_get_tool_calls(msg)`** in `evaluation/vis.py`, returning `msg.get("tool_calls") or []`, and routes both OpenAI **`tool_calls`** access paths through it.
> 
> **`_parse_tool_calls`** now always delegates to `_parse_tool_calls_from_openai_format(_get_tool_calls(msg))` instead of an inline `if "tool_calls" in msg and msg["tool_calls"]` guard. The **`_build_steps`** display branch uses the same helper before building the readable tool-call summary for **`display_response`**, so the duplicated key check and second dict lookup are gone.
> 
> Behavior stays the same for missing or falsy **`tool_calls`**; this is a small dedup aligned with other helpers in the file and clears ruff **RUF019** at those sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b0fa21c86f3f7e23489e79818b0ddc490418a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->