### PR TITLE
refactor(base): tighten build_task_config's eval_class param from Any to type[BaseMetric]

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -376,7 +376,7 @@ def build_task_config(
     url: str,
     task: str,
     user_metadata: UserMetadata,
-    eval_class: Any,
+    eval_class: type["BaseMetric"],
     eval_kwargs: dict[str, Any],
 ) -> BaseTaskConfig:
     eval_config = {"_target_": get_import_path(eval_class), **eval_kwargs}


### PR DESCRIPTION
## What

`build_task_config`'s `eval_class` parameter in `navi_bench/base.py` was typed `Any`, even though every one of its 7 call sites (craigslist, apartments, google_flights, resy x2, opentable x2) passes a `ResetsViaState`/`BaseMetric` subclass, and the function's only use of it (`get_import_path(eval_class)`) needs a class, not an instance.

Tightened to `type["BaseMetric"]`, matching the existing `evaluator: "BaseMetric"` forward-reference pattern already used a few lines above in `safe_update`.

## Why it's safe

Pure type-annotation tightening — no runtime behavior change, no call sites need updating (verified all 7 pass a `BaseMetric` subclass).

- `ruff check`: clean
- Full test suite: 538 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX8bJDAC5eesH2du4M6tBj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX8bJDAC5eesH2du4M6tBj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static typing change only; behavior and all domain call sites stay the same.
> 
> **Overview**
> **`build_task_config`** in `navi_bench/base.py` now types **`eval_class`** as **`type["BaseMetric"]`** instead of **`Any`**, aligning with how callers pass metric classes and with **`get_import_path(eval_class)`** expecting a class object.
> 
> This is annotation-only: no runtime or call-site changes. It mirrors the existing **`"BaseMetric"`** forward-reference style used on **`safe_update`** in the same module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3614ef90f4a21bcbb22e83e825ad3d525960f46d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->