### PR TITLE
refactor(base): extract find_equal_value_entry for duplicated GT-coverage lookup

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -165,6 +165,23 @@ def parse_filtered_query_params(query: str, ignored: Iterable[str]) -> dict[str,
 
 
 _T = TypeVar("_T")
+_KT = TypeVar("_KT")
+
+
+def find_equal_value_entry(observed: dict[_KT, _T], target: _T) -> tuple[_KT, _T] | None:
+    """Return the first ``(key, value)`` pair in ``observed`` whose value equals ``target``, else ``None``.
+
+    Centralizes the "scan recorded observations for one that equals a required ground-truth
+    value" loop that craigslist's AND-of-OR URL coverage (``CraigslistUrlMatch.compute``) and
+    google_flights' per-segment info coverage (``GoogleFlightsSearchMatch.compute``) each
+    hand-rolled with the same shape, differing only in variable names. A plain
+    ``target in observed.values()`` doesn't fit either call site as-is, since both also log
+    which key matched.
+    """
+    for key, value in observed.items():
+        if value == target:
+            return key, value
+    return None
 
 
 def unwrap_single_template_query(

--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -9,6 +9,7 @@ from navi_bench.base import (
     ResetsViaState,
     UrlMetricInput,
     build_task_config,
+    find_equal_value_entry,
     fractional_coverage_score,
     parse_filtered_query_params,
     repr_with_attr,
@@ -55,19 +56,17 @@ class CraigslistUrlMatch(ResetsViaState):
         for i, candidate_gt_states in enumerate(self._gt_states):
             # Second level of iteration: good if any of the elements in `candidate_gt_states` is covered
             for j, gt_state in enumerate(candidate_gt_states):
-                is_covered = False
-                for intermediate_url, intermediate_state in self._intermediate_url_to_state.items():
-                    if intermediate_state == gt_state:  # dicts need to be exactly the same
-                        is_covered = True
-                        n_covered += 1
-                        logger.info(
-                            f"CraigslistUrlMatch.compute found {i}-th candidate URL covered:\n"
-                            f"    intermediate_url: {intermediate_url}\n"
-                            f"    gt_url: {self.gt_urls[i][j]}\n"
-                            f"    gt_state: {gt_state}"
-                        )
-                        break
-                if is_covered:
+                # dicts need to be exactly the same
+                match = find_equal_value_entry(self._intermediate_url_to_state, gt_state)
+                if match is not None:
+                    intermediate_url, _ = match
+                    n_covered += 1
+                    logger.info(
+                        f"CraigslistUrlMatch.compute found {i}-th candidate URL covered:\n"
+                        f"    intermediate_url: {intermediate_url}\n"
+                        f"    gt_url: {self.gt_urls[i][j]}\n"
+                        f"    gt_state: {gt_state}"
+                    )
                     break
 
         n_required = len(self._gt_states)

--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -15,6 +15,7 @@ from navi_bench.base import (
     UrlMetricInput,
     all_or_nothing_coverage_result,
     build_task_config,
+    find_equal_value_entry,
     repr_with_attr,
 )
 from navi_bench.dates import initialize_placeholder_map, initialize_user_metadata, render_task_statement
@@ -151,16 +152,15 @@ class GoogleFlightsSearchMatch(ResetsViaState):
 
         # Every Info object in `self._gt_base_info` must be covered
         for i, gt_info in enumerate(self._gt_base_info):
-            # Iterate over
-            for url, flight_info in self._url_to_flight_info.items():
-                # compare on the FlightInfo, which compares field by field
-                if flight_info == gt_info:
-                    is_info_covered[i] = True
-                    logger.info(
-                        f"GoogleFlightsUrlMatch.compute found match for query {i}: "
-                        f"url={url}, flight_info={flight_info}, GT={gt_info}"
-                    )
-                    break
+            # compare on the FlightInfo, which compares field by field
+            match = find_equal_value_entry(self._url_to_flight_info, gt_info)
+            if match is not None:
+                url, flight_info = match
+                is_info_covered[i] = True
+                logger.info(
+                    f"GoogleFlightsUrlMatch.compute found match for query {i}: "
+                    f"url={url}, flight_info={flight_info}, GT={gt_info}"
+                )
 
         # Score is 1.0 only if all infos are covered
         return all_or_nothing_coverage_result("GoogleFlightsUrlMatch", is_info_covered)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -15,6 +15,7 @@ from navi_bench.base import (
     FinalResult,
     all_or_nothing_coverage_result,
     basic_pydantic_to_hf_features,
+    find_equal_value_entry,
     unwrap_optional_type,
 )
 from navi_bench.google_flights.google_flights_search_match import GoogleFlightsSearchMatch
@@ -87,6 +88,28 @@ class TestGoogleFlightsSearchMatchComputeUsesSharedHelper:
         result = _run(metric.compute())
 
         assert result.score == 1.0
+
+
+class TestFindEqualValueEntry:
+    """Characterization tests for the shared "scan a dict for the first value equal to a
+    target, returning its (key, value) pair" lookup, extracted from the near-identical loop
+    ``CraigslistUrlMatch.compute()`` and ``GoogleFlightsSearchMatch.compute()`` each hand-rolled
+    (they also need the matching key for their log messages, unlike a plain
+    ``target in observed.values()`` membership check).
+    """
+
+    def test_returns_first_matching_key_value_pair(self):
+        observed = {"a": 1, "b": 2, "c": 2}
+
+        assert find_equal_value_entry(observed, 2) == ("b", 2)
+
+    def test_returns_none_when_no_value_matches(self):
+        observed = {"a": 1, "b": 2}
+
+        assert find_equal_value_entry(observed, 3) is None
+
+    def test_empty_dict_returns_none(self):
+        assert find_equal_value_entry({}, "anything") is None
 
 
 class TestUnwrapOptionalType:


### PR DESCRIPTION
## What

`CraigslistUrlMatch.compute()` (`navi_bench/craigslist/craigslist_url_match.py`) and `GoogleFlightsSearchMatch.compute()` (`navi_bench/google_flights/google_flights_search_match.py`) each hand-rolled the identical loop shape: scan a dict of observed values for one that equals a required ground-truth value, and grab its key for a log message. The two copies differed only in variable names (`intermediate_url`/`intermediate_state` vs. `url`/`flight_info`).

A plain `target in observed.values()` doesn't fit either call site as-is, since both also need the matching *key* for their log message — so each site had grown its own manual `for key, value in observed.items(): if value == target: ...` loop instead.

## The change

Extracted `find_equal_value_entry(observed: dict, target) -> tuple[key, value] | None` into `navi_bench/base.py`, alongside this repo's other shared coverage helpers (`fractional_coverage_score`, `all_or_nothing_coverage_result`). Both call sites now delegate; control flow, log messages, and scoring semantics are unchanged — this is a pure "duplicated block → named shared helper" extraction with no behavior change.

## Why it's safe

- Both `compute()` methods already have direct test coverage in `tests/test_craigslist_url_match.py` and `tests/test_google_flights_search_match.py` (covered/uncovered/partial-coverage/OR-alternative cases) — all pass unchanged.
- Added `TestFindEqualValueEntry` in `tests/test_base.py` with direct characterization tests for the new helper (first-match, no-match, empty-dict cases).
- Full suite: 484 → 487 passing (3 new tests), `ruff check` clean, `ruff format --check` shows only the 2 pre-existing unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`) that predate this change.
- Single new shared helper, 3 files touched (plus a test file) — narrowly scoped, no functional/behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016B9w6ujZ6sUtNz5RkURGju)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with direct unit tests; only shared lookup logic moved, no scoring or URL parsing changes.
> 
> **Overview**
> Pulls a shared **`find_equal_value_entry`** helper into `navi_bench/base.py` so matchers can find the first dict entry whose value equals a ground-truth target and still get the matching **key** for logging (a plain `target in observed.values()` check isn’t enough).
> 
> **`CraigslistUrlMatch.compute()`** and **`GoogleFlightsSearchMatch.compute()`** now call that helper instead of duplicating the same `for key, value in observed.items()` loop. Scoring, break/continue behavior, and log output stay the same.
> 
> Adds **`TestFindEqualValueEntry`** in `tests/test_base.py` (first match, no match, empty dict).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8315da5f8fe974db50316dffceb99d3ba6080f2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->