### PR TITLE
refactor(resy_url_match): replace key-check guard with dict.get

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -411,8 +411,9 @@ class ResyUrlMatch(ResetsViaState):
         }[mode]
 
         for key in params_to_include:
-            if key in query_params and query_params[key]:
-                normalized_params[key] = query_params[key][0]
+            value = query_params.get(key)
+            if value:
+                normalized_params[key] = value[0]
 
         # Add query parameters in sorted order for consistency
         if normalized_params:


### PR DESCRIPTION
## Day-over-day pattern

Six refactor PRs landed today (2026-08-26): #227, #228, #229, #230, #231, #232. #227 in particular established a pattern for this repo — replacing an `if key in dict and dict[key]: ... dict[key]` guard (which re-indexes the dict after already checking membership) with a single `dict.get(key)` call, explicitly noting in its PR body that this also resolves ruff's `RUF019` ("unnecessary key check before dictionary access").

Scanning for the same shape across the rest of the repo (the other 5 PRs touched `stats.py`, `base.py`, `vis.py`, and `relative_dates.py`, but not `navi_bench/resy/`) turns up one more instance today's sweep didn't reach:

```python
# navi_bench/resy/resy_url_match.py, _normalize_url()
for key in params_to_include:
    if key in query_params and query_params[key]:
        normalized_params[key] = query_params[key][0]
```

## What this PR does

```python
for key in params_to_include:
    value = query_params.get(key)
    if value:
        normalized_params[key] = value[0]
```

Behavior-preserving: `query_params.get(key)` returns `None` when the key is absent (matching the old membership check) or the same list when present, and `if value:` matches the old truthy guard exactly (an empty list is falsy either way).

`ruff check` / `ruff format --check` clean. `tests/test_resy_url_match.py` (57/57) and the full suite (487/487) pass unchanged.

cc @dhruvbatra as author of all six of today's refactor PRs establishing this pattern, for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNvFHCHkBM1PjU9n1Y5VHj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny, behavior-preserving refactor in URL normalization with no change to matching semantics.
> 
> **Overview**
> Applies the same **dict access refactor** used elsewhere in today's sweep to `_normalize_url` when building canonical query strings from `parse_qs` output.
> 
> For each mode-selected key (`date`, `seats`, `time`), the loop now uses **`query_params.get(key)`** and a single truthy check instead of **`key in query_params` plus a second `query_params[key]` lookup**. Normalized URLs are unchanged: missing keys are still skipped, and only the first list element is kept when a value is present.
> 
> This also clears **ruff `RUF019`** (unnecessary key check before dictionary access) for this spot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2fa66f5b7a3d78be97bf2ab8d41dad897726635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->