### PR TITLE
refactor(google_flights): replace hand-rolled passenger-append loop with extend

### DIFF
--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -126,8 +126,7 @@ class GoogleFlightsSearchMatch(ResetsViaState):
             data.from_flight.airport = segment["from"]
             data.to_flight.airport = segment["to"]
 
-        for passenger in gt_info["passengers"]:
-            info.passengers.append(passenger)
+        info.passengers.extend(gt_info["passengers"])
 
         info.seat = gt_info["seat"]
         info.trip = gt_info["trip"]


### PR DESCRIPTION
## Issue

`GoogleFlightsSearchMatch._create_base_info()` built `info.passengers` (a protobuf repeated field, which supports the standard list-like `.extend()` method) using a hand-rolled `for` loop calling `.append()` on each element, instead of a single `.extend()` call.

## Improvement

```python
-        for passenger in gt_info["passengers"]:
-            info.passengers.append(passenger)
+        info.passengers.extend(gt_info["passengers"])
```

This is the same "hand-rolled accumulation loop → `extend()`/comprehension" idiom already applied repeatedly elsewhere in this repo (e.g. `relative_dates.py`'s weekday-filter loop in #228, `evaluation/stats.py`'s per-difficulty accumulation loops in #229/#230/#232).

## Why this is safe

- **Behavior-preserving**: `.extend()` appends every element in the exact same order the loop did — protobuf repeated fields support `.extend(iterable)` identically to a plain Python list.
- **Existing test coverage**: `tests/test_google_flights_search_match.py` already exercises `_create_base_info` with both a single-passenger case and a multi-passenger case (`["ADULT", "CHILD"]`), directly asserting `list(info.passengers) == [gf.ADULT, gf.CHILD]`. No new tests were needed.
- **Verified**: full local suite passes unchanged (491/491 tests), `ruff check` clean, `ruff format --check` shows only the 2 pre-existing unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`), neither touched by this change.
- Single file, minimal diff (-2/+1 lines). No functionality change — pure internal loop-to-stdlib-idiom refactor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GEicazXQN1XrRTyMmyTdFA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line, behavior-preserving refactor in benchmark ground-truth construction with existing test coverage.
> 
> **Overview**
> In **`GoogleFlightsSearchMatch._create_base_info`**, populating the protobuf **`info.passengers`** repeated field now uses a single **`info.passengers.extend(gt_info["passengers"])`** instead of looping with **`.append()`** per passenger.
> 
> Order and contents are unchanged; this is an internal idiomatic cleanup only. Existing tests in **`tests/test_google_flights_search_match.py`** already cover single- and multi-passenger cases for this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23a1cd069a8197cfec9555639ebfc59af29773e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->