### PR TITLE
refactor(google_flights): tighten resolve_date_references's Any param to a concrete type

### DIFF
--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -3,7 +3,6 @@ import binascii
 import urllib.parse
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any
 
 from beartype import beartype
 from loguru import logger
@@ -165,12 +164,15 @@ class GoogleFlightsSearchMatch(ResetsViaState):
         return all_or_nothing_coverage_result("GoogleFlightsUrlMatch", is_info_covered)
 
 
-def resolve_date_references(gt_info: list[dict], resolved_values: dict[str, Any]) -> list[dict]:
+def resolve_date_references(gt_info: list[dict], resolved_values: dict[str, str | list[str] | None]) -> list[dict]:
     """Replace date references like "dateRange.0" with actual dates from resolved_values.
 
     Args:
         gt_info: List of gt_info dicts with date references
-        resolved_values: Dict with resolved dates like {"dateRange": ["2026-06-27", "2026-06-30"]}
+        resolved_values: Dict with resolved dates like {"dateRange": ["2026-06-27", "2026-06-30"]}.
+            A value is a bare ``str`` for a single resolved date, a ``list[str]`` for a
+            multi-date range/list, or ``None`` when the placeholder resolved to no dates
+            (mirroring the three branches ``generate_task_config`` below uses to build it).
 
     Returns:
         List of gt_info dicts with resolved dates


### PR DESCRIPTION
## What

`resolve_date_references(gt_info, resolved_values)` in `navi_bench/google_flights/google_flights_search_match.py` typed `resolved_values` as `dict[str, Any]`. Its only caller, `generate_task_config` in the same file, always builds it as one of exactly three shapes per key:

```python
resolved_values[placeholder_key] = [iso_dates[0], iso_dates[-1]]   # list[str] (range)
resolved_values[placeholder_key] = iso_dates                        # list[str]
resolved_values[placeholder_key] = iso_dates[0] if iso_dates else None  # str | None
```

i.e. `str | list[str] | None`. Tightened the annotation to match and dropped the now-unused `from typing import Any` import (it was the only usage of `Any` in the file).

This follows the same "tighten a loose `Any` to the concrete type the code actually produces" pattern as #261 and #265.

## Why safe

- Pure static-annotation change — no runtime logic touched. `resolve_date_references` is not `@beartype`-decorated (only the `GoogleFlightsSearchMatch` class is), so this cannot newly raise at runtime.
- `resolve_date_references` already has direct test coverage (`test_direct_reference_is_substituted`, `test_indexed_reference_selects_list_element`, `test_original_gt_info_is_not_mutated`, `test_multiple_info_items_each_resolved_independently`) exercising both the `str` and `list[str]` branches — no new test needed since behavior is unchanged.
- Full suite: `538 passed`.
- `ruff check .`: clean. `ruff format --check` on the touched file: clean (two unrelated pre-existing formatting diffs in `evaluation/eval_n1.py` and `navi_bench/dates.py` exist on `main` already, untouched by this PR).
- Single file, ~8 lines changed.

## Testing

- `pytest -q` → 538 passed
- `ruff check .` → all checks passed
- `ruff format --check navi_bench/google_flights/google_flights_search_match.py` → already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDyPapdatFemwH7m4xsyzs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDyPapdatFemwH7m4xsyzs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static typing and documentation only; no logic or runtime validation paths changed.
> 
> **Overview**
> **Typing-only cleanup** for `resolve_date_references` in `google_flights_search_match.py`: `resolved_values` is now annotated as `dict[str, str | list[str] | None]` instead of `dict[str, Any]`, matching the three shapes `generate_task_config` actually assigns (single date, date list/range endpoints, or `None`).
> 
> The unused `from typing import Any` import is removed, and the docstring briefly documents those value variants. **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d26336bbc47a68cc0412b2763f542206f63f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->