### PR TITLE
refactor: collapse remaining SIM102 nested-if guard clauses

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -120,10 +120,9 @@ async def build_browser(
                 "viewport": viewport,
                 "timezone_id": task_config.user_metadata.timezone,
             }
-            if need_to_set_location:
-                if coords := LOCATION_COORDS.get(task_config.user_metadata.location):
-                    context_kwargs["geolocation"] = {"latitude": coords[0], "longitude": coords[1]}
-                    context_kwargs["permissions"] = ["geolocation"]
+            if need_to_set_location and (coords := LOCATION_COORDS.get(task_config.user_metadata.location)):
+                context_kwargs["geolocation"] = {"latitude": coords[0], "longitude": coords[1]}
+                context_kwargs["permissions"] = ["geolocation"]
             browser = await playwright.webkit.launch(headless=config.browser_headless)
             context = await browser.new_context(**context_kwargs)
         else:

--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -536,16 +536,14 @@ def _expand_md_range(
     # might have returned the current year due to using the 15th as reference
     if base is not None and modifier in ("next", "coming"):
         start_date = date(y, m, start_day)
-        # For "next", if start_date <= base, we need to go to next occurrence
-        if start_date <= base:
-            # If we're already in a future year, that's fine
-            # Otherwise bump to next year
-            if y <= base.year:
-                y += 1
-                # Re-clamp via clamp_day for the new year (handles leap year Feb 29 -> 28
-                # rollover instead of raising ValueError)
-                start_day = clamp_day(y, m, start_day).day
-                end_day = clamp_day(y, m, end_day).day
+        # For "next", if start_date <= base, we need to go to next occurrence.
+        # If we're already in a future year, that's fine; otherwise bump to next year.
+        if start_date <= base and y <= base.year:
+            y += 1
+            # Re-clamp via clamp_day for the new year (handles leap year Feb 29 -> 28
+            # rollover instead of raising ValueError)
+            start_day = clamp_day(y, m, start_day).day
+            end_day = clamp_day(y, m, end_day).day
 
     return [date(y, m, d) for d in range(start_day, end_day + 1)]
 


### PR DESCRIPTION
## Issue

PR #244 (merged earlier today) collapsed a nested-if guard-clause pattern (ruff `SIM102`) in `OpenTableInfoGathering`. A fresh `ruff check --select ALL` pass turns up two more instances of the exact same mechanism elsewhere in the repo that weren't covered by that PR:

1. `evaluation/browser.py::build_browser` — geolocation setup:
   ```python
   if need_to_set_location:
       if coords := LOCATION_COORDS.get(task_config.user_metadata.location):
           ...
   ```
2. `navi_bench/relative_dates.py::_expand_md_range` — "next" modifier year-bump:
   ```python
   if start_date <= base:
       if y <= base.year:
           ...
   ```

## Fix

Collapse both into single `if a and b:` statements, same as #244:

- `if need_to_set_location and (coords := LOCATION_COORDS.get(...)):`
- `if start_date <= base and y <= base.year:` (merging the two explanatory comments into one that covers both conditions)

## Why it's safe

- Pure guard-clause collapse — `and` short-circuits exactly like the nested `if`, so `LOCATION_COORDS.get(...)` in case 1 is still only evaluated when `need_to_set_location` is true, and no behavior changes in either case.
- Only 2 files touched, no new logic.
- `ruff check --select SIM102 .` now reports zero remaining instances.
- `ruff check .` and `ruff format --check` are clean on both files (two unrelated pre-existing formatting diffs elsewhere in the repo are untouched by this change).
- Full test suite: `uv run pytest -q` → 500 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018DSWS7uA3ww2AAx2gGZP1o)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Guard-clause refactors only; short-circuit semantics preserve geolocation setup and relative date year-bumping behavior.
> 
> **Overview**
> Follow-up to #244: two remaining **ruff SIM102** nested-`if` guard clauses are flattened into single compound conditions with no behavior change (`and` short-circuits the same way).
> 
> In **`build_browser`**, geolocation on the local WebKit path is applied only when `need_to_set_location` and a walrus-assigned `LOCATION_COORDS` lookup both succeed. In **`_expand_md_range`**, the "next"/"coming" year bump runs when `start_date <= base` **and** `y <= base.year`, with the inline comments merged to describe both checks.
> 
> Scope is style-only across these two files; full test suite reportedly still passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fc6f9904a22eaa557e7ada1358110d4c87ca177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->