### PR TITLE
refactor(stats): harden show_results zip with strict=True

### DIFF
--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -131,7 +131,7 @@ def show_results(dataset: list[DatasetItem], results: list[BaseModel | Crashed])
 
     per_domain_difficulty: dict[str, dict[str, list[tuple[float, bool]]]] = defaultdict(lambda: defaultdict(list))
 
-    for i, (item, result) in enumerate(zip(dataset, results)):
+    for i, (item, result) in enumerate(zip(dataset, results, strict=True)):
         difficulty = item.suggested_difficulty or "unknown"
         crashed = isinstance(result, Crashed)
         suffix = " (crashed)" if crashed else ""

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -12,6 +12,8 @@ entries) -> list`` helper.
 
 import json
 
+import pytest
+
 from navi_bench.base import DatasetItem, FinalResult
 from evaluation.stats import Crashed, TimingStats, show_results, show_timing_summary
 
@@ -71,6 +73,20 @@ class TestShowResultsSummaryTable:
         )
         assert "  [  2] t/resy/0                                                     | easy   | score = 0.50" in logged
         assert "  [  3] t/resy/1                                                     | unknown | score = 0.00" in logged
+
+    def test_mismatched_lengths_raise_instead_of_silently_truncating(self, monkeypatch):
+        """``zip(dataset, results, strict=True)`` -- a ``dataset``/``results`` length mismatch
+        is a bug (a task silently dropped from the summary) and should fail loudly rather than
+        truncate to the shorter list.
+        """
+        monkeypatch.setattr("evaluation.stats.logger.info", lambda *_a, **_kw: None)
+        monkeypatch.setattr("evaluation.stats.logger.error", lambda *_a, **_kw: None)
+
+        dataset = [_item("t/opentable/0", "opentable", "easy")]
+        results = [FinalResult(score=1.0), FinalResult(score=0.5)]
+
+        with pytest.raises(ValueError, match="zip"):
+            show_results(dataset, results)
 
 
 class TestShowTimingSummary:


### PR DESCRIPTION
## What
`evaluation/stats.py::show_results` zips `dataset` and `results` together without `strict=True`:

```python
for i, (item, result) in enumerate(zip(dataset, results)):
```

Plain `zip()` silently truncates to the shorter of the two iterables if their lengths ever diverge — a task would be silently dropped from the summary table with no error or warning.

## Why it's safe
At the sole call site (`evaluation/eval_n1.py::main`), `results` is built from `results_with_stats`, which is produced by `asyncio.gather()` over exactly one task per `dataset` item — so `len(dataset) == len(results)` always holds today. `strict=True` is a no-op for all current behavior and only changes what happens if that invariant is ever broken by a future change: it now raises `ValueError` immediately instead of silently truncating the results table.

This is the same `ruff` B905 hardening flagged (but deprioritized as "too marginal on its own") in two earlier audit notes for this repo (`.claude/REFACTOR.md`, 2026-08-24 and 2026-08-26 entries), now resolved directly.

## Verification
- Added `TestShowResultsSummaryTable::test_mismatched_lengths_raise_instead_of_silently_truncating`, confirmed via `git stash`/`git apply` to **fail** against the pre-fix source (silently truncates, no raise) and **pass** post-fix.
- Full suite: `uv run pytest -q` → 495 passed (up from 494 baseline + 1 new test).
- `uv run ruff check .` → clean.
- `uv run ruff check --select B905 .` → clean (was the flagged hit).
- `uv run ruff format --check .` → only the same 2 pre-existing, unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`), confirmed untouched by this diff.

1 source file + 1 test file changed, +17/-1.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2DXgNVnSK4Epi4tiqM2nF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive change only; raises on a bug that should not occur in current eval flow, with no change to happy-path reporting.
> 
> **Overview**
> **`show_results`** now pairs `dataset` and `results` with **`zip(..., strict=True)`**, so unequal list lengths raise **`ValueError`** instead of silently truncating the detailed/summary output.
> 
> A new test asserts that a one-item dataset with two results triggers that error (matching **ruff B905**). Behavior is unchanged when lengths already match at the sole caller in **`eval_n1.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63826a72309d0e8336dd35d0012a1bc370f39f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->