### PR TITLE
refactor(opentable,resy): share duplicated city location/timezone data

### DIFF
--- a/navi_bench/city_locations.py
+++ b/navi_bench/city_locations.py
@@ -1,0 +1,16 @@
+"""Canonical location/timezone metadata for well-known cities.
+
+Shared by domain matchers (opentable, resy) that each build their own ``CITY_METADATA``-shaped
+lookup keyed by their own domain-specific city spelling (e.g. resy's lowercase ``"new york"``/
+``"sf"`` with an extra ``city_slug`` field vs opentable's ``"NYC"``/``"SF"``/``"Boston"``/
+``"Los Angeles"`` with no slug). The two dicts previously hardcoded the identical
+``location``/``timezone`` pair for San Francisco and for New York independently, so the strings
+could drift out of sync if only one of the two files were ever updated. Centralizing just that
+overlapping (location, timezone) data here removes the duplication without imposing a single key
+vocabulary on either caller -- each file still keys its own dict however it needs to.
+"""
+
+SAN_FRANCISCO = {"location": "San Francisco, CA, United States", "timezone": "America/Los_Angeles"}
+NEW_YORK = {"location": "New York, NY, United States", "timezone": "America/New_York"}
+BOSTON = {"location": "Boston, MA, United States", "timezone": "America/New_York"}
+LOS_ANGELES = {"location": "Los Angeles, CA, United States", "timezone": "America/Los_Angeles"}

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -24,6 +24,7 @@ from navi_bench.base import (
     safe_evaluate,
     unwrap_single_template_query,
 )
+from navi_bench.city_locations import BOSTON, LOS_ANGELES, NEW_YORK, SAN_FRANCISCO
 from navi_bench.dates import (
     ensure_resolved_dates,
     format_natural_date,
@@ -471,12 +472,14 @@ class OpenTableInfoGathering(ResetsViaState):
             return base_ts, base_ts
 
 
-# City to location and timezone mapping
+# City to location and timezone mapping. Values come from navi_bench.city_locations so the
+# San Francisco / New York entries stay in sync with resy's CITY_METADATA (see that module's
+# docstring).
 CITY_METADATA = {
-    "SF": {"location": "San Francisco, CA, United States", "timezone": "America/Los_Angeles"},
-    "NYC": {"location": "New York, NY, United States", "timezone": "America/New_York"},
-    "Boston": {"location": "Boston, MA, United States", "timezone": "America/New_York"},
-    "Los Angeles": {"location": "Los Angeles, CA, United States", "timezone": "America/Los_Angeles"},
+    "SF": SAN_FRANCISCO,
+    "NYC": NEW_YORK,
+    "Boston": BOSTON,
+    "Los Angeles": LOS_ANGELES,
 }
 
 

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -27,6 +27,7 @@ from navi_bench.base import (
     safe_evaluate,
     unwrap_single_template_query,
 )
+from navi_bench.city_locations import NEW_YORK, SAN_FRANCISCO
 from navi_bench.dates import (
     ensure_resolved_dates,
     format_natural_date,
@@ -623,14 +624,12 @@ class ResyUrlMatch(ResetsViaState):
         )
 
 
-# City to location and timezone mapping
+# City to location and timezone mapping. The location/timezone pair comes from
+# navi_bench.city_locations so these stay in sync with opentable's CITY_METADATA (see that
+# module's docstring); city_slug is resy-specific and layered on top.
 CITY_METADATA = {
-    "new york": {"location": "New York, NY, United States", "timezone": "America/New_York", "city_slug": "new-york-ny"},
-    "sf": {
-        "location": "San Francisco, CA, United States",
-        "timezone": "America/Los_Angeles",
-        "city_slug": "san-francisco-ca",
-    },
+    "new york": {**NEW_YORK, "city_slug": "new-york-ny"},
+    "sf": {**SAN_FRANCISCO, "city_slug": "san-francisco-ca"},
 }
 
 # Manual mapping of restaurant names to Resy venue slugs


### PR DESCRIPTION
## Structural issue

`navi_bench/opentable/opentable_info_gathering.py` and `navi_bench/resy/resy_url_match.py` each
define a `CITY_METADATA`-shaped dict mapping a city name to its `location`/`timezone` pair. Two
entries overlap exactly between the files — San Francisco and New York — but were hardcoded
independently in each file, so the strings could silently drift out of sync if only one file were
ever updated (e.g. a timezone fix landing in one file but not the other).

A previous audit flagged this duplication but was right to be cautious about a blanket merge: the
two files use genuinely divergent key vocabularies (resy: lowercase `"sf"` / `"new york"` plus a
resy-specific `city_slug` field; opentable: `"SF"` / `"NYC"` / `"Boston"` / `"Los Angeles"`, no
slug) and different lookup semantics (resy lowercases the lookup key; opentable does not).
Unifying the two dicts into one schema would require picking a winning vocabulary — a design
decision, not a mechanical refactor.

## The fix

Instead of merging the two dicts, this PR extracts only the genuinely duplicated
`(location, timezone)` values into a new single-purpose module,
`navi_bench/city_locations.py` (`SAN_FRANCISCO`, `NEW_YORK`, `BOSTON`, `LOS_ANGELES`), and has
both files build their existing `CITY_METADATA` dict from it:

- `opentable_info_gathering.py`'s `CITY_METADATA` keeps its exact `"SF"`/`"NYC"`/`"Boston"`/
  `"Los Angeles"` keys, now pointing at the shared constants.
- `resy_url_match.py`'s `CITY_METADATA` keeps its exact `"new york"`/`"sf"` keys and its
  `city_slug` field, spreading the shared constant plus its own slug.

Each file's key vocabulary, casing, and shape are completely unchanged — only the previously
duplicated literal strings now have one source of truth. Both dicts are read-only everywhere
(`.get(...)`, `[...]` reads only — no mutation), so sharing the same dict objects across modules
is safe.

## Equivalence proof

Before making the change, I extracted each file's original `CITY_METADATA` literal via
`ast.literal_eval` and saved it. After the refactor, I asserted the resolved dicts are
byte-for-byte equal to those originals for every city in both files:

```
EQUIVALENCE CONFIRMED: opentable and resy CITY_METADATA are byte-for-byte identical to pre-refactor values
opentable: {'SF': {'location': 'San Francisco, CA, United States', 'timezone': 'America/Los_Angeles'}, 'NYC': {'location': 'New York, NY, United States', 'timezone': 'America/New_York'}, 'Boston': {'location': 'Boston, MA, United States', 'timezone': 'America/New_York'}, 'Los Angeles': {'location': 'Los Angeles, CA, United States', 'timezone': 'America/Los_Angeles'}}
resy: {'new york': {'location': 'New York, NY, United States', 'timezone': 'America/New_York', 'city_slug': 'new-york-ny'}, 'sf': {'location': 'San Francisco, CA, United States', 'timezone': 'America/Los_Angeles', 'city_slug': 'san-francisco-ca'}}
```

## Testing

- `python3 -m pytest -q` → 538 passed (same as baseline before the change)
- `ruff check` / `ruff format --check` on all three touched files → clean

## Scope

3 files touched (1 new, 2 edited), no behavior change, no call-site changes elsewhere.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbhdZh7YggdY4XFd4XWwRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbhdZh7YggdY4XFd4XWwRs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with no call-site or schema changes; resolved metadata values stay the same.
> 
> **Overview**
> Introduces **`navi_bench/city_locations.py`** as the single source of truth for shared **`location`** / **`timezone`** dicts (`SAN_FRANCISCO`, `NEW_YORK`, `BOSTON`, `LOS_ANGELES`), so OpenTable and Resy no longer duplicate the same strings in two places.
> 
> **OpenTable** `CITY_METADATA` still uses keys like `"SF"` / `"NYC"` but now points at those constants. **Resy** keeps lowercase `"sf"` / `"new york"` keys and **`city_slug`**, built with `{**NEW_YORK, "city_slug": ...}` on top of the shared data. Key vocabularies and runtime behavior are unchanged—only where the literals live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b358bb963d32b89a5106b721f4f2cedac0346718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->