### PR TITLE
refactor(stats): replace hand-rolled per-difficulty append loop with list.extend

### DIFF
--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -190,9 +190,11 @@ def show_results(dataset: list[DatasetItem], results: list[BaseModel | Crashed])
         all_entries.extend(domain_entries)
         table_rows.append(_metrics_row(domain, domain_entries))
 
-        for diff in difficulties_order:
-            if diff in difficulty_data:
-                table_rows.append(_metrics_row(f"  └─ {diff}", difficulty_data[diff]))
+        table_rows.extend(
+            _metrics_row(f"  └─ {diff}", difficulty_data[diff])
+            for diff in difficulties_order
+            if diff in difficulty_data
+        )
 
         table_rows.append(SEPARATING_LINE)
 


### PR DESCRIPTION
## What

`evaluation/stats.py::show_results` built its per-difficulty sub-rows with a
hand-rolled `for diff in difficulties_order: if diff in difficulty_data: table_rows.append(...)`
loop, instead of a single `list.extend(...)` comprehension.

## Why it's safe

- This is the exact same category of change already applied repeatedly in this
  file/repo's history (#225, #226, #228, #229: replacing a hand-rolled
  accumulation loop with the stdlib `list.extend`/comprehension idiom),
  flagged here by `ruff --select PERF401`.
- It's a pure mechanical transform: the comprehension iterates the same
  `difficulties_order` sequence in the same order, applies the same `if diff
  in difficulty_data` filter, and calls the same `_metrics_row(...)` per
  matching element — `list.extend` on a generator preserves order and produces
  a byte-identical `table_rows` list.
- The very next line above (`domain_entries.extend(difficulty_data[diff])`
  inside the same `for` loop shape) already uses this idiom, so the change
  also makes the two adjacent loops in this function consistent with each
  other.
- Existing coverage in `tests/test_stats.py::TestShowResultsSummaryTable`
  already exercises this exact code path with multiple difficulties across
  two domains (pinning both the domain rows and the `└─ {diff}` sub-rows) —
  no new tests were needed, and the full suite (484 tests) passes unchanged
  before and after.
- Single file, 1 function, no interface/type changes, no `@beartype`
  decorators anywhere near this code.

## Verification

- `ruff check --select PERF401 .` — clean (was 1 hit, now 0)
- `ruff check .` — clean
- `ruff format --check .` — same 2 pre-existing, unrelated baseline spots
  (`evaluation/eval_n1.py`, `navi_bench/dates.py`), unchanged
- `pytest tests/` — 484 passed, identical to the pre-change baseline


---
_Generated by [Claude Code](https://claude.ai/code/session_016zsvMMgKqk2LEhqgNfdzNP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single mechanical refactor in summary table assembly with existing test coverage and no API or output contract changes.
> 
> **Overview**
> In **`show_results`**, building per-difficulty sub-rows (`└─ {diff}`) now uses **`table_rows.extend(...)`** with a generator comprehension instead of a **`for` / `if` / `append`** loop.
> 
> Behavior is unchanged: same **`difficulties_order`**, same **`diff in difficulty_data`** filter, same **`_metrics_row`** calls—aligned with the adjacent **`domain_entries.extend`** pattern and clears **`ruff PERF401`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740cadc3fd1d810eb9acf5afa93664d8c43cb377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->