### PR TITLE
refactor(base): table-drive the basic-type dispatch in basic_pydantic_to_hf_features

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -312,6 +312,13 @@ def unwrap_optional_type(annotation: Any) -> tuple[Any, bool]:
     return annotation, False
 
 
+# Maps each basic type `basic_pydantic_to_hf_features` supports to its HuggingFace `Value`
+# dtype string. Dict lookup replaces what used to be a chain of `field_type is <type>` elifs;
+# a plain `type` key match is unaffected by `bool` being a subclass of `int` since the lookup
+# is by exact type identity, not `isinstance`.
+_HF_FEATURE_DTYPES: dict[type, str] = {str: "string", int: "int64", float: "float64", bool: "bool"}
+
+
 def basic_pydantic_to_hf_features(model_class: type[BaseModel]) -> Features:
     """
     Basic function to convert a pydantic model to a HuggingFace Features dictionary.
@@ -334,14 +341,8 @@ def basic_pydantic_to_hf_features(model_class: type[BaseModel]) -> Features:
         # recursive if the field is a pydantic model
         if issubclass(field_type, BaseModel):
             features_dict[name] = basic_pydantic_to_hf_features(field_type)
-        elif field_type is str:
-            features_dict[name] = Value(dtype="string")
-        elif field_type is int:
-            features_dict[name] = Value(dtype="int64")
-        elif field_type is float:
-            features_dict[name] = Value(dtype="float64")
-        elif field_type is bool:
-            features_dict[name] = Value(dtype="bool")
+        elif field_type in _HF_FEATURE_DTYPES:
+            features_dict[name] = Value(dtype=_HF_FEATURE_DTYPES[field_type])
         else:
             raise ValueError(f"Unexpected field type: {field_type}")
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ValidationError
 from navi_bench.base import (
     DatasetItem,
     FinalResult,
+    _HF_FEATURE_DTYPES,
     all_or_nothing_coverage_result,
     basic_pydantic_to_hf_features,
     find_equal_value_entry,
@@ -186,6 +187,20 @@ class TestBasicPydanticToHfFeatures:
 
         with pytest.raises(ValueError, match="Unexpected field type"):
             basic_pydantic_to_hf_features(Model)
+
+
+class TestHfFeatureDtypesTable:
+    """Pins the ``_HF_FEATURE_DTYPES`` dispatch table ``basic_pydantic_to_hf_features`` looks up,
+    which replaced a ``field_type is <type>`` elif chain. ``bool`` is a subclass of ``int``, but
+    the table is keyed and looked up by exact type identity, not ``isinstance``, so this doesn't
+    change which dtype a ``bool``-typed field resolves to.
+    """
+
+    def test_covers_exactly_the_four_basic_types(self):
+        assert _HF_FEATURE_DTYPES == {str: "string", int: "int64", float: "float64", bool: "bool"}
+
+    def test_bool_key_resolves_to_bool_not_int(self):
+        assert _HF_FEATURE_DTYPES[bool] == "bool"
 
 
 def _valid_dataset_item_kwargs(**overrides) -> dict:


### PR DESCRIPTION
## Issue

`navi_bench/base.py::basic_pydantic_to_hf_features` resolved a pydantic field's basic type to its HuggingFace `Value` dtype string via a chain of four `field_type is <type>` `elif` branches:

```python
elif field_type is str:
    features_dict[name] = Value(dtype="string")
elif field_type is int:
    features_dict[name] = Value(dtype="int64")
elif field_type is float:
    features_dict[name] = Value(dtype="float64")
elif field_type is bool:
    features_dict[name] = Value(dtype="bool")
```

This is a straight one-to-one lookup table wearing a branch chain — the same shape this repo has repeatedly table-driven elsewhere (e.g. `evaluation/vis.py`'s `_ACTION_DETAIL_FIELDS`/`_FORM_ACTION_DETAIL_FIELDS`, `navi_bench/relative_dates.py`'s recent month/day table-drive).

## Improvement

Replaced the chain with a module-level `_HF_FEATURE_DTYPES: dict[type, str]` and a single `elif field_type in _HF_FEATURE_DTYPES` lookup. The `issubclass(field_type, BaseModel)` recursive branch and the final `else: raise ValueError(...)` are untouched — only the flat basic-type dispatch is collapsed.

## Why it's safe

- **Behavior-preserving by construction**: dict membership/lookup on a `type` object matches by identity/hash, the same semantics as the original `is` chain — `bool` being a subclass of `int` doesn't change which branch it hits, since neither the old code nor the new lookup use `isinstance`.
- **Existing test coverage** (`tests/test_base.py::TestBasicPydanticToHfFeatures`) already pins the exact `Value(dtype=...)` output for `str`/`int`/`float`/`bool`, plus the optional-unwrap, nested-model, non-optional-union-raises, and unsupported-type-raises paths — all pass unchanged.
- **New characterization test** (`TestHfFeatureDtypesTable`) pins the table's exact contents and explicitly asserts the `bool` key resolves to `"bool"` (not `"int64"`), documenting the identity-vs-`isinstance` subtlety for future readers.
- **Scope**: 1 source file + 1 test file, no call-site changes (the function's public signature/behavior is identical), no eval-scoring logic touched.

## Verification

- `python3 -m pytest tests/` — 535/535 passing (533 baseline + 2 new)
- `ruff check .` — clean
- `ruff format --check .` — clean except 2 pre-existing, unrelated drift spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`) that predate this change and are left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01258eCipS2otgSp4Cfze8dq

---
_Generated by [Claude Code](https://claude.ai/code/session_01258eCipS2otgSp4Cfze8dq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in dataset feature conversion with existing characterization tests; no other call sites beyond tests.
> 
> **Overview**
> **`basic_pydantic_to_hf_features`** now maps Pydantic basic field types to HuggingFace `Value` dtypes via a module-level **`_HF_FEATURE_DTYPES`** dict and a single membership lookup, instead of four **`field_type is <type>`** branches. Nested models, optional unwrapping, and unsupported-type errors are unchanged.
> 
> Tests add **`TestHfFeatureDtypesTable`** to lock the table contents and document that **`bool`** resolves to **`"bool"`** by exact type identity (not **`isinstance`** against **`int`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cca9e37c87266c6506a1bf0d8e6498ce17ca4ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->