### PR TITLE
refactor: finish the os.path -> pathlib.Path migration

### DIFF
--- a/evaluation/dataset.py
+++ b/evaluation/dataset.py
@@ -1,6 +1,7 @@
 import json
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from datasets import concatenate_datasets, disable_caching, load_dataset
@@ -24,7 +25,7 @@ class DatasetBuildConfig(Protocol):
 
 
 def load_dataset_item_json(dataset_item_json: str) -> DatasetItem:
-    with open(dataset_item_json) as f:
+    with Path(dataset_item_json).open() as f:
         item = json.load(f)
 
     if "task_generation_config" in item and "task_generation_config_json" not in item:

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -705,7 +705,7 @@ def load_restaurant_metadata() -> dict:
     metadata = {}
 
     try:
-        with open(csv_path) as f:
+        with csv_path.open() as f:
             reader = csv.DictReader(f)
             for row in reader:
                 city = row["city"].strip().lower()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,11 +6,13 @@ already cleared the domain/task-id/per-domain-cap checks, so the interaction bet
 ``dataset_max_samples_per_domain`` and ``dataset_max_samples`` is order-dependent.
 """
 
+import json
+
 from dataclasses import dataclass
 
 from datasets import Dataset
 
-from evaluation.dataset import build_dataset
+from evaluation.dataset import build_dataset, load_dataset_item_json
 from tests.conftest import run_async
 
 
@@ -42,6 +44,28 @@ def _build(monkeypatch, items: list[dict], config: _FakeDatasetBuildConfig) -> l
     monkeypatch.setattr("evaluation.dataset.concatenate_datasets", lambda datasets: datasets[0])
     result = run_async(build_dataset(config))
     return [dataset_item.task_id for dataset_item in result]
+
+
+def test_load_dataset_item_json_parses_file_into_dataset_item(tmp_path):
+    item_path = tmp_path / "item.json"
+    item_path.write_text(json.dumps(_item("google_flights", 1)))
+
+    result = load_dataset_item_json(str(item_path))
+
+    assert result.task_id == "fake/google_flights/1"
+    assert result.domain == "google_flights"
+
+
+def test_load_dataset_item_json_migrates_legacy_task_generation_config_key(tmp_path):
+    item = _item("resy", 2)
+    item["task_generation_config"] = json.loads(item.pop("task_generation_config_json"))
+    item_path = tmp_path / "legacy_item.json"
+    item_path.write_text(json.dumps(item))
+
+    result = load_dataset_item_json(str(item_path))
+
+    assert result.task_id == "fake/resy/2"
+    assert result.task_generation_config_json == "{}"
 
 
 class TestBuildDatasetSampling:

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -5,7 +5,6 @@ filename and pydantic model type). ``recorder.py`` had zero prior test coverage.
 """
 
 import json
-from os import path as osp
 
 import pytest
 from loguru import logger
@@ -26,9 +25,9 @@ def test_logging_writes_task_log_file(tmp_path):
     with recorder.logging():
         logger.bind(task_id="task-1").debug("hello from task-1")
 
-    log_path = osp.join(str(tmp_path), "task-1", "task.log")
-    assert osp.exists(log_path)
-    with open(log_path) as f:
+    log_path = tmp_path / "task-1" / "task.log"
+    assert log_path.exists()
+    with log_path.open() as f:
         assert "hello from task-1" in f.read()
 
 
@@ -50,8 +49,8 @@ async def test_save_usage_writes_expected_json_shape(tmp_path):
 
     await recorder.save_usage(usage)
 
-    save_path = osp.join(str(tmp_path), "task-1", "usage.json")
-    with open(save_path) as f:
+    save_path = tmp_path / "task-1" / "usage.json"
+    with save_path.open() as f:
         content = json.load(f)
     assert content == {"input_tokens": 10, "output_tokens": 20}
 
@@ -66,8 +65,8 @@ async def test_load_usage_returns_none_when_file_missing(tmp_path):
 @pytest.mark.asyncio
 async def test_load_usage_returns_none_on_invalid_content(tmp_path):
     recorder = Recorder(str(tmp_path), "task-1")
-    save_path = osp.join(str(tmp_path), "task-1", "usage.json")
-    with open(save_path, "w") as f:
+    save_path = tmp_path / "task-1" / "usage.json"
+    with save_path.open("w") as f:
         f.write('{"not_a_valid_field": "oops"')  # malformed JSON
 
     assert await recorder.load_usage(_DummyUsage) is None
@@ -103,8 +102,8 @@ async def test_save_timing_writes_expected_json_shape(tmp_path):
 
     await recorder.save_timing(timing)
 
-    save_path = osp.join(str(tmp_path), "task-1", "timing.json")
-    with open(save_path) as f:
+    save_path = tmp_path / "task-1" / "timing.json"
+    with save_path.open() as f:
         content = json.load(f)
     assert content["times_ms"] == [50.0]
     assert content["call_count"] == 1


### PR DESCRIPTION
## Summary

- #262 replaced `os.path` with `pathlib.Path` in `Recorder` and claimed it was "the last file in the repo still using `os.makedirs`/`os.path.join`/`os.path.exists`" — but three spots were left behind:
  - `evaluation/dataset.py::load_dataset_item_json`'s `open(dataset_item_json)`
  - `navi_bench/resy/resy_url_match.py::load_restaurant_metadata`'s `open(csv_path)` — `csv_path` is already a `Path` there, so this was purely a missed call
  - `tests/test_recorder.py`'s own new characterization tests (added by #262 itself), which used `os.path.join`/`os.path.exists`/`open()` against a pytest `tmp_path` fixture that is already a `Path`
- Switched all of these to `Path.open()` / `Path.exists()` / the `/` operator. No behavior change.

## Why / safety

- `load_restaurant_metadata()` runs at import time and is exercised by every `resy` test in the suite, so its regression coverage was already implicit — if the `Path.open()` swap broke it, virtually the entire resy test file would fail immediately.
- `load_dataset_item_json()` had no direct test coverage before this change. Added two characterization tests (plain parse, and the legacy `task_generation_config` key migration path) and confirmed both pass **unchanged against the pre-refactor implementation** via `git stash` before applying the source change.
- Deliberately left `evaluation/eval_n1.py`'s own leftover `os.makedirs`/`os.path.join` calls untouched — that file is the core eval-scoring file this repo's own refactor backlog has repeatedly flagged as off-limits for behavior-change risk, so it's out of scope here even though it shares the same PTH103/PTH118 lint category.

## Test plan

- [x] `python3 -m pytest tests/` — 538 passed (536 baseline + 2 new)
- [x] New tests confirmed to pass against the pre-refactor source via `git stash`
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean aside from the 2 documented pre-existing drift spots in `eval_n1.py`/`dates.py` (untouched by this PR)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XgCDkKirwSjJE9UVYPR1e

---
_Generated by [Claude Code](https://claude.ai/code/session_014XgCDkKirwSjJE9UVYPR1e)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical I/O API swaps with no intended behavior change; new tests cover `load_dataset_item_json`, and Resy metadata loading remains exercised by the existing resy test suite.
> 
> **Overview**
> Completes the **pathlib** cleanup started in #262 by replacing the remaining `open()` / `os.path` usage in dataset loading, Resy CSV loading, and recorder tests.
> 
> `load_dataset_item_json` now reads via `Path(...).open()`, and `load_restaurant_metadata` uses `csv_path.open()` on the existing `Path`. Recorder characterization tests assert paths with `tmp_path / ...`, `.exists()`, and `.open()` instead of `os.path.join` / `open`.
> 
> Adds **two characterization tests** for `load_dataset_item_json` (normal JSON parse and legacy `task_generation_config` → `task_generation_config_json` migration). `evaluation/eval_n1.py` is intentionally unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8715016346a1929ddbdf6a5eba74d35bd20a2b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->