### PR TITLE
refactor(vis): replace hand-rolled param_parts loop with list comprehension

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -455,9 +455,7 @@ def _build_steps(
                             # Build a concise summary of the action parameters
                             params = {k: v for k, v in inp.items() if k != "action"}
                             if params:
-                                param_parts = []
-                                for k, v in params.items():
-                                    param_parts.append(f"{k}={json.dumps(v)}")
+                                param_parts = [f"{k}={json.dumps(v)}" for k, v in params.items()]
                                 tool_summary.append(f"{action_name}({', '.join(param_parts)})")
                             else:
                                 tool_summary.append(f"{action_name}()")

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -442,6 +442,37 @@ class TestAssistantResponseToolCallSummary:
         )
         assert _raw_response_text(html) == 'Tool calls:\ntype({"text": "hi"})'
 
+    def test_anthropic_browser_tool_unwraps_action_with_single_param(self):
+        """The "browser"/"computer" tool name is unwrapped to show its inner action name
+        directly, with the remaining input fields rendered as key=value parameters."""
+        html = generate_visualization_html(
+            "task1",
+            _messages_with_anthropic_tool_use(
+                None, name="browser", tool_input={"action": "left_click", "coordinates": [10, 20]}
+            ),
+            None,
+        )
+        assert _raw_response_text(html) == "Tool calls:\nleft_click(coordinates=[10, 20])"
+
+    def test_anthropic_computer_tool_unwraps_action_with_multiple_params(self):
+        """Multiple remaining input fields are joined in iteration order."""
+        html = generate_visualization_html(
+            "task1",
+            _messages_with_anthropic_tool_use(
+                None, name="computer", tool_input={"action": "type", "text": "hi", "coordinate": [1, 2]}
+            ),
+            None,
+        )
+        assert _raw_response_text(html) == 'Tool calls:\ntype(text="hi", coordinate=[1, 2])'
+
+    def test_anthropic_browser_tool_action_with_no_other_params(self):
+        html = generate_visualization_html(
+            "task1",
+            _messages_with_anthropic_tool_use(None, name="browser", tool_input={"action": "screenshot"}),
+            None,
+        )
+        assert _raw_response_text(html) == "Tool calls:\nscreenshot()"
+
     def test_openai_tool_calls_with_text(self):
         html = generate_visualization_html(
             "task1", _messages_with_openai_tool_calls("looking at the page", arguments='{"ref": "e1"}'), None


### PR DESCRIPTION
## What

`_build_steps` in `evaluation/vis.py` built `param_parts` (the `k=v` pieces shown in the Tool calls: summary for an unwrapped "browser"/"computer" action) via a hand-rolled `for` loop plus `.append()` instead of a single list comprehension:

```python
param_parts = []
for k, v in params.items():
    param_parts.append(f"{k}={json.dumps(v)}")
```

becomes:

```python
param_parts = [f"{k}={json.dumps(v)}" for k, v in params.items()]
```

## Why

Same hand-rolled-loop-to-comprehension/extend idiom already applied repeatedly elsewhere in this repo (e.g. `relative_dates.py`'s weekday-filter loop, `stats.py`'s per-difficulty accumulation loops, and most recently `google_flights_search_match.py`'s passenger-append loop in #236). Purely mechanical, no behavior change — same order, same string formatting.

## Why safe

This exact branch (unwrapping a `"browser"`/`"computer"` tool's action with remaining input params) had **zero prior test coverage**, so three characterization tests were added first in `tests/test_vis.py`:
- single param
- multiple params (join order)
- no params (the sibling `else` branch, confirming it's untouched)

Confirmed all three pass against the pre-refactor code, then re-ran them unchanged after the change.

## Verification

- Full suite: 494 passed (491 baseline + 3 new)
- `ruff check` clean on changed files
- `ruff format --check` shows only the same 2 pre-existing unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFVzfJMGTP7ArKuKEhLPcw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only refactor in evaluation HTML generation, locked by new tests with no production logic changes beyond syntax.
> 
> **Overview**
> Replaces the loop that builds `k=json.dumps(v)` fragments for unwrapped **browser**/**computer** tool actions in eval visualization Raw Response text with a one-line list comprehension. Output format is unchanged.
> 
> Adds three characterization tests in `tests/test_vis.py` for that unwrap path (single param, multiple params, action-only with no extra fields), which had no coverage before the refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad92243214218b4f855ebe1023955b4ef28f0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->