### PR TITLE
refactor(resy): use dict.get instead of key-check-then-index in _normalize_url

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -411,8 +411,8 @@ class ResyUrlMatch(ResetsViaState):
         }[mode]
 
         for key in params_to_include:
-            if key in query_params and query_params[key]:
-                normalized_params[key] = query_params[key][0]
+            if values := query_params.get(key):
+                normalized_params[key] = values[0]
 
         # Add query parameters in sorted order for consistency
         if normalized_params:

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -403,6 +403,38 @@ class TestGenerateTaskConfigRandomDaysAheadCapping:
 # A ground-truth URL whose `time` param is in raw "HHMM" form, so a browser URL using
 # colon-separated time (e.g. "19:00") normalizes to the same time-of-day but fails the
 # strict raw-string URL comparison -- the setup the conditional-match tests below rely on.
+class TestNormalizeUrl:
+    """Characterization tests for ``_normalize_url``'s query-parameter extraction, which loops
+    over ``params_to_include`` and only copies a parameter into ``normalized_params`` when it is
+    both present in the parsed query string and non-empty. The existing ``update``/``compute``
+    tests below only exercise URLs where every ``full``-mode parameter (date/seats/time) is
+    present, so this pins the "requested parameter missing from the URL entirely" branch, which
+    otherwise has no direct coverage.
+    """
+
+    def test_full_mode_with_all_params_present(self):
+        url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=2&time=1900"
+        assert (
+            ResyUrlMatch._normalize_url(url, mode="full")
+            == "resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=2&time=1900"
+        )
+
+    def test_full_mode_with_a_requested_param_missing_from_the_url(self):
+        # No "seats" in the query string at all -- distinct from an empty "seats=" value.
+        url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&time=1900"
+        assert (
+            ResyUrlMatch._normalize_url(url, mode="full")
+            == "resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&time=1900"
+        )
+
+    def test_date_only_mode_ignores_other_present_params(self):
+        url = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=2&time=1900"
+        assert (
+            ResyUrlMatch._normalize_url(url, mode="date_only")
+            == "resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15"
+        )
+
+
 _GT_URL = "https://resy.com/cities/new-york-ny/venues/carbone?date=2025-07-15&seats=2&time=1900"
 
 


### PR DESCRIPTION
## Issue

`ResyUrlMatch._normalize_url`'s query-parameter extraction loop checked `key in query_params and query_params[key]` before indexing `query_params[key]` a second time to read the value — an "unnecessary key check before dictionary access" (ruff `RUF019`). This is the same pattern already extracted once in this repo, in `evaluation/vis.py`'s `_get_tool_calls` (PR #227), just a fresh, previously-unflagged occurrence in a different file.

## Improvement

Replaced the two-step check-then-index with a single `query_params.get(key)` walrus assignment:

```python
for key in params_to_include:
    if values := query_params.get(key):
        normalized_params[key] = values[0]
```

`.get(key)` is truthy in exactly the same cases the old guard was: a missing key returns `None` (falsy), and a present key from `parse_qs` is always a non-empty list (also matching the old `and query_params[key]` truthiness check).

## Safety

- `_normalize_url` previously had no *direct* test coverage — it was only exercised indirectly through `update()`/`compute()` tests, and only with URLs where every `full`-mode query parameter (date/seats/time) was present. Added a small `TestNormalizeUrl` class with 3 characterization tests, including one URL that omits a requested parameter entirely (the exact branch this change touches, previously untested).
- Verified the new tests pass identically against both the pre-refactor and post-refactor source (via `git stash`), confirming the change is behavior-preserving.
- Full suite: 490/490 passing (487 baseline + 3 new tests).
- `ruff check .`: clean. `ruff format --check .`: only the same 2 pre-existing, unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`).
- Single file touched in source (`navi_bench/resy/resy_url_match.py`), plus the new test file addition. No behavior, scoring, or verifier semantics changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KCbaVfB4N7TLXDPHYmhgio)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving style refactor in Resy URL canonicalization with new direct tests; no intentional scoring or matcher semantic changes.
> 
> **Overview**
> Refactors **`ResyUrlMatch._normalize_url`** so each mode’s query keys are copied with a single walrus + **`query_params.get(key)`** instead of a separate membership check and second dict lookup (addresses ruff **`RUF019`**). Missing keys and empty values are still skipped the same way as before.
> 
> Adds **`TestNormalizeUrl`** with three characterization tests that directly exercise **`_normalize_url`**, including **`full`** mode when a requested param (e.g. **`seats`**) is absent from the URL and **`date_only`** mode when extra params are present—coverage the existing **`update`**/**`compute`** tests did not hit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489b3f11bc570b0cc4d8b184617ec44a154c752e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->