### PR TITLE
refactor(relative_dates): chain the cause when parse_relative_dates re-raises ValueError

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -806,8 +806,8 @@ def parse_relative_dates(query: str, base: date | None = None, return_iso: bool 
     try:
         d = parse_relative_date(query, base, return_iso=False)
         return [d.isoformat()] if return_iso else [d]
-    except ValueError:
-        raise ValueError(f"Could not parse date range/multiple description: '{query}'")
+    except ValueError as e:
+        raise ValueError(f"Could not parse date range/multiple description: '{query}'") from e
 
 
 # --------------------------

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -460,3 +460,21 @@ class TestExpandMdRangeDirect:
         assert _expand_md_range(2025, 5, 11, 14, base=base, modifier="coming") == _expand_md_range(
             2025, 5, 11, 14, base=base, modifier="next"
         )
+
+
+class TestParseRelativeDatesUnparsableFallbackChainsCause:
+    """``parse_relative_dates``'s final fallback (single-date parser) wraps a ``ValueError``
+    raised by ``parse_relative_date`` into its own, more specific ``ValueError``. This pins that
+    the wrapping preserves exception chaining (``raise ... from e``), matching the convention
+    used everywhere else in the repo an exception is re-raised as a different type (e.g.
+    ``base.py``'s ``ImportError from e``, ``google_flights_search_match.py``'s
+    ``ValueError from e``) -- this was previously the sole site missing ``from e``, which drops
+    the original traceback/cause when the wrapped error is inspected or logged.
+    """
+
+    def test_unparsable_query_raises_with_original_error_as_cause(self):
+        with pytest.raises(ValueError, match="Could not parse date range/multiple description") as exc_info:
+            parse_relative_dates("asdfghjkl gibberish query", BASE_DATE)
+
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "Could not parse relative date description" in str(exc_info.value.__cause__)


### PR DESCRIPTION
## What

`parse_relative_dates()`'s final fallback branch (the single-date parser) catches
`ValueError` and re-raises a more specific `ValueError` describing the query, but
dropped the original exception's traceback/cause instead of chaining it with
`from e`:

```python
try:
    d = parse_relative_date(query, base, return_iso=False)
    return [d.isoformat()] if return_iso else [d]
except ValueError:
    raise ValueError(f"Could not parse date range/multiple description: '{query}'")
```

## Why this is an improvement

This is the **sole site in the repo** missing this convention — every other
except-and-re-raise-as-a-different-type site already chains explicitly:

- `navi_bench/base.py`: `raise ImportError(...) from e`
- `navi_bench/google_flights/google_flights_search_match.py`: `raise ValueError(...) from e`

So the fix brings this one straggler in line with the codebase's own established
pattern rather than introducing anything new. Without the chain, anyone debugging
an "unparsable date" failure only sees the generic wrapper message and loses the
original `ValueError` (and its traceback) that actually explains what went wrong —
`ruff --select B904` flags exactly this.

## Why it's safe

- Single-line functional change (`except ValueError:` → `except ValueError as e:`,
  and `from e` appended to the re-raise); everything else is test scaffolding.
- This raise path had **zero prior test coverage**. Added a characterization test
  (`TestParseRelativeDatesUnparsableFallbackChainsCause`) asserting the wrapped
  `ValueError.__cause__` is the original `ValueError` from `parse_relative_date`.
  Confirmed via `git stash` that the new test **fails** against the pre-fix code
  (`__cause__` is `None`) and **passes** post-fix.
- Full suite: 489 → 491 tests passing (`pytest -q`).
- `ruff check .`: clean. `ruff format --check .`: only the same 2 pre-existing,
  unrelated baseline spots (`evaluation/eval_n1.py:318`, `navi_bench/dates.py:151`) —
  neither touched by this change.
- No verifier/scoring logic touched — this only affects how a parse error is
  reported, not what dates are resolved.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HcqXEC4CiRq5oXTYH6itAh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line exception-handling change on an error-only path; no date resolution or scoring logic is affected.
> 
> **Overview**
> When `parse_relative_dates` falls through to the single-date parser and that fails, the re-raised `ValueError` now uses **`raise ... from e`** so the underlying `parse_relative_date` error remains on **`__cause__`** for logs and debugging. This matches the repo’s other wrap-and-re-raise sites; parsing behavior for valid queries is unchanged.
> 
> A new test (`TestParseRelativeDatesUnparsableFallbackChainsCause`) asserts an unparsable query raises the range/multiple message and that **`__cause__`** is the original relative-date `ValueError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574baa66a5020d45e990b37e74730a59082c18a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->