### PR TITLE
refactor(opentable): merge nested-if guard clauses in candidate-query checks

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -375,9 +375,8 @@ class OpenTableInfoGathering(ResetsViaState):
             if info["restaurantName"].lower() not in query_names:
                 return False
 
-        if party_sizes := query.get("party_sizes"):
-            if info["partySize"] not in party_sizes:
-                return False
+        if (party_sizes := query.get("party_sizes")) and info["partySize"] not in party_sizes:
+            return False
 
         branch, matched = cls._match_query_window(query.get("dates"), query.get("times"), info)
         if branch == "available":
@@ -392,13 +391,12 @@ class OpenTableInfoGathering(ResetsViaState):
     @classmethod
     def _check_single_candidate_query(cls, query: SingleCandidateQuery, info: InfoDict) -> bool:
         """Check if the single-candidate query is covered by the info"""
-        if (query_name := query.get("restaurant_name")) is not None:
-            if info["restaurantName"].lower() != query_name.lower():
-                return False
+        query_name = query.get("restaurant_name")
+        if query_name is not None and info["restaurantName"].lower() != query_name.lower():
+            return False
 
-        if (query_party_size := query.get("party_size")) is not None:
-            if info["partySize"] != query_party_size:
-                return False
+        if (query_party_size := query.get("party_size")) is not None and info["partySize"] != query_party_size:
+            return False
 
         query_date = query.get("date")
         query_time = query.get("time")


### PR DESCRIPTION
## Summary
- Collapses the three remaining `if x := query.get(...): if cond: return False` nested-if pairs in `OpenTableInfoGathering._check_multi_candidate_query` and `_check_single_candidate_query` into single `if x and cond: return False` guards (ruff `SIM102`), matching the sibling guard clause earlier in `_check_multi_candidate_query` that was already in single-`if` form.
- Purely mechanical, behavior-preserving control-flow simplification — no logic changes.

## Test plan
- [x] `python -m pytest -q` — 500 passed (full suite)
- [x] `ruff check .` — all checks pass
- [x] `ruff format --check .` — only the two known pre-existing baseline-drift files (`evaluation/eval_n1.py`, `navi_bench/dates.py`) flagged, both untouched by this change
- [x] Existing characterization tests in `tests/test_opentable_info_gathering.py` already pin the exact behavior of both methods across their branch combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CS2jDaRuGYUHqo4Sh11cV

---
_Generated by [Claude Code](https://claude.ai/code/session_014CS2jDaRuGYUHqo4Sh11cV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical control-flow cleanup in query-matching helpers with characterization tests; no logic or API changes.
> 
> **Overview**
> Refactors early-exit guards in `OpenTableInfoGathering._check_multi_candidate_query` and `_check_single_candidate_query` so party-size (and, for single-candidate, restaurant-name) filters use one combined `if` instead of nested `if` blocks, aligning with the existing restaurant-names guard style and satisfying ruff **SIM102**.
> 
> **No behavioral change** — the same conditions still short-circuit with `return False` when query constraints don’t match the gathered `info`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c995b7b16b576433e1d3a55895b1fabca825fb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->