### PR TITLE
refactor(vis): replace hand-rolled tool_calls_summary loop with a comprehension

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -162,6 +162,16 @@ def _parse_tool_calls(msg: dict) -> list[dict]:
     return _parse_tool_calls_from_openai_format(_get_tool_calls(msg))
 
 
+def _format_openai_tool_call(tool_call: dict) -> str:
+    """Render one OpenAI-format tool call as a ``name(arguments)`` summary line.
+
+    Extracted from the display-response branch in ``_build_steps`` that previously
+    accumulated these into a list via a hand-rolled ``for`` loop.
+    """
+    func = tool_call.get("function", {})
+    return f"{func.get('name', 'unknown')}({func.get('arguments', '{}')})"
+
+
 def _anthropic_image_to_data_url(block: dict) -> str | None:
     """Convert an Anthropic base64 image block to a ``data:`` URL.
 
@@ -485,10 +495,7 @@ def _build_steps(
             # If OpenAI format with tool_calls, show a more readable format
             tool_calls = _get_tool_calls(msg)
             if tool_calls:
-                tool_calls_summary = []
-                for tc in tool_calls:
-                    func = tc.get("function", {})
-                    tool_calls_summary.append(f"{func.get('name', 'unknown')}({func.get('arguments', '{}')})")
+                tool_calls_summary = [_format_openai_tool_call(tc) for tc in tool_calls]
                 display_response = _join_text_and_tool_calls(assistant_text, tool_calls_summary)
 
             steps.append(


### PR DESCRIPTION
## What
In `evaluation/vis.py`'s `_build_steps` (the debug-trajectory HTML visualizer), the OpenAI-format tool-call display branch built its `tool_calls_summary` list via a hand-rolled `for` loop:

```python
tool_calls_summary = []
for tc in tool_calls:
    func = tc.get("function", {})
    tool_calls_summary.append(f"{func.get('name', 'unknown')}({func.get('arguments', '{}')})")
```

This extracts the per-call formatting into a small named helper, `_format_openai_tool_call`, and replaces the loop with a list comprehension:

```python
tool_calls_summary = [_format_openai_tool_call(tc) for tc in tool_calls]
```

## Why this is an improvement
- Matches the extraction/dispatch style already used throughout this same file (e.g. `_join_text_and_tool_calls`, `_get_action_marker_style`, `_first_present`) and the exact "hand-rolled accumulation loop -> comprehension" pattern this repo has applied elsewhere (e.g. #237, #229, #236).
- Gives the per-call formatting logic a name and a single call site, instead of an inline block only reachable through the surrounding `if tool_calls:` branch.

## Why this is safe
- **No change to any task/verifier logic.** This file is purely the local debug/replay HTML visualizer (`generate_visualization_html`) used to render saved eval trajectories for human inspection — it has no bearing on task definitions, verifier scoring, or benchmark semantics.
- The new helper produces byte-identical output to the old loop body for every input (same `.get(...)` calls, same defaults, same f-string).
- Scoped to a single file, ~10 line diff.

## What I verified
- `python -m pytest tests/` — all 535 tests pass (including `tests/test_vis.py`'s 113 tests, which directly cover the OpenAI tool-calls display path via `test_openai_tool_calls_with_text` / `test_openai_tool_calls_without_text`).
- `ruff check evaluation/vis.py` and `ruff format --diff evaluation/vis.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9iAjBxPM94GjhCENMjXP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9iAjBxPM94GjhCENMjXP8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only refactor in the local eval HTML visualizer with existing `test_vis.py` coverage on the OpenAI tool-calls path; no scoring or task logic touched.
> 
> **Overview**
> In **`evaluation/vis.py`**, OpenAI-format assistant steps in the debug trajectory HTML visualizer no longer build tool-call summary lines with an inline **`for`** loop inside **`_build_steps`**.
> 
> The per-call **`name(arguments)`** formatting moves into **`_format_openai_tool_call`**, and **`tool_calls_summary`** is built with a list comprehension. **Raw Response** display for messages with **`tool_calls`** should look the same; only structure and naming change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e70379a39dec6e824f2921b6e55ef8b511e6424b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->