### PR TITLE
refactor(opentable): tighten Any param to str | int on unconditional-evidence helper

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -5,7 +5,7 @@ import random
 import re
 from collections.abc import Callable, Iterator
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Literal
 
 from beartype import beartype
 from loguru import logger
@@ -177,7 +177,7 @@ class OpenTableInfoGathering(ResetsViaState):
         *,
         restaurant: str,
         condition_key: str,
-        all_satisfy: Callable[[Any], bool],
+        all_satisfy: Callable[[str | int], bool],
         on_covered: Callable[[int, MultiCandidateQuery], None],
     ) -> None:
         """Mark uncovered queries as covered when an evidence item rules them out unconditionally.


### PR DESCRIPTION
## Summary
- `OpenTableInfoGathering._mark_uncovered_queries_with_unconditional_evidence`'s `all_satisfy: Callable[[Any], bool]` parameter is only ever called with values pulled from a `MultiCandidateQuery`'s `"dates"` (`list[str]`) or `"party_sizes"` (`list[int]`) keys at its two private call sites (`_handle_too_far_in_advance`, `_handle_party_too_small_or_too_large`). Narrowed the annotation to `Callable[[str | int], bool]` to match, and dropped the now-unused `Any` import.
- Pure type-tightening, no behavior change. `OpenTableInfoGathering` is `@beartype`-decorated, but beartype only checks `Callable` parameters for callability at runtime (not their inner argument/return types), so this annotation change has no runtime effect.

This follows the same pattern as #265/#266 (narrowing an overly broad `Any` parameter to the concrete type its actual callers use).

## Test plan
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check navi_bench/opentable/opentable_info_gathering.py` — already formatted
- [x] `uv run pytest tests/test_opentable_info_gathering.py -q` — 60 passed
- [x] `uv run pytest -q` (full suite) — 538 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9pWqPtRzZ7VNjp3TS56Uu

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9pWqPtRzZ7VNjp3TS56Uu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change in OpenTable query-coverage logic; no logic, I/O, or security surface changes.
> 
> **Overview**
> Tightens typing on **`OpenTableInfoGathering._mark_uncovered_queries_with_unconditional_evidence`**: the **`all_satisfy`** callback is annotated as **`Callable[[str | int], bool]`** instead of **`Callable[[Any], bool]`**, reflecting that callers only pass **`dates`** strings or **`party_sizes`** integers from **`MultiCandidateQuery`**.
> 
> Removes the unused **`Any`** import from **`typing`**. **No runtime or behavioral change**—only static type accuracy, consistent with prior **`Any`**-narrowing refactors in this codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b01328c3e31984aa0f8cca5124ec4df73ed5d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->