### PR TITLE
refactor(eval_n1): extract _split_results_with_stats for the results_with_stats unzip

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -500,6 +500,19 @@ async def run_task(
                     return failure
 
 
+def _split_results_with_stats(
+    results_with_stats: list[tuple[BaseModel | Crashed, TokenUsage, TimingStats]],
+) -> tuple[list[BaseModel | Crashed], list[TokenUsage], list[TimingStats]]:
+    """Unzip the per-task ``(result, usage, timing)`` tuples gathered in ``main()`` into three
+    parallel lists, preserving order. ``zip(*...)`` needs at least one tuple to unpack from, so
+    the empty-dataset case is handled explicitly rather than falling through to a ``ValueError``.
+    """
+    if not results_with_stats:
+        return [], [], []
+    results, usages, timings = zip(*results_with_stats)
+    return list(results), list(usages), list(timings)
+
+
 @cli
 async def main(config: Config) -> None:
     os.makedirs(config.eval_save_dir, exist_ok=True)
@@ -556,9 +569,7 @@ async def main(config: Config) -> None:
             await asyncio.gather(*eval_tasks, return_exceptions=True)
             raise
 
-    results = [r for r, _, _ in results_with_stats]
-    usages = [u for _, u, _ in results_with_stats]
-    timings = [t for _, _, t in results_with_stats]
+    results, usages, timings = _split_results_with_stats(results_with_stats)
 
     if config.dataset_item_json and results:
         final_answer = getattr(results[0], "final_answer", None)

--- a/tests/test_eval_n1.py
+++ b/tests/test_eval_n1.py
@@ -36,7 +36,15 @@ from openai import (
     UnprocessableEntityError,
 )
 
-from evaluation.eval_n1 import RETRYABLE_API_ERRORS, Config, TimingStats, TokenUsage, _is_fatal_api_error, run_task
+from evaluation.eval_n1 import (
+    RETRYABLE_API_ERRORS,
+    Config,
+    TimingStats,
+    TokenUsage,
+    _is_fatal_api_error,
+    _split_results_with_stats,
+    run_task,
+)
 from evaluation.stats import Crashed
 
 
@@ -184,3 +192,38 @@ class TestRunTaskErrorHandling:
         result, _, _ = _run_task(item, max_attempts=1)
         assert item.calls == 1
         assert isinstance(result, Crashed)
+
+
+class TestSplitResultsWithStats:
+    """``main()`` gathers ``(result, usage, timing)`` tuples and unzips them into three parallel
+    lists before handing them to ``TokenUsage.show_summary``/``show_timing_summary``/
+    ``show_results``. ``main()`` itself has no unit coverage (it drives a real browser/API
+    client), so this pins the pure unzip logic directly.
+    """
+
+    def test_empty_input_returns_three_empty_lists(self):
+        assert _split_results_with_stats([]) == ([], [], [])
+
+    def test_splits_and_preserves_order(self):
+        crashed = Crashed(score=0.0, exception="boom", traceback="")
+        results_with_stats = [
+            (crashed, TokenUsage(input_tokens=1), TimingStats(times_ms=[10])),
+            (Crashed(score=1.0), TokenUsage(input_tokens=2), TimingStats(times_ms=[20])),
+        ]
+
+        results, usages, timings = _split_results_with_stats(results_with_stats)
+
+        assert results == [crashed, Crashed(score=1.0)]
+        assert usages == [TokenUsage(input_tokens=1), TokenUsage(input_tokens=2)]
+        assert timings == [TimingStats(times_ms=[10]), TimingStats(times_ms=[20])]
+
+    def test_single_element_input(self):
+        crashed = Crashed(score=0.5)
+        usage = TokenUsage(input_tokens=3)
+        timing = TimingStats(times_ms=[5])
+
+        results, usages, timings = _split_results_with_stats([(crashed, usage, timing)])
+
+        assert results == [crashed]
+        assert usages == [usage]
+        assert timings == [timing]


### PR DESCRIPTION
## What
`evaluation/eval_n1.py::main()` unzipped the gathered `(result, usage, timing)` tuples with three separate list comprehensions:

```python
results = [r for r, _, _ in results_with_stats]
usages = [u for _, u, _ in results_with_stats]
timings = [t for _, _, t in results_with_stats]
```

Extracted `_split_results_with_stats()`, which does the same thing via `zip(*results_with_stats)` — the standard-library idiom for this "unzip a list of tuples" shape, and the same category of fix this repo has applied repeatedly (hand-rolled loop/comprehension → stdlib idiom).

`zip(*[])` has nothing to unpack into three variables (`ValueError: not enough values to unpack`), so the empty-dataset case is handled with an explicit early return rather than relying on `zip`'s default truncation behavior.

## Why now
This exact spot was flagged as a candidate in two prior refactor-cronjob audits on this repo but deliberately left alone both times because `main()` has zero unit-test coverage (it drives a real Playwright browser + Yutori API client) and there was no isolated, testable unit to characterize first. Extracting the unzip into its own pure helper removes that blocker: the helper takes plain tuples in, returns plain lists out, and is fully unit-testable without touching `main()`'s I/O.

## Testing
- Added `TestSplitResultsWithStats` in `tests/test_eval_n1.py` (empty input, multi-element, single-element — pinning order and the empty-list guard).
- Full suite: 498 passed (up from 495 baseline).
- `ruff check .`: clean.
- `ruff format --check .`: clean except the same 2 pre-existing unrelated baseline spots (`evaluation/eval_n1.py:318`, `navi_bench/dates.py:151`), confirmed untouched by this diff.

## Scope
2 files touched (1 source + 1 test), no behavior change to `main()`'s output.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WfZYmQi1CTuvJTnC2AuHZR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of post-gather list splitting with unit tests; no intended change to eval summary output.
> 
> **Overview**
> **`eval_n1.main()`** no longer splits gathered `(result, usage, timing)` tuples with three list comprehensions; it delegates to a new pure helper **`_split_results_with_stats`**, which uses `zip(*...)` and returns three parallel lists in the same order.
> 
> The helper **explicitly returns three empty lists** when the input is empty, avoiding a `ValueError` from unpacking `zip(*[])`.
> 
> **`TestSplitResultsWithStats`** in `tests/test_eval_n1.py` covers the empty, multi-row, and single-row cases so this logic is testable without exercising `main()`’s browser/API I/O.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b81516cba03fb386a17d18adae5af1f13ba98e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->