### PR TITLE
refactor(resy): collapse if/else assignment blocks into ternaries (SIM108)

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -62,10 +62,7 @@ def _normalize_time_value(raw_time: Any) -> str | None:
     if raw_time is None:
         return None
 
-    if isinstance(raw_time, (int, float)):
-        raw = f"{int(raw_time):04d}"
-    else:
-        raw = str(raw_time).strip()
+    raw = f"{int(raw_time):04d}" if isinstance(raw_time, (int, float)) else str(raw_time).strip()
 
     if not raw:
         return None
@@ -995,12 +992,8 @@ def generate_task_config_random(
         # Clamp to valid range
         party_size = max(guests_min, min(guests_max - 1, party_size))
 
-    # Determine date range
-    if date_range is None:
-        date_range = (1, days_ahead)
-    else:
-        # Clamp to days_ahead
-        date_range = (max(1, date_range[0]), min(days_ahead, date_range[1]))
+    # Determine date range (default to the full window, or clamp an explicit one to days_ahead)
+    date_range = (1, days_ahead) if date_range is None else (max(1, date_range[0]), min(days_ahead, date_range[1]))
 
     # Select a valid date (avoiding closed days)
     target_date = select_valid_date(today, date_range, closed_days)

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -31,6 +31,7 @@ from navi_bench.resy.resy_url_match import (
     ResyUrlMatch,
     _BOUNDARY_REASON_MESSAGE_TEMPLATES,
     _get_booking_window_limit,
+    _normalize_time_value,
     _parse_optional_int,
     _render_placeholders_in_queries_all,
     _render_placeholders_in_queries_any,
@@ -272,6 +273,29 @@ class TestParseTimeToHour:
     )
     def test_parses_expected_values(self, time_str, expected):
         assert parse_time_to_hour(time_str) == expected
+
+
+class TestNormalizeTimeValue:
+    """Characterization tests for ``_normalize_time_value``'s int/float vs. string branch,
+    which was collapsed from an if/else block into a ternary expression.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw_time", "expected"),
+        [
+            (None, None),
+            (930, "09:30:00"),
+            (930.0, "09:30:00"),
+            (5, "00:05:00"),
+            ("1830", "18:30:00"),
+            ("  1830  ", "18:30:00"),
+            ("18:30", "18:30:00"),
+            ("", None),
+            ("   ", None),
+        ],
+    )
+    def test_normalizes_expected_values(self, raw_time, expected):
+        assert _normalize_time_value(raw_time) == expected
 
 
 class TestParseOptionalInt:


### PR DESCRIPTION
## Summary
- `_normalize_time_value`'s int/float-vs-string coercion and `generate_task_config_random`'s date_range default/clamp logic each used an if/else block to assign a single variable — the shape ruff's `SIM108` flags, and the same idiom already collapsed for standalone conditionals elsewhere in this repo (#237, #244, #245).
- Converted both to ternary expressions. No behavior change.
- Added direct characterization tests for `_normalize_time_value` (previously only exercised indirectly through the URL-matching pipeline), pinning both branches through to the function's final `HH:MM:SS` output. `date_range`'s existing coverage in `TestGenerateTaskConfigRandomDateRange` already pins the default/clamp behavior.

## Test plan
- [x] `python -m pytest -q` — 509/509 pass
- [x] `ruff check .` — clean
- [x] `ruff format --check` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015z4gcJ7Tuvnwpr9JZczaaL

---
_Generated by [Claude Code](https://claude.ai/code/session_015z4gcJ7Tuvnwpr9JZczaaL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with new characterization tests; no logic changes beyond expression form.
> 
> **Overview**
> Style-only refactor in **`resy_url_match.py`** to satisfy ruff **SIM108**: two single-assignment `if`/`else` blocks are now ternary expressions, with **no intended behavior change**.
> 
> **`_normalize_time_value`** now uses one line to coerce numeric times (`int`/`float` → zero-padded `HHMM`) vs. stripped strings. **`generate_task_config_random`** does the same for `date_range` (default `(1, days_ahead)` or clamp an explicit tuple to `days_ahead`), with a slightly clearer comment.
> 
> **Tests** add **`TestNormalizeTimeValue`** with parametrized cases that pin int/float/string/empty inputs through to `HH:MM:SS` output—coverage that previously only ran indirectly via URL matching. `date_range` default/clamp logic remains covered by existing random task-config tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a104d778ce2a0381522d6fc48e784a62c1f97c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->