### PR TITLE
refactor(tests): use monkeypatch fixture in test_browser.py

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -81,7 +81,7 @@ class TestWaitForPageReady:
         assert page.evaluate_call_count == 1
 
     @pytest.mark.asyncio
-    async def test_honors_initial_sleep_before_first_check(self):
+    async def test_honors_initial_sleep_before_first_check(self, monkeypatch):
         page = _FakeReadyPage([True])
         slept: list[float] = []
 
@@ -91,11 +91,7 @@ class TestWaitForPageReady:
             slept.append(seconds)
             await real_sleep(0)
 
-        original_sleep = asyncio.sleep
-        asyncio.sleep = _fake_sleep
-        try:
-            await wait_for_page_ready(page, sleep_s=1.0)
-        finally:
-            asyncio.sleep = original_sleep
+        monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+        await wait_for_page_ready(page, sleep_s=1.0)
 
         assert slept == [1.0]


### PR DESCRIPTION
## What

`TestWaitForPageReady.test_honors_initial_sleep_before_first_check` in `tests/test_browser.py` hand-rolled a manual save/assign/try-finally around `asyncio.sleep` to monkeypatch it for the duration of the test.

## Why this is an improvement

Every other test module in this repo that patches a global or module attribute (`test_dates.py`, `test_resy_url_match.py`, `test_stats.py`) already uses pytest's built-in `monkeypatch` fixture, which restores the original automatically — including on test failure — instead of a hand-rolled `try/finally`. This was the one remaining outlier, confirmed via `grep` across `tests/`.

## Why this is safe — no behavioral change

Same patch target (`asyncio.sleep`), same fake implementation, same restore guarantee. `monkeypatch.setattr` is a documented drop-in for this exact pattern.

## Verification

- `pytest tests/test_browser.py` — 9 passed.
- `ruff check` / `ruff format --check` on the touched file: clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_012f9gsVSajRRPs1q17Dxze1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; behavior under test is unchanged.
> 
> **Overview**
> Aligns **`test_honors_initial_sleep_before_first_check`** with the rest of the test suite by replacing a manual save/`asyncio.sleep` assignment/`try`–`finally` restore with pytest’s **`monkeypatch`** fixture and **`monkeypatch.setattr(asyncio, "sleep", _fake_sleep)`**.
> 
> The fake sleep behavior and assertion (`slept == [1.0]`) are unchanged; only how the patch is applied and torn down differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e8db5c8830f844ba3bd25e174f881795b2db6a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->