### PR TITLE
refactor: drop redundant "r" mode from read-only open() calls (UP015)

### DIFF
--- a/evaluation/dataset.py
+++ b/evaluation/dataset.py
@@ -24,7 +24,7 @@ class DatasetBuildConfig(Protocol):
 
 
 def load_dataset_item_json(dataset_item_json: str) -> DatasetItem:
-    with open(dataset_item_json, "r") as f:
+    with open(dataset_item_json) as f:
         item = json.load(f)
 
     if "task_generation_config" in item and "task_generation_config_json" not in item:

--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -88,7 +88,7 @@ class Recorder:
         if not osp.exists(load_path):
             return None
         try:
-            async with aiofiles.open(load_path, "r") as f:
+            async with aiofiles.open(load_path) as f:
                 content = await f.read()
             return deserialize(json.loads(content))
         except Exception:

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -705,7 +705,7 @@ def load_restaurant_metadata() -> dict:
     metadata = {}
 
     try:
-        with open(csv_path, "r") as f:
+        with open(csv_path) as f:
             reader = csv.DictReader(f)
             for row in reader:
                 city = row["city"].strip().lower()


### PR DESCRIPTION
## What

`"r"` is `open()`'s documented default mode, so passing it explicitly does nothing. This drops it from the three read-only `open()` sites in navi-bench production code:

- `navi_bench/resy/resy_url_match.py` — restaurant-metadata CSV read
- `evaluation/dataset.py` — dataset-item JSON read
- `evaluation/recorder.py` — async replay read (`aiofiles.open`)

## Why

Pure redundancy removal (ruff `UP015`, not in the repo's enforced `E,W,F` config so CI was already green). Behavior is byte-identical — all three sites open for reading with the default text mode either way.

## Verification

- `ruff check` (enforced `E,W,F,W291/292/293`) — clean
- `ruff check --select UP015` — clean (was 3 hits)
- `ruff format --check` — unchanged
- `python -m py_compile` on all three files — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVWZP9LZiXxi4ErmRo761a)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic open() signature changes only; no logic, I/O mode, or data handling changes.
> 
> **Overview**
> Removes the explicit `"r"` argument from three read-only file opens, since text read mode is already the default for `open()` and `aiofiles.open()`.
> 
> The updates are in `evaluation/dataset.py` (dataset-item JSON load), `evaluation/recorder.py` (async JSON replay load), and `navi_bench/resy/resy_url_match.py` (restaurant metadata CSV load). **Behavior is unchanged** — this is style/lint cleanup for ruff **UP015**, not a functional change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4536a5a0094e6593cf5c017d0184ac0d4614573f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->