### PR TITLE
refactor(base): declare use_cdp on BaseTaskConfig instead of getattr duck-typing

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -102,7 +102,7 @@ async def build_browser(
         viewport = {"width": config.browser_viewport_width, "height": config.browser_viewport_height}
         need_to_set_location = _url_contains_any(task_config.url, GEOLOCATION_REQUIRED_DOMAINS)
 
-        force_cdp = getattr(task_config, "use_cdp", False)
+        force_cdp = task_config.use_cdp
         use_local_browser = not force_cdp and not _url_contains_any(task_config.url, CDP_REQUIRED_DOMAINS)
         if not use_local_browser and not os.getenv("BROWSER_CDP_URL"):
             if force_cdp:

--- a/evaluation/custom_task.py
+++ b/evaluation/custom_task.py
@@ -25,7 +25,7 @@ class CustomTaskCaptureMetric(ResetsViaState):
 
 
 class CustomTaskConfig(BaseTaskConfig):
-    use_cdp: bool = False
+    """Distinct return type for :func:`generate_task_config`; ``use_cdp`` now lives on the base."""
 
 
 def generate_task_config(

--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -360,6 +360,15 @@ class BaseTaskConfig(BaseModel):
     url: str
     user_metadata: UserMetadata
     eval_config: dict[str, Any]
+    use_cdp: bool = Field(
+        default=False,
+        description=(
+            "Whether evaluation must use a CDP-attached browser rather than the local-browser "
+            "fallback. Declared here (not only on the ``CustomTaskConfig`` subclass that sets it) "
+            "so ``evaluation/browser.py::build_browser`` can read it as a typed field instead of "
+            "via ``getattr(task_config, 'use_cdp', False)`` duck-typing."
+        ),
+    )
 
 
 def build_task_config(


### PR DESCRIPTION
## What

`evaluation/browser.py::build_browser` reads `task_config.use_cdp` via
`getattr(task_config, "use_cdp", False)`, even though its `task_config`
parameter is typed as `BaseTaskConfig`. The `use_cdp` field only actually
existed on the `CustomTaskConfig` subclass (`evaluation/custom_task.py`), so
the base class's declared type didn't match what one of its own consumers
required — the definition of an overly broad interface papered over with
`getattr`+default duck-typing.

## Change

- Moved `use_cdp: bool` (with its `False` default and a short docstring) onto
  `BaseTaskConfig` in `navi_bench/base.py`, so it's a typed part of the
  contract every domain's task config carries.
- Removed the now-redundant re-declaration on `CustomTaskConfig` (kept as an
  otherwise-empty subclass, since it's still a useful distinct return type for
  `generate_task_config`).
- Replaced `getattr(task_config, "use_cdp", False)` in `build_browser` with a
  direct `task_config.use_cdp` attribute access.

## Why it's safe

- Behavior-preserving: every existing task config that didn't set `use_cdp`
  previously fell through the `getattr` default of `False`; now it gets the
  same value from the field's own default of `False`. `CustomTaskConfig`
  still accepts and stores `use_cdp` exactly as before.
- Pydantic allows extra/inherited fields with defaults without any migration
  concern here — task configs are always freshly constructed by
  `generate_task_config()`, never deserialized from an older stored shape.
- 3 files, ~11 lines changed, no call sites elsewhere in the repo reference
  `CustomTaskConfig.use_cdp`'s prior redeclaration.
- Full test suite: 535/535 passing (unchanged from baseline before this
  change). `ruff check` clean; `ruff format --check` clean on all three
  touched files (the two pre-existing, unrelated format-drift files in this
  repo are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rsapDbxM3SzRM6annpLNA

---
_Generated by [Claude Code](https://claude.ai/code/session_011rsapDbxM3SzRM6annpLNA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving typing refactor on task config and browser launch path; default `use_cdp=False` matches the old `getattr` fallback.
> 
> **Overview**
> **`use_cdp` is now part of the shared task-config contract** instead of living only on `CustomTaskConfig` and being read with `getattr(..., False)` in browser setup.
> 
> `BaseTaskConfig` gains `use_cdp: bool = False` (with a short field description). `CustomTaskConfig` drops the duplicate field but stays as the return type for `generate_task_config`, which still passes `use_cdp` through unchanged. `build_browser` uses `task_config.use_cdp` directly, matching the `BaseTaskConfig` type it already takes.
> 
> Runtime behavior should be unchanged: configs that never set the flag still default to `False`, and custom tasks can still opt into CDP the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b5d373f07b31f2e3d68ea8074d325afc868a5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->