### PR TITLE
refactor(relative_dates): extract _weekdays_in_month for duplicated month-day filter loop

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -421,6 +421,11 @@ def _iter_month_days(y: int, m: int):
         yield date(y, m, d)
 
 
+def _weekdays_in_month(y: int, m: int, wds: set[int]) -> list[date]:
+    """Days in year/month `y`/`m` whose weekday is in `wds`."""
+    return [d for d in _iter_month_days(y, m) if d.weekday() in wds]
+
+
 def _month_ref_to_year_month(text: str, base: date) -> tuple[int, int]:
     """
     Resolve phrases like:
@@ -626,9 +631,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
     if m:
         wds = _parse_weekdays_or_raise(m.group(1))
         y, mo = _month_ref_to_year_month(m.group(2) + " month", base)
-        for d in _iter_month_days(y, mo):
-            if d.weekday() in wds:
-                out.append(d)
+        out.extend(_weekdays_in_month(y, mo, wds))
         out.sort()
         return _maybe_iso_list(out, return_iso)
 
@@ -644,9 +647,7 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
         # iterate months inclusive
         y, mo = y1, m1
         while (y < y2) or (y == y2 and mo <= m2):
-            for d in _iter_month_days(y, mo):
-                if d.weekday() in wds:
-                    out.append(d)
+            out.extend(_weekdays_in_month(y, mo, wds))
             # next month (day=1 never triggers clamp_day's end-of-month clamping)
             next_month = add_months(date(y, mo, 1), 1)
             y, mo = next_month.year, next_month.month


### PR DESCRIPTION
## What

`parse_relative_dates` in `navi_bench/relative_dates.py` had the identical 3-line loop duplicated across two branches:

```python
for d in _iter_month_days(y, mo):
    if d.weekday() in wds:
        out.append(d)
```

- Branch 1 (`"<weekdays> in (this|next|last) month"`)
- Branch 2 (`"<weekdays> in <month-ref> through <month-ref>"`, inside its month-stepping `while` loop)

Extracted a small helper:

```python
def _weekdays_in_month(y: int, m: int, wds: set[int]) -> list[date]:
    """Days in year/month `y`/`m` whose weekday is in `wds`."""
    return [d for d in _iter_month_days(y, m) if d.weekday() in wds]
```

and replaced both call sites with `out.extend(_weekdays_in_month(y, mo, wds))`.

## Why this is safe

- **Behavior-preserving:** the helper iterates `_iter_month_days` in the exact same order and applies the exact same weekday filter as the old inline loop, so `out.extend(...)` appends the same elements in the same order that the old loop appended one at a time. The trailing `out.sort()` at each call site is untouched.
- **Scope:** single file, single duplicated pattern, no interface/behavior changes.
- **Tests:** 483/483 tests pass unchanged. Both affected branches are covered by `tests/test_relative_dates.py` (e.g. the `"weekends in the next month"` case and the `"Mondays in this month through next Jan"` case).
- `ruff check` and `ruff format --check` are clean on the changed file.
- This mirrors the file's existing convention of extracting shared parsing helpers out of duplicated blocks (e.g. the earlier `_parse_weekdays_or_raise` extraction).

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01VXSNPQoa3U8k6jbJVLwUSK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in relative date parsing only; no API or logic changes beyond deduplication.
> 
> **Overview**
> Pulls duplicated “walk every day in a month and keep matching weekdays” logic in **`parse_relative_dates`** into a shared **`_weekdays_in_month`** helper next to **`_iter_month_days`**.
> 
> Both affected phrase handlers now call **`out.extend(_weekdays_in_month(y, mo, wds))`** instead of inline loops: **`<weekdays> in (this|next|last) month`** and **`<weekdays> in <month-ref> through <month-ref>`** (inside the month-stepping loop). Ordering and filtering are unchanged; existing **`out.sort()`** at each branch is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6372829c619464d41793a22a18c0d46557982489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->