### PR TITLE
refactor(eval_n1): harden _split_results_with_stats zip with strict=True

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -509,7 +509,7 @@ def _split_results_with_stats(
     """
     if not results_with_stats:
         return [], [], []
-    results, usages, timings = zip(*results_with_stats)
+    results, usages, timings = zip(*results_with_stats, strict=True)
     return list(results), list(usages), list(timings)
 
 

--- a/tests/test_eval_n1.py
+++ b/tests/test_eval_n1.py
@@ -227,3 +227,19 @@ class TestSplitResultsWithStats:
         assert results == [crashed]
         assert usages == [usage]
         assert timings == [timing]
+
+    def test_malformed_extra_element_raises_instead_of_silently_dropping_a_row(self):
+        # Every entry should be a plain 3-tuple. A row with a 4th element wouldn't fail the
+        # `results, usages, timings = zip(...)` unpack (zip(*...) still yields 3 groups, one
+        # per position 0/1/2) -- without `strict=True` it would silently drop that row's extra
+        # element rather than surfacing the malformed input.
+        good_row = (Crashed(score=0.0), TokenUsage(input_tokens=1), TimingStats(times_ms=[10]))
+        malformed_row = (
+            Crashed(score=1.0),
+            TokenUsage(input_tokens=2),
+            TimingStats(times_ms=[20]),
+            "unexpected_extra_field",
+        )
+
+        with pytest.raises(ValueError, match="zip"):
+            _split_results_with_stats([good_row, malformed_row])


### PR DESCRIPTION
## What
`evaluation/eval_n1.py::_split_results_with_stats` (extracted in #239, just merged) unzips the per-task `(result, usage, timing)` rows via `zip(*results_with_stats)` without `strict=True`.

## Why
Every row should be a plain 3-tuple, but if a future change ever produced a malformed row with an extra element, `zip()` would silently drop it instead of raising — the following `results, usages, timings = zip(...)` unpack only checks that there are exactly 3 output *groups*, not that every input row had exactly 3 elements, so a too-long row's extra field would vanish with no error. `strict=True` turns that into an immediate `ValueError`.

This is the same class of fix already applied one file over in `stats.py::show_results` in #238 — hardening a `zip()` call so a length mismatch fails loudly instead of silently truncating/dropping data.

## Safety
- No behavior change for well-formed input: every row at the sole call site (`main()`, which builds `results_with_stats` from `asyncio.gather()` over tasks that each return a plain `(result, usage, timing)` tuple) is already a 3-tuple, so `strict=True` is a no-op today.
- Added `test_malformed_extra_element_raises_instead_of_silently_dropping_a_row`, which pins the new behavior. Confirmed via `git stash` that it fails against the pre-fix source (silently drops the row's extra element, no error) and passes post-fix.
- Full suite: 499 passed (up from 498 baseline).
- `ruff check .`: clean.
- `ruff format --check .`: clean except the same 2 pre-existing unrelated baseline spots (`evaluation/eval_n1.py:318`, `navi_bench/dates.py:151`), confirmed untouched by this diff.

## Scope
2 files touched (1 source + 1 test), single-line source change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyKWS6ybG464e9U1Dcsg1W)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defensive change on evaluation aggregation; no behavior change for valid 3-tuple rows at the existing call site.
> 
> **Overview**
> Hardens **`_split_results_with_stats`** so malformed per-task rows fail loudly instead of silently losing data.
> 
> The unzip step now uses **`zip(*results_with_stats, strict=True)`**. Without `strict`, a row with a fourth element would still unpack into three lists (extra field dropped); with `strict=True`, mismatched tuple lengths raise **`ValueError`**. Well-formed 3-tuples from **`main()`** behave the same as before.
> 
> Adds **`test_malformed_extra_element_raises_instead_of_silently_dropping_a_row`** to lock in that failure mode, aligned with the same **`strict=True`** pattern already used in **`show_results`** in **`stats.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ca698b86b57a19ac45aa3431e0bc5f5191f2da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->