### PR TITLE
refactor(eval_n1): drop the always-None content field from retry logging

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -329,7 +329,7 @@ Today is: {dt.strftime("%A")}"""
 
         delay = initial_delay
 
-        async def _sleep_or_reraise(attempt: int, content: object) -> None:
+        async def _sleep_or_reraise(attempt: int) -> None:
             """Back off before the next attempt, or re-raise the current exception when out of retries.
 
             Called from within an ``except`` block; bare ``raise`` re-raises
@@ -337,18 +337,15 @@ Today is: {dt.strftime("%A")}"""
             """
             nonlocal delay
             if attempt == max_attempts:
-                logger.opt(exception=True).error(
-                    f"[{step_idx}] Failed to get valid response: {content=}. No more attempts."
-                )
+                logger.opt(exception=True).error(f"[{step_idx}] Failed to get valid response. No more attempts.")
                 raise
             logger.opt(exception=True).warning(
-                f"[{step_idx}] Failed to get valid response: {content=}. Retrying in {delay:.2f}s..."
+                f"[{step_idx}] Failed to get valid response. Retrying in {delay:.2f}s..."
             )
             await asyncio.sleep(delay)
             delay = min(delay * 2, max_delay)
 
         for attempt in range(1, max_attempts + 1):
-            content = None
             try:
                 kwargs = {}
                 if config.eval_temperature is not None:
@@ -378,7 +375,7 @@ Today is: {dt.strftime("%A")}"""
             except Exception as e:
                 if _is_fatal_api_error(e):
                     raise
-                await _sleep_or_reraise(attempt, content)
+                await _sleep_or_reraise(attempt)
 
     while step_idx < config.eval_max_steps:
         step_idx += 1


### PR DESCRIPTION
## What

In `evaluation/eval_n1.py`'s `_predict`, the retry closure `_sleep_or_reraise(attempt, content)` accepted a `content` parameter used only in two log f-strings (`{content=}`). But `content` was assigned `None` at the top of every retry attempt and never reassigned before the `except` block called `_sleep_or_reraise` — so both the warning and error log lines always printed the misleading `content=None`, regardless of what actually failed.

Removed the dead parameter from `_sleep_or_reraise` and its call site; the log messages now read `Failed to get valid response. No more attempts.` / `Failed to get valid response. Retrying in {delay:.2f}s...` without the always-`None` field.

## Why it's an improvement

A log field that can never carry diagnostic value actively misleads anyone reading eval logs into thinking response content was captured on failure. Confirmed via `git log --follow -p` that this has been dead since the line was introduced — no intervening commit ever assigned it.

## Why it's safe

- `content` is read nowhere except the two log f-strings — no other code path, test, or caller depends on it.
- Only change in observable behavior is the log message text shrinking (drops the always-`None` field); no change to retry/control-flow logic.
- Full test suite passes: `533 passed`.
- `ruff check` passes; the file has pre-existing, unrelated formatting drift from `ruff format` (a local ruff-version mismatch, confirmed by reproducing it on the unmodified file) that this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGqnWXAYncR2yE1r9PNALn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGqnWXAYncR2yE1r9PNALn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only log message text changes in eval retry paths; no control-flow or API behavior changes.
> 
> **Overview**
> Cleans up retry logging in **`_predict`** by dropping the unused **`content`** argument from **`_sleep_or_reraise`** and removing the per-attempt **`content = None`** assignment.
> 
> Those log lines previously always printed **`content=None`** because nothing ever set **`content`** before a failure; warnings and errors now say **Failed to get valid response** without that misleading field. **Retry backoff, fatal-error handling, and API call behavior are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 300146f65b03a2776af4e82696ded44b39c520cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->