### PR TITLE
refactor(base): tighten safe_update's evaluator param from Any to BaseMetric

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -77,7 +77,7 @@ async def safe_evaluate(
 
 
 async def safe_update(
-    evaluator: Any,
+    evaluator: "BaseMetric",
     *,
     log_fn: Callable[[Exception], None],
     **kwargs: Any,
@@ -90,6 +90,14 @@ async def safe_update(
     ``log_fn`` receives the caught exception so callers can format their own message
     (and, e.g., call ``logger.opt(exception=True)`` from within the still-live except
     context).
+
+    ``evaluator`` is annotated as the forward-referenced string ``"BaseMetric"`` (mirroring
+    ``TokenUsage.__add__``'s same-file self-reference in ``evaluation/eval_n1.py``) because
+    :class:`BaseMetric` is defined later in this module; this documents the exact contract
+    ``safe_update`` requires, the same "``Any`` -> the concrete type already in the repo"
+    tightening :func:`safe_evaluate` got via :class:`PageLike`. Not ``@beartype``-enforced,
+    so purely documentation, and duck-typed test doubles (e.g. ``tests/test_safe_update.py``)
+    remain valid callers without needing to subclass ``BaseMetric``.
     """
     try:
         await evaluator.update(**kwargs)

--- a/tests/test_safe_update.py
+++ b/tests/test_safe_update.py
@@ -6,7 +6,7 @@ navigate away or throw mid-update.
 
 import pytest
 
-from navi_bench.base import safe_update
+from navi_bench.base import BaseMetric, safe_update
 
 
 class _FakeEvaluator:
@@ -49,3 +49,15 @@ async def test_safe_update_passes_arbitrary_kwargs_through():
     await safe_update(evaluator, url="u", page="p", answer_message="done", log_fn=lambda exc: pytest.fail("unexpected"))
 
     assert evaluator.calls == [{"url": "u", "page": "p", "answer_message": "done"}]
+
+
+def test_evaluator_annotation_names_base_metric():
+    """``safe_update``'s ``evaluator`` param is documented as the ``BaseMetric`` contract it
+    actually calls (``.update(**kwargs)``), not a bare ``Any`` -- the same ``Any`` -> concrete
+    type tightening ``safe_evaluate``'s ``page`` param got via ``PageLike``. Forward-referenced
+    as the string ``"BaseMetric"`` since :class:`BaseMetric` is defined later in ``base.py``;
+    not ``@beartype``-enforced, so ``_FakeEvaluator`` above stays a valid duck-typed caller
+    without subclassing it.
+    """
+    assert safe_update.__annotations__["evaluator"] == "BaseMetric"
+    assert hasattr(BaseMetric, "update")


### PR DESCRIPTION
## What

`safe_update()` (`navi_bench/base.py`) only ever calls `evaluator.update(**kwargs)`, which is exactly `BaseMetric`'s contract, but its `evaluator` parameter was still typed as `Any`.

This is the same "`Any` -> the concrete type already in the repo" tightening `safe_evaluate`'s `page` parameter got via the `PageLike` protocol in #224 — the same lens, applied to `safe_update`'s sibling parameter that #224 didn't touch.

## Why this shape

`BaseMetric` is defined later in `navi_bench/base.py` (it also uses `safe_update`'s helper functions, which come first), so `evaluator` is annotated as the forward-referenced string `"BaseMetric"` — mirroring the same-file self-reference idiom `TokenUsage.__add__` already uses in `evaluation/eval_n1.py` (`other: "TokenUsage"`).

`safe_update` is not `@beartype`-decorated, so this annotation is documentation-only, not runtime-enforced — duck-typed test doubles (e.g. `tests/test_safe_update.py`'s `_FakeEvaluator`) remain valid callers without needing to subclass `BaseMetric`.

## Safety

- Added a direct test (`test_evaluator_annotation_names_base_metric`) pinning the tightened annotation, alongside the existing behavior tests for `safe_update`.
- No behavior change: the function body is untouched, only the type hint moved from `Any` to a forward-referenced concrete type.
- 500/500 tests pass (499 existing + 1 new), `ruff check` clean, `ruff format --check` shows only the two pre-existing unrelated baseline spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`) that predate this change and are left untouched.
- Single file touched in source (`navi_bench/base.py`) plus its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MbAtQPEe2MiDJMLTtZstNM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only type hint and test; no logic or call-site changes.
> 
> **Overview**
> **`safe_update`**’s **`evaluator`** parameter is now annotated as forward-referenced **`"BaseMetric"`** instead of **`Any`**, documenting that the helper only calls **`.update(**kwargs)`**—the same “concrete type in the repo” tightening **`safe_evaluate`** got for **`page`** via **`PageLike`**.
> 
> The docstring explains the forward reference ( **`BaseMetric`** is defined later in **`base.py`**) and that the hint is documentation-only because **`safe_update`** is not **`@beartype`**-decorated, so duck-typed fakes in tests stay valid. **Runtime behavior is unchanged.**
> 
> A new test **`test_evaluator_annotation_names_base_metric`** pins **`evaluator == "BaseMetric"`** and that **`BaseMetric`** exposes **`update`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31eca9ced52a82a2e06ad0699474006e3d5daada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->