### PR TITLE
Return negated condition in build_dataset's sample filter

### DIFF
--- a/evaluation/dataset.py
+++ b/evaluation/dataset.py
@@ -73,9 +73,7 @@ async def build_dataset(config: DatasetBuildConfig) -> list[DatasetItem]:
         nonlocal _overall_counter
         _overall_counter += 1
 
-        if config.dataset_max_samples and _overall_counter > config.dataset_max_samples:
-            return False
-        return True
+        return not (config.dataset_max_samples and _overall_counter > config.dataset_max_samples)
 
     dataset = dataset.filter(_sample_fn)
     logger.info(f"Sampled {len(dataset)} tasks eventually for evaluation")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,86 @@
+"""Characterization tests for ``evaluation/dataset.py::build_dataset``'s sampling filter.
+
+Pins ``_sample_fn``'s domain/task-id inclusion filters and its per-domain and overall
+sample caps -- in particular that ``_overall_counter`` only advances past items that
+already cleared the domain/task-id/per-domain-cap checks, so the interaction between
+``dataset_max_samples_per_domain`` and ``dataset_max_samples`` is order-dependent.
+"""
+
+from dataclasses import dataclass
+
+from datasets import Dataset
+
+from evaluation.dataset import build_dataset
+from tests.conftest import run_async
+
+
+@dataclass
+class _FakeDatasetBuildConfig:
+    dataset_item_json: str | None = None
+    dataset_name: str = "fake/dataset"
+    dataset_splits: tuple[str, ...] = ("test",)
+    dataset_revision: str | None = None
+    dataset_include_domains: list[str] | None = None
+    dataset_include_task_ids: list[str] | None = None
+    dataset_max_samples_per_domain: int | None = None
+    dataset_max_samples: int | None = None
+
+
+def _item(domain: str, index: int) -> dict:
+    return {
+        "task_id": f"fake/{domain}/{index}",
+        "task_generation_config_json": "{}",
+        "env": "sim",
+        "domain": domain,
+        "l1_category": "travel",
+    }
+
+
+def _build(monkeypatch, items: list[dict], config: _FakeDatasetBuildConfig) -> list[str]:
+    dataset = Dataset.from_list(items)
+    monkeypatch.setattr("evaluation.dataset.load_dataset", lambda *args, **kwargs: dataset)
+    monkeypatch.setattr("evaluation.dataset.concatenate_datasets", lambda datasets: datasets[0])
+    result = run_async(build_dataset(config))
+    return [dataset_item.task_id for dataset_item in result]
+
+
+class TestBuildDatasetSampling:
+    def test_no_filters_keeps_every_item(self, monkeypatch):
+        items = [_item("resy", 0), _item("resy", 1), _item("craigslist", 0)]
+        assert _build(monkeypatch, items, _FakeDatasetBuildConfig()) == [
+            "fake/resy/0",
+            "fake/resy/1",
+            "fake/craigslist/0",
+        ]
+
+    def test_include_domains_filters_out_other_domains(self, monkeypatch):
+        items = [_item("resy", 0), _item("craigslist", 0)]
+        config = _FakeDatasetBuildConfig(dataset_include_domains=["resy"])
+        assert _build(monkeypatch, items, config) == ["fake/resy/0"]
+
+    def test_include_task_ids_filters_to_exact_ids(self, monkeypatch):
+        items = [_item("resy", 0), _item("resy", 1)]
+        config = _FakeDatasetBuildConfig(dataset_include_task_ids=["fake/resy/1"])
+        assert _build(monkeypatch, items, config) == ["fake/resy/1"]
+
+    def test_max_samples_per_domain_caps_each_domain_independently(self, monkeypatch):
+        items = [_item("resy", 0), _item("resy", 1), _item("craigslist", 0), _item("craigslist", 1)]
+        config = _FakeDatasetBuildConfig(dataset_max_samples_per_domain=1)
+        assert _build(monkeypatch, items, config) == ["fake/resy/0", "fake/craigslist/0"]
+
+    def test_max_samples_caps_overall_count_across_domains(self, monkeypatch):
+        items = [_item("resy", 0), _item("resy", 1), _item("craigslist", 0)]
+        config = _FakeDatasetBuildConfig(dataset_max_samples=2)
+        assert _build(monkeypatch, items, config) == ["fake/resy/0", "fake/resy/1"]
+
+    def test_max_samples_does_not_count_items_dropped_by_per_domain_cap(self, monkeypatch):
+        # The 2nd "resy" item is dropped by the per-domain cap before the overall counter
+        # advances, so it does not consume one of the two overall slots below.
+        items = [_item("resy", 0), _item("resy", 1), _item("craigslist", 0), _item("craigslist", 1)]
+        config = _FakeDatasetBuildConfig(dataset_max_samples_per_domain=1, dataset_max_samples=2)
+        assert _build(monkeypatch, items, config) == ["fake/resy/0", "fake/craigslist/0"]
+
+    def test_zero_max_samples_is_treated_as_unset(self, monkeypatch):
+        items = [_item("resy", 0), _item("resy", 1)]
+        config = _FakeDatasetBuildConfig(dataset_max_samples=0)
+        assert _build(monkeypatch, items, config) == ["fake/resy/0", "fake/resy/1"]


### PR DESCRIPTION
## What

`evaluation/dataset.py::build_dataset`'s inner `_sample_fn` closure ended with:

```python
if config.dataset_max_samples and _overall_counter > config.dataset_max_samples:
    return False
return True
```

which is the textbook "if/return False/return True" shape (ruff `SIM103`) that always reduces to returning the negated condition. Replaced with:

```python
return not (config.dataset_max_samples and _overall_counter > config.dataset_max_samples)
```

## Why it's an improvement

This is the same class of mechanical simplification this repo has repeatedly landed (e.g. the `SIM108` ternary collapses in `resy_url_match.py`, #246). It's been flagged by multiple prior audits of this repo's structural-refactor backlog as the one remaining candidate, but left open each time because `evaluation/dataset.py::build_dataset` had zero test coverage and depends on the `datasets` package to exercise — `pip install -e ".[dev,eval]"` now pulls in `datasets` in this environment, so it was possible to add proper characterization tests first.

## Why it's safe

- **No behavior change.** `not (A and B)` and the original if/else are truth-table identical for every combination, including the short-circuit case where `dataset_max_samples` is falsy (`None`/`0`) — verified directly, not just by inspection.
- **New test coverage first.** Added `tests/test_dataset.py` (7 tests) exercising `build_dataset`'s domain filter, task-id filter, per-domain cap, overall cap, and the interaction between the per-domain and overall caps (the overall counter only advances past items that already cleared the earlier checks, so caps compose in an order-dependent way) — this module had no direct tests before. Confirmed all 7 pass unchanged against the pre-refactor code, then again after the one-line change.
- **Only 2 files touched**, both scoring/matching logic untouched — this is dataset *filtering* plumbing (which raw items get selected for a run), not the eval-scoring code (`browser.py::build_browser`, `eval_n1.py::run_agent`, url-match matchers, `vis.py`) this backlog explicitly keeps off-limits.
- **Full suite**: 525/525 passing (518 baseline + 7 new). `ruff check` clean. `ruff format --check` shows only the same 2 pre-existing drift spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`), both untouched by this change.
- No CI is configured in this repo (confirmed via `.github/workflows`); relying on the local pytest/ruff runs above plus review-bot feedback on the PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QsKSYzJnqpmVxkfkx7U6CW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor plus new tests on evaluation dataset filtering only; sampling semantics are explicitly pinned and unchanged.
> 
> **Overview**
> Collapses the final **if/return False/return True** branch in `build_dataset`'s `_sample_fn` into a single `return not (...)` expression (ruff **SIM103**), with **no intended behavior change** for overall sample limits or falsy `dataset_max_samples`.
> 
> Adds **`tests/test_dataset.py`** with seven characterization tests that mock Hugging Face loading and pin domain/task-id filters, per-domain caps, overall caps, their **order-dependent** interaction (overall counter only increments after per-domain checks), and treating **`dataset_max_samples=0`** as unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1f3ca8d2e8d32e172d0a54289158faa063b321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->