### PR TITLE
refactor(recorder): replace os.path with pathlib.Path in Recorder

### DIFF
--- a/evaluation/recorder.py
+++ b/evaluation/recorder.py
@@ -1,9 +1,8 @@
 import functools
 import json
-import os
 from collections.abc import Callable
 from contextlib import contextmanager
-from os import path as osp
+from pathlib import Path
 from typing import TypeVar
 
 import aiofiles
@@ -24,15 +23,15 @@ class Recorder:
     def __init__(self, save_dir: str, task_id: str):
         self.save_dir = save_dir
         self.task_id = task_id
-        self.item_dir = osp.join(save_dir, task_id)
-        os.makedirs(self.item_dir, exist_ok=True)
+        self.item_dir = Path(save_dir) / task_id
+        self.item_dir.mkdir(parents=True, exist_ok=True)
 
     def _log_filter(self, record: dict) -> bool:
         return record["extra"].get("task_id") == self.task_id
 
     @contextmanager
     def logging(self):
-        log_path = osp.join(self.item_dir, "task.log")
+        log_path = self.item_dir / "task.log"
         handler_id = logger.add(
             log_path, format=functools.partial(log_formatter, colorize=False), filter=self._log_filter, level="DEBUG"
         )
@@ -42,7 +41,7 @@ class Recorder:
             logger.remove(handler_id)
 
     async def _save_text(self, filename: str, build_content: Callable[[], str], kind: str) -> None:
-        save_path = osp.join(self.item_dir, filename)
+        save_path = self.item_dir / filename
         try:
             content = build_content()
             async with aiofiles.open(save_path, "w") as f:
@@ -84,8 +83,8 @@ class Recorder:
         await self._save_text("messages.jsonl", build_content, "messages")
 
     async def _load_json(self, filename: str, deserialize: Callable[[dict], T], kind: str) -> T | None:
-        load_path = osp.join(self.item_dir, filename)
-        if not osp.exists(load_path):
+        load_path = self.item_dir / filename
+        if not load_path.exists():
             return None
         try:
             async with aiofiles.open(load_path) as f:

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -8,6 +8,7 @@ import json
 from os import path as osp
 
 import pytest
+from loguru import logger
 from pydantic import BaseModel
 
 from evaluation.recorder import Recorder
@@ -17,6 +18,18 @@ from evaluation.stats import TimingStats
 class _DummyUsage(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
+
+
+def test_logging_writes_task_log_file(tmp_path):
+    recorder = Recorder(str(tmp_path), "task-1")
+
+    with recorder.logging():
+        logger.bind(task_id="task-1").debug("hello from task-1")
+
+    log_path = osp.join(str(tmp_path), "task-1", "task.log")
+    assert osp.exists(log_path)
+    with open(log_path) as f:
+        assert "hello from task-1" in f.read()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`evaluation/recorder.py`'s `Recorder` class was the last file in the repo still building/checking
paths via `os.makedirs`/`os.path.join`/`os.path.exists` (imported as `from os import path as osp`),
while the rest of the codebase's path handling already uses `pathlib.Path`
(`navi_bench/base.py::read_sidecar`, `navi_bench/resy/resy_url_match.py`'s CSV path). This
replaces the hand-rolled `os.path` calls with the idiomatic `pathlib.Path` equivalents already
established elsewhere:

- `self.item_dir` is now a `Path` built with `/` instead of a string built with `osp.join`
- directory creation uses `Path.mkdir(parents=True, exist_ok=True)` instead of `os.makedirs`
- existence checks use `Path.exists()` instead of `osp.exists()`

## Why it's safe

- No behavior change: `aiofiles.open()` and loguru's `logger.add()` both accept `Path` objects
  natively, and `Path`'s `/` produces the same separator as `os.path.join` on the same platform.
- `Recorder`'s public constructor signature (`save_dir: str, task_id: str`) is unchanged, and no
  other module reads `.item_dir`/`.save_dir` expecting a `str` (checked via repo-wide grep — the
  sole external caller, `evaluation/eval_n1.py`, only passes `task_id`/`save_dir` in and never
  reads the attributes back out).
- Added a characterization test for `Recorder.logging()` (previously untested — it's the one
  method whose behavior depends on `logger.add()` accepting the new `Path`-typed `log_path`) and
  confirmed it passes unchanged against the pre-refactor implementation via `git stash`.
- Full suite: 536 passed (535 baseline + 1 new test), `ruff check` clean, `ruff format --check`
  shows only the same 2 pre-existing unrelated baseline drift spots (`evaluation/eval_n1.py`,
  `navi_bench/dates.py`), untouched by this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKHJHVi9Rcsaj3Z9rFPwym


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKHJHVi9Rcsaj3Z9rFPwym)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical path API swap with no signature or external attribute changes; new characterization test covers the logging path that passes a `Path` to loguru.
> 
> **Overview**
> **`Recorder` path handling** now uses `pathlib.Path` instead of `os.path`/`os.makedirs`: `item_dir` is built with `/`, directories are created via `Path.mkdir`, and load paths use `Path.exists()`. The public API (`save_dir: str`, `task_id: str`) is unchanged; `aiofiles` and loguru still receive path objects they already support.
> 
> Adds **`test_logging_writes_task_log_file`** to lock in behavior of the `logging()` context manager (task-filtered debug lines land in `task.log` under the task directory).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200dd97b1f986e9a88a8c98ccc69e367cdc7328e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->