### PR TITLE
refactor(resy): fold three fixed-string reason branches into the description table

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -124,6 +124,9 @@ _CONDITIONAL_REASON_DESCRIPTIONS = {
     "boundary_next_seen_via_prev": "unavailable slot inferred after latest visible availability",
     "gt_time_outside_available_range": "unavailable slot outside listed availability range",
     "no_available_slots": "unavailable slot inferred because page lists no availability",
+    "gt_time_missing": "ground-truth time missing from configuration",
+    "gt_time_available_not_seen": "available slot exists but was not observed",
+    "no_slots_but_wrong_time": "URL time does not match ground truth and no availability data to verify",
 }
 
 # Message templates for the reason-code prefixes that carry a ":"-delimited suffix (the
@@ -608,13 +611,6 @@ class ResyUrlMatch(ResetsViaState):
         base = _CONDITIONAL_REASON_DESCRIPTIONS.get(reason)
         if base:
             return base
-
-        if reason == "gt_time_missing":
-            return "ground-truth time missing from configuration"
-        if reason == "gt_time_available_not_seen":
-            return "available slot exists but was not observed"
-        if reason == "no_slots_but_wrong_time":
-            return "URL time does not match ground truth and no availability data to verify"
 
         for prefix, template in _BOUNDARY_REASON_MESSAGE_TEMPLATES.items():
             if reason.startswith(prefix):


### PR DESCRIPTION
## Issue

`ResyUrlMatch._describe_conditional_reason` already resolves most conditional-coverage reason codes through the `_CONDITIONAL_REASON_DESCRIPTIONS` table lookup, but three reason codes (`gt_time_missing`, `gt_time_available_not_seen`, `no_slots_but_wrong_time`) were left as a leftover chain of `if reason == "...": return "..."` branches immediately below the table lookup — even though each maps 1:1 to a fixed string with no interpolation, exactly like every other entry already in the table. This is the same shape the repo's own table-driving convention (documented in the comment directly above the table, and applied elsewhere via #247/#249/#252/#257) already covers.

## Improvement

Moved the three fixed strings into `_CONDITIONAL_REASON_DESCRIPTIONS` and deleted the now-redundant if-branches. Net -4 lines, one file.

## Safety

- Zero behavior change: the three reason codes now hit the same `_CONDITIONAL_REASON_DESCRIPTIONS.get(reason)` lookup and return the identical string they did before.
- Already has direct characterization test coverage for all three reason codes (`tests/test_resy_url_match.py::test_gt_time_missing`, `test_gt_time_available_not_seen`, `test_no_slots_but_wrong_time`), which still pass unchanged.
- Full suite: 535/535 passing (unchanged from baseline).
- `ruff check .`: clean. `ruff format --check .`: only the same 2 pre-existing unrelated drift spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`), untouched by this change.
- 1 file changed, no scoring/verifier logic touched (string only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoGweAuMDdcoLXYHWgfY3j

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoGweAuMDdcoLXYHWgfY3j)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-mapping refactor only; existing characterization tests for the three reason codes should preserve identical messages.
> 
> **Overview**
> Consolidates how **ResyUrlMatch** turns conditional-coverage reason codes into human-readable text: `gt_time_missing`, `gt_time_available_not_seen`, and `no_slots_but_wrong_time` are now entries in `_CONDITIONAL_REASON_DESCRIPTIONS` instead of separate `if reason == ...` branches in `_describe_conditional_reason`.
> 
> The method still does a dict lookup first, then prefix-based templates for suffixed reasons, then the generic fallback. **No scoring or evaluation logic changes**—only where those three strings are defined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff17a9c4c1e8633d6f5a8eb75e4417b1b5b717d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->