### PR TITLE
refactor(eval_n1): replace remaining os.path usage with pathlib.Path

### DIFF
--- a/evaluation/eval_n1.py
+++ b/evaluation/eval_n1.py
@@ -35,12 +35,11 @@ import copy
 import functools
 import io
 import json
-import os
 import sys
 import time
 import traceback
 from datetime import datetime
-from os import path as osp
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from PIL import Image
@@ -512,13 +511,13 @@ def _split_results_with_stats(
 
 @cli
 async def main(config: Config) -> None:
-    os.makedirs(config.eval_save_dir, exist_ok=True)
+    Path(config.eval_save_dir).mkdir(parents=True, exist_ok=True)
 
     logger.remove()
     logger.level("DEBUG", color="<fg #808080>")
     logger.add(sys.stdout, format=functools.partial(log_formatter, colorize=True))
     logger.add(
-        osp.join(config.eval_save_dir, config.eval_log_name), format=functools.partial(log_formatter, colorize=False)
+        Path(config.eval_save_dir) / config.eval_log_name, format=functools.partial(log_formatter, colorize=False)
     )
     logger.info(f"{config=}")
 


### PR DESCRIPTION
#263 claimed to finish the `os.path` -> `pathlib.Path` migration but missed `evaluation/eval_n1.py::main`, which still used `os.makedirs` and `os.path.join` (aliased as `osp`) for the `eval_save_dir` directory creation and log-file path. Every other file in the repo (`base.py`, `recorder.py`, `resy_url_match.py`, `dataset.py`) already uses `pathlib.Path` for the same kind of path handling.

**What changed**
- `os.makedirs(dir, exist_ok=True)` -> `Path(dir).mkdir(parents=True, exist_ok=True)`
- `osp.join(dir, name)` -> `Path(dir) / name`
- Dropped the now-unused `import os` and `from os import path as osp`

**Why safe**
- Behavior-identical for these plain directory/filename strings; loguru's `logger.add()` already accepts `Path` objects natively (used elsewhere in this same file's `Recorder`).
- This is `main()`'s own setup code (directory + logger init), not the eval-scoring loop (`run_agent`/`_predict`), so it's outside this repo's standing "no eval-scoring-behavior-change" constraint.
- `main()` has no direct test coverage before or after this change (it requires a live playwright/openai/yutori client, same gap as before this PR).
- 538/538 existing tests pass, `ruff check` clean, `ruff format --check` shows only the same 2 pre-existing unrelated drift spots (`eval_n1.py:314`, `dates.py`) — confirmed unaffected by diffing against the pre-change tree.

1 file changed, 3 insertions(+), 4 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqrSKpooJhSQgTYP9hGCnu

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqrSKpooJhSQgTYP9hGCnu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only path handling refactor with equivalent semantics; loguru already accepts Path objects elsewhere in this module.
> 
> **Overview**
> Completes the **`os.path` → `pathlib.Path`** cleanup in `evaluation/eval_n1.py` that was missed in an earlier migration, aligning `main()` with the rest of the evaluation package (`recorder.py`, `dataset.py`, etc.).
> 
> **`main()` setup** now creates the results directory with `Path(...).mkdir(parents=True, exist_ok=True)` instead of `os.makedirs`, and builds the log file path with `Path(dir) / name` instead of `os.path.join`. Unused `os` and `osp` imports are removed.
> 
> No change to eval scoring or agent loop behavior—only directory creation and loguru file sink wiring at startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231aeb95a72b479fb94354db251aac642a18d2ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->