### PR TITLE
refactor(demo): tighten result printing to FinalResult's actual interface

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -17,7 +17,7 @@ from typing import Any
 from datasets import load_dataset
 from playwright.async_api import Page, async_playwright
 
-from navi_bench.base import BaseMetric, DatasetItem, FinalResult, instantiate, safe_update
+from navi_bench.base import BaseMetric, DatasetItem, instantiate, safe_update
 
 
 HF_DATASET = "yutori-ai/navi-bench"
@@ -102,7 +102,7 @@ async def run_human_session(task_id: str) -> None:
 
         # Compute the evaluation result
         print("\nComputing evaluation result...\n")
-        result: FinalResult = await evaluator.compute()
+        result = await evaluator.compute()
 
         # Now we can close the browser
         await context.close()
@@ -113,7 +113,8 @@ async def run_human_session(task_id: str) -> None:
     print("RESULT")
     print("=" * 80)
     print(f"Score: {result.score}")
-    print(f"Reasoning: {result.reasoning}")
+    if hasattr(result, "reasoning"):
+        print(f"Reasoning: {result.reasoning}")
     print("=" * 80 + "\n")
 
 

--- a/demo.py
+++ b/demo.py
@@ -17,7 +17,7 @@ from typing import Any
 from datasets import load_dataset
 from playwright.async_api import Page, async_playwright
 
-from navi_bench.base import BaseMetric, DatasetItem, instantiate, safe_update
+from navi_bench.base import BaseMetric, DatasetItem, FinalResult, instantiate, safe_update
 
 
 HF_DATASET = "yutori-ai/navi-bench"
@@ -102,7 +102,7 @@ async def run_human_session(task_id: str) -> None:
 
         # Compute the evaluation result
         print("\nComputing evaluation result...\n")
-        result = await evaluator.compute()
+        result: FinalResult = await evaluator.compute()
 
         # Now we can close the browser
         await context.close()
@@ -112,11 +112,8 @@ async def run_human_session(task_id: str) -> None:
     print("=" * 80)
     print("RESULT")
     print("=" * 80)
-    print(f"Score: {getattr(result, 'score', None)}")
-    if hasattr(result, "reasoning"):
-        print(f"Reasoning: {result.reasoning}")
-    if hasattr(result, "details"):
-        print(f"Details: {result.details}")
+    print(f"Score: {result.score}")
+    print(f"Reasoning: {result.reasoning}")
     print("=" * 80 + "\n")
 
 


### PR DESCRIPTION
## Structural issue

`demo.py`'s final result printing duck-types `evaluator.compute()`'s generic
`BaseMetric.compute() -> BaseModel` return via:

```python
print(f"Score: {getattr(result, 'score', None)}")
if hasattr(result, "reasoning"):
    print(f"Reasoning: {result.reasoning}")
if hasattr(result, "details"):
    print(f"Details: {result.details}")
```

But every concrete `BaseMetric` subclass in this repo (`ApartmentsUrlMatch`,
`CraigslistUrlMatch`, `GoogleFlightsSearchMatch`, `OpenTableInfoGathering`,
`ResyUrlMatch` — confirmed via `grep -rn "async def compute"`, the only 5 that
exist) declares `compute() -> FinalResult`, and `FinalResult` only ever has a
required `score: float` and an optional `reasoning: str | None = None` — no
`details` field exists anywhere in the codebase (confirmed via repo-wide
grep). So in practice:

- `hasattr(result, "details")` is **always `False`** — permanently dead code.
- `hasattr(result, "reasoning")` is **always `True`** (the field exists on the
  model even when its value is `None`) — the guard never actually guards
  anything.
- `getattr(result, "score", None)` silently falls back to `None` instead of
  raising if the interface guarantee were ever violated — masking rather than
  surfacing a bug.

## The fix

Annotated `result: FinalResult` and replaced the duck-typed checks with direct
attribute access, dropping the always-false `details` branch:

```python
result: FinalResult = await evaluator.compute()
...
print(f"Score: {result.score}")
print(f"Reasoning: {result.reasoning}")
```

## Why it's safe

Output is provably unchanged for every evaluator that exists today:
- `hasattr(result, "reasoning")` was always `True`, so the print always ran —
  now it always runs unconditionally, same output (including printing
  `Reasoning: None` when `reasoning` is unset, matching prior behavior).
- `hasattr(result, "details")` was always `False`, so that branch never
  printed anything — removing it changes no observed output.
- `result.score` was always present (required field), so direct access is
  equivalent to the `getattr` fallback.

Verified directly:
```
>>> FinalResult(score=1.0, reasoning='ok') -> "Score: 1.0" / "Reasoning: ok"
>>> FinalResult(score=0.0)                 -> "Score: 0.0" / "Reasoning: None"
```
(identical to pre-change output in both cases)

## Testing

- `python3 -m pytest -q` → 538/538 passed (no change from baseline)
- `ruff check .` → clean
- `ruff format --check .` → only the 2 pre-existing, unrelated drift spots
  (`evaluation/eval_n1.py`, `navi_bench/dates.py`), untouched by this change

## Scope

1 file touched (`demo.py`), no behavior change, no call-site changes
elsewhere. `demo.py` is an interactive human-in-the-loop script with no
existing unit test file, so correctness was verified directly via
`FinalResult` construction rather than a new test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSzyUXZwDpB7jwaPqCJqKo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSzyUXZwDpB7jwaPqCJqKo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file change to an interactive demo script’s print logic, with no runtime behavior change for current evaluators.
> 
> **Overview**
> **demo.py** result reporting stops duck-typing the evaluator output and aligns with the shared **`FinalResult`** shape evaluators already return.
> 
> The score line now uses **`result.score`** instead of **`getattr(..., None)`**, so a broken return type would fail loudly rather than printing **`Score: None`**. The **`details`** print branch is removed—it never ran because **`FinalResult`** has no **`details`** field.
> 
> Console output for existing metrics should match prior behavior (including **`Reasoning: None`** when reasoning is unset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be320c32615748bc766abfe673f693321fe8d27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->