### PR TITLE
refactor(stats): replace remaining hand-rolled per-difficulty extend loop with a comprehension

### DIFF
--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -182,10 +182,9 @@ def show_results(dataset: list[DatasetItem], results: list[BaseModel | Crashed])
     for domain in sorted(per_domain_difficulty.keys()):
         difficulty_data = per_domain_difficulty[domain]
 
-        domain_entries: list[tuple[float, bool]] = []
-        for diff in difficulties_order:
-            if diff in difficulty_data:
-                domain_entries.extend(difficulty_data[diff])
+        domain_entries: list[tuple[float, bool]] = [
+            entry for diff in difficulties_order if diff in difficulty_data for entry in difficulty_data[diff]
+        ]
 
         all_entries.extend(domain_entries)
         table_rows.append(_metrics_row(domain, domain_entries))


### PR DESCRIPTION
## Issue

`show_results()` built `domain_entries` with a hand-rolled `for`/`if`/`extend` loop, two lines above a near-identical `table_rows.extend(...)` comprehension that #230 just converted from the exact same pattern (`for diff in difficulties_order: if diff in difficulty_data: ...`). This occurrence was left behind in the same function/file.

## Improvement

Replaced the loop with a nested-for list comprehension that flattens each difficulty's list of `(score, crashed)` entries in `difficulties_order`:

```python
domain_entries: list[tuple[float, bool]] = [
    entry for diff in difficulties_order if diff in difficulty_data for entry in difficulty_data[diff]
]
```

Control flow and output are unchanged — this only changes *how* the same list is built.

## Safety

- `show_results()` has direct characterization test coverage in `tests/test_stats.py` pinning its printed summary table (per-domain rows, per-difficulty sub-rows, overall row).
- All 487 tests pass unchanged (`pytest -q`).
- `ruff check .` clean; `ruff format --check .` shows only the same 2 pre-existing unrelated baseline format spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`) already noted in #231 — `evaluation/stats.py` itself is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxHpJZtEnUV7YK8KiYPdSx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in evaluation reporting; characterization tests in `tests/test_stats.py` pin the summary output.
> 
> **Overview**
> In `show_results()`, **domain-level summary rows** now build `domain_entries` with a nested list comprehension instead of a `for`/`if`/`extend` loop over `difficulties_order`.
> 
> The comprehension still walks difficulties in fixed order (`easy`, `medium`, `hard`, `unknown`), only includes keys present in `difficulty_data`, and flattens each difficulty’s `(score, crashed)` tuples into one list. **Printed tables and metrics are unchanged**—this matches the comprehension style already used for per-difficulty `table_rows` lines in the same loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff2aceba0052b6c8214ac10e2fe1aebf71640e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->