### PR TITLE
refactor(vis): replace hand-rolled text-block accumulation loop with a comprehension

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -422,11 +422,10 @@ def _build_steps(
                 assistant_content = ""
 
             # Extract text from Anthropic format (list with text blocks)
-            text_parts = []
             if isinstance(assistant_content, list):
-                for block in assistant_content:
-                    if _block_type(block) == "text":
-                        text_parts.append(_block_field(block, "text", ""))
+                text_parts = [
+                    _block_field(block, "text", "") for block in assistant_content if _block_type(block) == "text"
+                ]
                 assistant_text = "\n\n".join(text_parts) if text_parts else ""
             elif isinstance(assistant_content, str):
                 assistant_text = assistant_content

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -454,6 +454,25 @@ class TestAssistantResponseToolCallSummary:
         )
         assert _raw_response_text(html) == 'Tool calls:\nleft_click({"ref": "e1"})'
 
+    def test_anthropic_tool_use_with_multiple_text_blocks(self):
+        """Anthropic content can carry more than one text block before the tool_use block;
+        they must be joined with a blank line, matching the join used for a single block."""
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "do the task"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "first, I'll check the page"},
+                    {"type": "text", "text": "then I'll click the button"},
+                    {"type": "tool_use", "name": "left_click", "input": {}},
+                ],
+            },
+        ]
+        html = generate_visualization_html("task1", messages, None)
+        assert _raw_response_text(html) == (
+            "first, I'll check the page\n\nthen I'll click the button\n\nTool calls:\nleft_click({})"
+        )
+
 
 def _messages_with_final_answer(text: str | None) -> list[dict]:
     """Assistant message with no tool_calls, i.e. an implicit "final answer" stop."""


### PR DESCRIPTION
## What

`evaluation/vis.py::_build_steps`'s Anthropic text-block extraction built `text_parts` with a hand-rolled append loop:

```python
text_parts = []
if isinstance(assistant_content, list):
    for block in assistant_content:
        if _block_type(block) == "text":
            text_parts.append(_block_field(block, "text", ""))
    assistant_text = "\n\n".join(text_parts) if text_parts else ""
```

three lines below the adjacent tool_use extraction over the same `assistant_content` list, which already uses a comprehension for the identical filter-then-extract shape:

```python
tool_uses = [b for b in assistant_content if _block_type(b) == "tool_use"]
```

This PR converts the text-block loop to the same comprehension style, matching the pattern this repo has applied repeatedly elsewhere (e.g. #226's `resy_url_match.py` accumulation-loop-to-comprehension conversions).

## Why it's safe

- Same predicate (`_block_type(block) == "text"`), same field lookup (`_block_field(block, "text", "")`), same iteration order, no early exit (`break`/`continue`) in the original loop that a comprehension could lose.
- `_block_field`/`_block_type` are pure lookups with no side effects, so reordering evaluation makes no observable difference.
- The `text_parts = []` pre-initialization is now dead (the comprehension binds `text_parts` directly inside the `if isinstance(..., list)` branch, same as the sibling `tool_uses` line) and is removed.
- Added `TestAssistantResponseToolCallSummary.test_anthropic_tool_use_with_multiple_text_blocks`, the first characterization test for the "more than one text block, joined with `\n\n`" case (previously only single-block/no-block were covered) — confirmed it passes against the pre-refactor code first, then again after the refactor.
- Full suite: 483 → 484 passing. `ruff check .` clean. `ruff format --check .` shows only the same 2 pre-existing baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`), unrelated to this change and untouched by it.

## Scope

Single file touched (`evaluation/vis.py`) plus its test file. No behavior change, no call-site changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_015kyXN3gccqEg4oviowQPKA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style-only change in eval visualization parsing plus a new characterization test; no API or production-path changes.
> 
> **Overview**
> In **`_build_steps`**, Anthropic assistant **text blocks** are collected with a **list comprehension** instead of an append loop, aligned with the nearby **`tool_uses`** filter style. **Joining** multiple text blocks with **`\\n\\n`** and building the Raw Response string is unchanged.
> 
> Adds **`test_anthropic_tool_use_with_multiple_text_blocks`**, which locks in Raw Response when an assistant message has **several text blocks** before a **`tool_use`** block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e85f1bb47214deb9107fd92934037cf3aedc184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->