### PR TITLE
refactor(demo): annotate human-agent-loop evaluator param as BaseMetric

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -17,7 +17,7 @@ from typing import Any
 from datasets import load_dataset
 from playwright.async_api import Page, async_playwright
 
-from navi_bench.base import DatasetItem, instantiate, safe_update
+from navi_bench.base import BaseMetric, DatasetItem, instantiate, safe_update
 
 
 HF_DATASET = "yutori-ai/navi-bench"
@@ -34,7 +34,7 @@ def load_task(task_id: str) -> dict[str, Any]:
     raise ValueError(f"Task {task_id} not found in {HF_DATASET}/{HF_SPLIT}")
 
 
-async def _safe_evaluator_update(evaluator, page: Page, *, label: str = "") -> None:
+async def _safe_evaluator_update(evaluator: BaseMetric, page: Page, *, label: str = "") -> None:
     await safe_update(
         evaluator,
         url=page.url,
@@ -43,7 +43,7 @@ async def _safe_evaluator_update(evaluator, page: Page, *, label: str = "") -> N
     )
 
 
-async def attach_human_agent_loop(page: Page, evaluator) -> None:
+async def attach_human_agent_loop(page: Page, evaluator: BaseMetric) -> None:
     """
     This is the human-agent-loop. Execute the task by navigating the website.
     """


### PR DESCRIPTION
## Day-over-day pattern

Today's #3c49a1d tightened `safe_update`'s own `evaluator` param from `Any` to the forward-ref `BaseMetric`, and its rationale explicitly frames the existing untyped-`evaluator` pattern as duplicated across two call sites: the human-agent-loop step (`demo.py`) and the N1 eval step (`evaluation/eval_n1.py`). The N1 side already annotates `evaluator: BaseMetric` — `demo.py`'s side was the literal sibling left behind.

## What this PR does

`demo.py`'s `_safe_evaluator_update` and `attach_human_agent_loop` both take an `evaluator` param that was completely unannotated (not even `Any`), despite calling `safe_update(evaluator, ...)` directly and driving `evaluator.reset()`/`.update()`/`.compute()` — exactly the `BaseMetric` contract. This PR imports `BaseMetric` from `navi_bench.base` and annotates both params.

Pure annotation change, no `@beartype` enforcement on this path, no behavior change.

## Verification

This sandbox doesn't have `datasets`/`playwright` installed, so I verified via:
- `ruff check` / `ruff format --check` clean.
- `ast.parse` / `py_compile` syntax check.
- Confirmed `BaseMetric` is defined in `navi_bench/base.py` and already used identically (`evaluator: BaseMetric`) in `evaluation/eval_n1.py`.
- Checked for a `demo.py`-specific test (none exists; `tests/test_safe_update.py` only references `demo.py` in a docstring).

cc @dhruvbatra — sole/dominant author of `demo.py` and `navi_bench/base.py`, and author of today's #3c49a1d that this follows up on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8m2KinYfXfW3fCgunDsAM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only annotations on the demo script; no logic, enforcement, or API surface changes.
> 
> **Overview**
> Aligns the human-in-the-loop demo with the N1 eval path and `safe_update` by typing the shared `evaluator` argument as **`BaseMetric`**.
> 
> Imports **`BaseMetric`** from `navi_bench.base` and applies it to **`_safe_evaluator_update`** and **`attach_human_agent_loop`**, which previously left `evaluator` unannotated despite calling `safe_update` and the metric lifecycle. **No runtime behavior change**—types only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cfaf977fc408643a7cdde879b4a5654fbd9a58b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->