### PR TITLE
refactor(resy): replace hand-rolled dash-collapse loop with re.sub

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -1,6 +1,7 @@
 import csv
 import functools
 import random
+import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -849,9 +850,8 @@ def get_venue_slug(restaurant_name: str) -> str:
         slug = name_lower.replace(" ", "-").replace("+", "").replace("'", "").replace("&", "and")
         # Remove special characters
         slug = "".join(c for c in slug if c.isalnum() or c == "-")
-        # Remove multiple dashes
-        while "--" in slug:
-            slug = slug.replace("--", "-")
+        # Collapse runs of dashes into one
+        slug = re.sub(r"-+", "-", slug)
         return slug.strip("-")
 
 

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -36,6 +36,7 @@ from navi_bench.resy.resy_url_match import (
     _render_placeholders_in_queries_all,
     _render_placeholders_in_queries_any,
     generate_task_config_random,
+    get_venue_slug,
     parse_time_to_hour,
 )
 
@@ -356,6 +357,22 @@ class TestGetBookingWindowLimit:
 
     def test_lookup_is_case_insensitive(self):
         assert _get_booking_window_limit("NEW YORK", "CARBONE", 100) == 28
+
+
+class TestGetVenueSlug:
+    """Characterization tests for ``get_venue_slug``'s fallback slugification, which strips
+    special characters and collapses any resulting run of dashes into a single dash."""
+
+    def test_known_restaurant_uses_explicit_mapping(self):
+        assert get_venue_slug("Carbone") == "carbone"
+
+    def test_fallback_collapses_adjacent_special_characters_into_one_dash(self):
+        # "+" drops out between two space-turned-dashes, so the naive per-character
+        # substitution alone would previously produce a double dash here.
+        assert get_venue_slug("Joe's + Diner") == "joes-diner"
+
+    def test_fallback_strips_leading_and_trailing_dashes(self):
+        assert get_venue_slug("'Café Central'") == "café-central"
 
 
 class TestGenerateTaskConfigRandomDaysAheadCapping:


### PR DESCRIPTION
## Issue

`get_venue_slug`'s fallback slugification collapsed runs of dashes with a
hand-rolled loop:

```python
while "--" in slug:
    slug = slug.replace("--", "-")
```

## Improvement

Replaced it with the stdlib equivalent, which expresses the same fixed-point
collapse in one pass:

```python
slug = re.sub(r"-+", "-", slug)
```

This matches the repo's established pattern of replacing hand-rolled
loops with their stdlib equivalents (e.g. `dict.fromkeys` for dedup,
`sum(start=...)` for folds).

## Why it's safe

- `re.sub(r"-+", "-", slug)` and the `while "--" in slug: replace(...)` loop
  are provably equivalent: both reduce any run of one-or-more dashes to
  exactly one dash, and neither can produce a `"--"` that the other would
  miss.
- `get_venue_slug` had no direct unit tests before this change (only
  exercised indirectly through restaurants already covered by the explicit
  `VENUE_SLUG_MAPPING`, which never reaches the fallback branch). Added a
  small `TestGetVenueSlug` class covering the mapped case and the fallback
  slugification, including a name whose special characters used to produce
  an adjacent double-dash.
- Full test suite (518 tests) and `ruff check`/`ruff format --check` pass on
  the touched files.


---
_Generated by [Claude Code](https://claude.ai/code/session_014f3sVv9Vi1VQivfqRBEBFJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to benchmark URL slug generation with characterization tests; no auth, data, or production runtime impact.
> 
> **Overview**
> **`get_venue_slug`** fallback slugification now collapses consecutive dashes with **`re.sub(r"-+", "-", slug)`** instead of a **`while "--" in slug`** loop, with a new **`import re`**. Behavior for mapped venues and the rest of the slugification pipeline is unchanged.
> 
> Adds **`TestGetVenueSlug`** in **`test_resy_url_match.py`** so the explicit **`VENUE_SLUG_MAPPING`** path and fallback slugification are covered directly, including names that would have produced double dashes (e.g. **`Joe's + Diner`** → **`joes-diner`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d423cc84efbbc7507acdb717d65442abce69b4aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->