### PR TITLE
refactor(relative_dates): table-drive parse_relative_date's month+day branches

### DIFF
--- a/navi_bench/relative_dates.py
+++ b/navi_bench/relative_dates.py
@@ -45,6 +45,28 @@ _DAY_NUM = r"(\d{1,2})(?:st|nd|rd|th)?"
 # fallback case.
 _MONTH_DAY_RANGE_PATTERN = re.compile(rf"(?:({_MOD_NONCAP}\s+)?([a-z.]+)\s+)?{_DAY_NUM}\s*-\s*{_DAY_NUM}")
 
+# Single month+day phrasings accepted by `parse_relative_date`, tried in this order.
+# Every phrasing resolves identically -- look up the month name, parse the ordinal day,
+# normalize the modifier, hand off to `_resolve_month_day` -- and differs only in the
+# order of its capture groups, so each entry carries the 1-based group indices for its
+# day, month, and modifier. `mod_group` is None for the phrasing that has no modifier
+# group at all, which then falls back to the default upcoming/on-or-after behavior.
+_MONTH_DAY_PATTERNS: tuple[tuple[re.Pattern[str], int, int, int | None], ...] = (
+    # A) Month + day: "next Dec. 3rd" / "this september 1" / "last jul 4th"
+    (re.compile(rf"{_MOD_GROUP}?\s*([a-z.]+)\s+{_ORDINAL_DAY}"), 3, 2, 1),
+    # B1) Day + 'of' + Month with leading modifier:
+    #     "this the 3rd of december" / "next 3rd of december"
+    (re.compile(rf"{_MOD_GROUP}\s*(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+(?:of\s+)?([a-z.]+)"), 2, 3, 1),
+    # B2) Day + Month + trailing modifier:
+    #     "the 3rd of december next" / "3rd december upcoming"
+    (re.compile(rf"(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+(?:of\s+)?([a-z.]+)\s+{_MOD_GROUP}"), 1, 2, 3),
+    # B3) Day + modifier + Month: "the 3rd next december" / "3rd next december"
+    (re.compile(rf"(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+{_MOD_GROUP}\s+([a-z.]+)"), 1, 3, 2),
+    # B4) Day + 'of' + Month with NO modifier:
+    #     "the 3rd of december" / "3rd of dec." / "3rd december"
+    (re.compile(rf"(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+(?:of\s+)?([a-z.]+)"), 1, 2, None),
+)
+
 
 def _days_in_month(year: int, month: int) -> int:
     return calendar.monthrange(year, month)[1]
@@ -279,58 +301,18 @@ def parse_relative_date(text: str, base: date | None = None, return_iso: bool = 
     s = _canon(raw)
 
     # ----------------------------
-    # A) Month + day: "next Dec. 3rd" / "this september 1" / "last jul 4th"
+    # A/B) Month + day, in each accepted word order (see `_MONTH_DAY_PATTERNS`).
+    # A pattern that matches but whose month group is not a real month name falls
+    # through to the next phrasing, same as the original per-branch checks.
     # ----------------------------
-    m = re.fullmatch(rf"{_MOD_GROUP}?\s*([a-z.]+)\s+{_ORDINAL_DAY}", s)
-    if m and m.group(2) in MONTHS:
-        modifier = _normalize_modifier(m.group(1))
-        month = MONTHS[m.group(2)]
-        day = _parse_ordinal_day(m.group(3))
-        return _resolve_month_day(month, day, base, modifier, return_iso)
-
-    # ----------------------------
-    # B1) Day + 'of' + Month with leading modifier:
-    #     "this the 3rd of december" / "next 3rd of december"
-    # ----------------------------
-    m = re.fullmatch(
-        rf"{_MOD_GROUP}\s*(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+(?:of\s+)?([a-z.]+)",
-        s,
-    )
-    if m and m.group(3) in MONTHS:
-        modifier = _normalize_modifier(m.group(1))
-        day = _parse_ordinal_day(m.group(2))
-        month = MONTHS[m.group(3)]
-        return _resolve_month_day(month, day, base, modifier, return_iso)
-
-    # B2) Day + Month + trailing modifier:
-    #     "the 3rd of december next" / "3rd december upcoming"
-    m = re.fullmatch(
-        rf"(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+(?:of\s+)?([a-z.]+)\s+{_MOD_GROUP}",
-        s,
-    )
-    if m and m.group(2) in MONTHS:
-        day = _parse_ordinal_day(m.group(1))
-        month = MONTHS[m.group(2)]
-        modifier = _normalize_modifier(m.group(3))
-        return _resolve_month_day(month, day, base, modifier, return_iso)
-
-    # B3) Day + modifier + Month:
-    #     "the 3rd next december" / "3rd next december"
-    m = re.fullmatch(rf"(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+{_MOD_GROUP}\s+([a-z.]+)", s)
-    if m and m.group(3) in MONTHS:
-        day = _parse_ordinal_day(m.group(1))
-        modifier = _normalize_modifier(m.group(2))
-        month = MONTHS[m.group(3)]
-        return _resolve_month_day(month, day, base, modifier, return_iso)
-
-    # B4) Day + 'of' + Month with NO modifier:
-    #     "the 3rd of december" / "3rd of dec." / "3rd december"
-    m = re.fullmatch(rf"(?:on\s+)?(?:the\s+)?{_ORDINAL_DAY}\s+(?:of\s+)?([a-z.]+)", s)
-    if m and m.group(2) in MONTHS:
-        day = _parse_ordinal_day(m.group(1))
-        month = MONTHS[m.group(2)]
-        # no modifier -> default behavior: upcoming/on-or-after base
-        return _resolve_month_day(month, day, base, modifier="", return_iso=return_iso)
+    for pattern, day_group, month_group, mod_group in _MONTH_DAY_PATTERNS:
+        m = pattern.fullmatch(s)
+        if m and m.group(month_group) in MONTHS:
+            # No modifier group -> default behavior: upcoming/on-or-after base.
+            modifier = _normalize_modifier(m.group(mod_group) if mod_group is not None else None)
+            month = MONTHS[m.group(month_group)]
+            day = _parse_ordinal_day(m.group(day_group))
+            return _resolve_month_day(month, day, base, modifier, return_iso)
 
     # ----------------------------
     # C) "<D> of the <mod> month" AND loose variants:

--- a/tests/test_relative_dates.py
+++ b/tests/test_relative_dates.py
@@ -478,3 +478,47 @@ class TestParseRelativeDatesUnparsableFallbackChainsCause:
 
         assert isinstance(exc_info.value.__cause__, ValueError)
         assert "Could not parse relative date description" in str(exc_info.value.__cause__)
+
+
+class TestMonthDayPatternFallThrough:
+    """Pins the ordering/fall-through semantics of the ``_MONTH_DAY_PATTERNS`` table that
+    ``parse_relative_date`` iterates. Each accepted month+day phrasing used to be its own
+    ``re.fullmatch`` + ``if m and m.group(N) in MONTHS`` block; a phrasing whose regex matched
+    but whose month group was not a real month name fell through to the *next* phrasing (and
+    ultimately to the weekday/holiday/``in N units`` branches below). These tests pin that
+    behavior so the table-driven loop's ``continue``-to-next-pattern is verifiable.
+    """
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            # A) month + day
+            ("next Dec. 3rd", "2025-12-03"),
+            # B1) leading modifier + day + 'of' + month
+            ("next 3rd of December", "2025-12-03"),
+            # B2) day + month + trailing modifier
+            ("the 3rd of December next", "2025-12-03"),
+            # B3) day + modifier + month
+            ("the 3rd next December", "2025-12-03"),
+            # B4) day + month, no modifier
+            ("3rd of Dec.", "2025-12-03"),
+        ],
+    )
+    def test_each_month_day_phrasing_resolves_identically(self, text, expected):
+        assert parse_relative_date(text, BASE_DATE) == expected
+
+    def test_month_day_shape_with_non_month_word_falls_through_to_later_branches(self):
+        # Matches the bare day+word shape, but "month" is not a month name, so the
+        # month+day patterns must all decline and let the "<D> of the <mod> month"
+        # branch handle it.
+        assert parse_relative_date("26th of the next month", BASE_DATE) == "2025-12-26"
+
+    def test_month_day_shape_with_unknown_word_is_unparseable(self):
+        # Same shape, but nothing further down the chain claims it either.
+        with pytest.raises(ValueError, match="Could not parse relative date description"):
+            parse_relative_date("3rd of notamonth", BASE_DATE)
+
+    def test_modifier_plus_weekday_is_not_captured_by_month_day_patterns(self):
+        # "next monday" matches the bare ``<mod>? <word>`` weekday branch, not a month+day
+        # phrasing; pins that the month+day loop declines it rather than consuming it.
+        assert parse_relative_date("next Monday", BASE_DATE) == "2025-11-10"


### PR DESCRIPTION
## Issue

`parse_relative_date` in `navi_bench/relative_dates.py` accepted five month+day phrasings (labelled `A`, `B1`–`B4` in the source) as five consecutive `re.fullmatch` blocks spanning ~55 lines.

Every one of those blocks did the identical thing:

1. `re.fullmatch` an f-string-built pattern,
2. guard on `if m and m.group(N) in MONTHS`,
3. look up the month, parse the ordinal day, normalize the modifier,
4. hand off to `_resolve_month_day(month, day, base, modifier, return_iso)`.

They differed **only** in which capture-group index held the day, the month, and the modifier — because the five accepted phrasings put those tokens in different word orders. The regexes were also rebuilt from f-strings on every single call.

## Improvement

Collapsed the five blocks into a module-level `_MONTH_DAY_PATTERNS` table of `(compiled pattern, day_group, month_group, mod_group)` that the function iterates:

```python
for pattern, day_group, month_group, mod_group in _MONTH_DAY_PATTERNS:
    m = pattern.fullmatch(s)
    if m and m.group(month_group) in MONTHS:
        modifier = _normalize_modifier(m.group(mod_group) if mod_group is not None else None)
        month = MONTHS[m.group(month_group)]
        day = _parse_ordinal_day(m.group(day_group))
        return _resolve_month_day(month, day, base, modifier, return_iso)
```

The per-phrasing explanatory comments move onto their table rows, so nothing is lost. Patterns are now compiled once at import rather than on every call.

This matches the repo's established table-driving pattern — the same shape as #247 and #249 in `evaluation/vis.py`.

Net: **-51 / +33** in the source file.

### Complexity

`parse_relative_date` drops from:

| metric | before | after |
| --- | --- | --- |
| cyclomatic complexity (C901) | 19 | 16 |
| statements (PLR0915) | 76 | 57 |
| branches (PLR0912) | 20 | 17 |
| return statements (PLR0911) | 10 (over limit) | no longer flagged |

## Safety

Behavior is preserved exactly, including the subtle part: a pattern that *matches* but whose month group is **not** a real month name previously fell through to the next phrasing, and ultimately to the weekday / holiday / `in N units` branches further down. The loop's implicit `continue` reproduces that precisely.

The one non-mechanical detail: the no-modifier phrasing (`B4`) used to pass `modifier=""` explicitly. The loop passes `_normalize_modifier(None)`, which returns `""` — identical.

Verification:

- **525 existing tests pass unchanged**; `ruff check` clean; `ruff format --check` unchanged (same 2 pre-existing drift spots, untouched).
- **Added 8 characterization tests** pinning each of the five phrasings individually plus the fall-through semantics (month+day shape with a non-month word must be declined and handled by a later branch; unknown word must still raise). These were **verified to pass against the pre-refactor code as well**, so they characterize existing behavior rather than the new shape.
- **Differential fuzz, old vs new `parse_relative_date`: 1,321,472 cases, zero mismatches.** 20,648 generated phrasings × 32 base dates × `return_iso` in `{True, False}`, covering all five word orders, every modifier, real/fake/ambiguous month tokens (including weekday names as the month slot), dotted abbreviations, ordinal suffixes, leading `the`/`on the`/`of`, whitespace padding, day-of-month overflow, leap days, and unparseable input. Compared both return values **and** raised exception type/message.
- **Second differential fuzz over the sibling `parse_relative_dates`** (which calls into the changed function): 1,740 cases, zero mismatches.

No behavior change, single file of source touched, reviewer can verify the mapping row-by-row against the deleted branches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5i16kvsHTAB61hk5Ehqy1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor of date parsing with characterization tests and intended behavior parity; no new API or security-sensitive logic.
> 
> **Overview**
> **Refactors** `parse_relative_date` so five nearly identical month+day regex branches (A, B1–B4) become one loop over a module-level `_MONTH_DAY_PATTERNS` table of precompiled patterns plus capture-group indices for day, month, and modifier.
> 
> Parsing behavior is unchanged: patterns are tried in the same order, matches whose “month” group is not in `MONTHS` still fall through to later phrasings and other branches, and the no-modifier case still uses default upcoming/on-or-after semantics via `_normalize_modifier(None)`.
> 
> **Tests** add `TestMonthDayPatternFallThrough` to lock each word order, fall-through to `"26th of the next month"`, unparsable input, and that `"next Monday"` is not consumed by the month+day loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9de080292f275457f14dc6aa708c736249a5ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->