### PR TITLE
refactor(vis): table-drive the form-action detail field chain

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -64,6 +64,28 @@ _ACTION_DETAIL_FIELDS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("value",), 'value: "{0}"'),
 )
 
+# Additional "key: value" detail lines for form-recording action types, keyed by
+# action_type and layered on top of _ACTION_DETAIL_FIELDS above. Each entry is
+# (payload key, str.format template, default rendered when the key is absent) -- the
+# same table-of-(field, template) shape as _ACTION_DETAIL_FIELDS, but selected by
+# action_type rather than by field presence, since these fields aren't shared across
+# action types the way ref/coordinates/etc. are.
+_FORM_ACTION_DETAIL_FIELDS: dict[str, tuple[tuple[str, str, object], ...]] = {
+    "add_question": (
+        ("index", "index: {}", "?"),
+        ("question", 'question: "{}"', ""),
+        ("response_type", "response_type: {}", "?"),
+    ),
+    "add_input_options": (
+        ("question_index", "question_index: {}", "?"),
+        ("input_options", 'input_options: "{}"', ""),
+    ),
+    "add_choices": (  # Legacy name for add_input_options
+        ("question_index", "question_index: {}", "?"),
+        ("choices", 'choices: "{}"', ""),
+    ),
+}
+
 
 def _first_present(action: dict, *keys: str) -> object:
     """Return the value of the first of ``keys`` that is present in ``action`` (checked via
@@ -189,17 +211,8 @@ def _build_action_detail_lines(action: dict) -> list[str]:
             details.append(template.format(value))
 
     # Form recording actions: add_question and add_input_options (renamed from add_choices)
-    if action_type == "add_question":
-        details.append(f"index: {action.get('index', '?')}")
-        details.append(f'question: "{action.get("question", "")}"')
-        details.append(f"response_type: {action.get('response_type', '?')}")
-    if action_type == "add_input_options":
-        details.append(f"question_index: {action.get('question_index', '?')}")
-        details.append(f'input_options: "{action.get("input_options", "")}"')
-    if action_type == "add_choices":
-        # Legacy support for old name
-        details.append(f"question_index: {action.get('question_index', '?')}")
-        details.append(f'choices: "{action.get("choices", "")}"')
+    for key, template, default in _FORM_ACTION_DETAIL_FIELDS.get(action_type, ()):
+        details.append(template.format(action.get(key, default)))
     if action_type == "list_records":
         details.append("(outputs all recorded questions)")
 

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -27,6 +27,7 @@ from evaluation.vis import (
     _render_section,
     _ACTION_COLOR_CLASSES,
     _ACTION_DETAIL_FIELDS,
+    _FORM_ACTION_DETAIL_FIELDS,
 )
 
 
@@ -223,6 +224,27 @@ class TestFormActionDetailFields:
 
     def test_list_records(self):
         assert _render_action_details({}, name="list_records") == "(outputs all recorded questions)"
+
+
+class TestFormActionDetailFieldTable:
+    """Pin the contract of the ``_FORM_ACTION_DETAIL_FIELDS`` table driving the
+    form-recording branch of ``_build_action_detail_lines``: every declared entry renders
+    its default when the key is absent, and its actual value (via ``str.format``) when
+    present, in table order."""
+
+    def test_defaults_render_when_keys_are_absent(self):
+        for action_type, fields in _FORM_ACTION_DETAIL_FIELDS.items():
+            expected = [template.format(default) for _key, template, default in fields]
+            assert _build_action_detail_lines({"action_type": action_type}) == expected
+
+    def test_present_values_render_in_table_order(self):
+        for action_type, fields in _FORM_ACTION_DETAIL_FIELDS.items():
+            action = {"action_type": action_type, **{key: f"v-{key}" for key, _template, _default in fields}}
+            expected = [template.format(f"v-{key}") for key, template, _default in fields]
+            assert _build_action_detail_lines(action) == expected
+
+    def test_unrecognized_action_type_gets_no_form_fields(self):
+        assert _build_action_detail_lines({"action_type": "left_click"}) == []
 
 
 class TestActionCardStyling:


### PR DESCRIPTION
## Issue

`evaluation/vis.py::_build_action_detail_lines` renders the "key: value" lines shown in an action card. After #247 table-drove the *field-presence* chain (`_ACTION_DETAIL_FIELDS`), the function still had a separate chain of near-identical blocks for the four form-recording action types:

```python
if action_type == "add_question":
    details.append(f"index: {action.get('index', '?')}")
    details.append(f'question: "{action.get("question", "")}"')
    details.append(f"response_type: {action.get('response_type', '?')}")
if action_type == "add_input_options":
    details.append(f"question_index: {action.get('question_index', '?')}")
    details.append(f'input_options: "{action.get("input_options", "")}"')
if action_type == "add_choices":
    # Legacy support for old name
    details.append(f"question_index: {action.get('question_index', '?')}")
    details.append(f'choices: "{action.get("choices", "")}"')
```

Same repeated shape (`if action_type == X: append f"<key>: {action.get(<key>, <default>)}"`), just keyed by `action_type` instead of field presence.

## Improvement

Replaced the three `if` blocks with a declarative `_FORM_ACTION_DETAIL_FIELDS: dict[str, tuple[tuple[str, str, object], ...]]` table (`action_type -> [(payload key, str.format template, default), ...]`) plus a 2-line loop, mirroring the exact table-of-`(field, template)` convention `_ACTION_DETAIL_FIELDS` already established in this file (and `_CLICK_KWARGS`/`_SCROLL_VECTORS` in `evaluation/eval_n1.py`). The `list_records` branch (no fields, just a fixed string) is left as its own one-line `if`, since it doesn't fit the "field -> template" shape.

## Safety

- **No eval/scoring/verifier behavior touched** — this is debug/HTML-visualization output only (`evaluation/vis.py`), not a task definition, verifier, or scoring path.
- Verified behavior-preserving via a differential harness running the old and new implementations over 78,125 randomized `(action_type, field-values)` combinations (all four form action types plus a non-form control, with missing/falsy/empty-string values) — output identical in every case.
- Added `TestFormActionDetailFieldTable` (3 cases) pinning the new table's default-vs-present-value contract. The pre-existing `TestFormActionDetailFields` characterization tests (which pin the exact rendered strings end-to-end through `generate_visualization_html`) pass unchanged.
- Full suite: 515/515 passing (up from 512 baseline). `ruff check`/`ruff format --check` clean on both touched files.
- 2 files touched (`evaluation/vis.py`, `tests/test_vis.py`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqEgaHyht5JFs5QgodY9J4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visualization-only refactor in `evaluation/vis.py` with table-driven tests; no scoring or verifier paths touched.
> 
> **Overview**
> Replaces the three `if action_type == ...` branches in `_build_action_detail_lines` with a declarative **`_FORM_ACTION_DETAIL_FIELDS`** map (`add_question`, `add_input_options`, legacy `add_choices`) and a short loop, matching the existing **`_ACTION_DETAIL_FIELDS`** pattern for eval visualization action cards only.
> 
> **`list_records`** still appends its fixed “(outputs all recorded questions)” line outside the table. Adds **`TestFormActionDetailFieldTable`** to lock default-vs-present rendering and that non-form action types get no extra lines; intended behavior is unchanged for HTML debug output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ebb8a046341614807c9df55b4bbbd2da3e4bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->