### PR TITLE
refactor(apartments): mark self-unused _normalize_url as staticmethod

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -171,7 +171,8 @@ class ApartmentsUrlMatch(ResetsViaState):
 
         return locations, normalized_params
 
-    def _normalize_url(self, url: str) -> str:
+    @staticmethod
+    def _normalize_url(url: str) -> str:
         """Normalize URL by treating locations as sets so order doesn't matter."""
         parsed, fallback = basic_normalize_url(url, "apartments.com")
         if parsed is None:
@@ -179,10 +180,10 @@ class ApartmentsUrlMatch(ResetsViaState):
 
         # Extract locations from both path and query parameters
         path_parts = [part for part in parsed.path.split("/") if part]
-        path_locations, non_location_path_parts = self._extract_locations_from_path(path_parts)
+        path_locations, non_location_path_parts = ApartmentsUrlMatch._extract_locations_from_path(path_parts)
 
-        query_params = parse_filtered_query_params(parsed.query, self.IGNORE_URL_PARAMS)
-        query_locations, normalized_params = self._extract_locations_from_query(query_params)
+        query_params = parse_filtered_query_params(parsed.query, ApartmentsUrlMatch.IGNORE_URL_PARAMS)
+        query_locations, normalized_params = ApartmentsUrlMatch._extract_locations_from_query(query_params)
 
         # Combine all locations and sort for canonical representation
         all_locations = path_locations | query_locations


### PR DESCRIPTION
## Summary
- `ApartmentsUrlMatch._normalize_url` never reads or writes instance state — it only touches the `IGNORE_URL_PARAMS` class attribute and calls sibling staticmethods. Mark it `@staticmethod`, matching the identical `_normalize_url`/`_normalize_url_without_time` pattern already established in the sibling `ResyUrlMatch` verifier (PRs #216/#217).
- No behavior change: `IGNORE_URL_PARAMS` has no per-instance override anywhere in the codebase, and all existing call sites (`self._normalize_url(...)` in `update()`, and the test helper that calls it via an instance) continue to work unchanged since a staticmethod remains callable through an instance.

## Test plan
- [x] `python3 -m pytest tests/test_apartments_url_match.py -v` — 16 passed
- [x] `python3 -m pytest tests/ -q` — full suite, 535 passed
- [x] `ruff check navi_bench/apartments/apartments_url_match.py` and `ruff format --check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TJHzQKpxa96EayNn1W87fL

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJHzQKpxa96EayNn1W87fL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with no logic changes; existing instance call sites remain valid for staticmethods.
> 
> **Overview**
> Marks `ApartmentsUrlMatch._normalize_url` as a **`@staticmethod`**, aligning it with the other URL helpers on the class and the same pattern used in `ResyUrlMatch`.
> 
> Inside the method, calls that used **`self`** for class-level helpers are updated to **`ApartmentsUrlMatch._extract_locations_from_path`**, **`ApartmentsUrlMatch._extract_locations_from_query`**, and **`ApartmentsUrlMatch.IGNORE_URL_PARAMS`**. Normalization logic is unchanged; **`self._normalize_url(...)`** in `update()` and tests still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce139bdccc98d3e291a60ec0a09ee617b55916e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->