### PR TITLE
refactor(dates): tighten resolve_city_now's city_meta param from dict to Mapping[str, str]

### DIFF
--- a/navi_bench/dates.py
+++ b/navi_bench/dates.py
@@ -1,6 +1,7 @@
 """Unified utilities for parsing and evaluating dynamic date expressions."""
 
 import re
+from collections.abc import Mapping
 from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
@@ -221,8 +222,14 @@ def initialize_user_metadata(
     return user_metadata
 
 
-def resolve_city_now(city_meta: dict) -> tuple[datetime, UserMetadata]:
+def resolve_city_now(city_meta: Mapping[str, str]) -> tuple[datetime, UserMetadata]:
     """Resolve the current tz-aware time and UserMetadata for a CITY_METADATA entry.
+
+    ``city_meta`` is one entry from resy's or opentable's ``CITY_METADATA`` dict (see
+    :mod:`navi_bench.city_locations`) -- only its ``"timezone"``/``"location"`` string values
+    are read here, so a ``Mapping[str, str]`` covers both call sites' shapes (opentable's plain
+    ``{location, timezone}`` pair and resy's superset that layers on an extra ``city_slug`` key)
+    without requiring a shared concrete type between the two.
 
     Delegates the ``UserMetadata`` construction to :func:`initialize_user_metadata` (passing
     the already-computed ``today``'s timestamp explicitly) instead of re-building the same


### PR DESCRIPTION
## What

`navi_bench/dates.py::resolve_city_now` accepted a bare, unparameterized `city_meta: dict`, even though it only ever reads two string-valued keys off it: `city_meta["timezone"]` and `city_meta["location"]`. Tightened the annotation to `Mapping[str, str]`.

## Why it's safe

- Both call sites (`navi_bench/resy/resy_url_match.py`, `navi_bench/opentable/opentable_info_gathering.py`) pass an entry straight from their own `CITY_METADATA` dicts. Since #268 extracted the shared `(location, timezone)` pairs into `navi_bench/city_locations.py`, those entries are provably `str`-valued: opentable's plain `{location, timezone}` pair, and resy's superset that layers on one extra `city_slug` string. `Mapping[str, str]` covers both shapes exactly, without forcing a single concrete type between the two domain matchers (which have genuinely different key vocabularies, per this repo's standing convention).
- `resolve_city_now` is **not** `@beartype`-decorated, so this is a documentation-only annotation change with zero runtime behavior difference — same reasoning as the previously-merged #223/#224 typing-only PRs in this repo.
- Same category as the three most recently merged PRs here (#265, #266, #267): narrowing an overly broad parameter type (`Any`/bare `dict`) to the concrete type its actual callers use.

## Verification

- `resolve_city_now` already has direct characterization coverage (`tests/test_dates.py::TestResolveCityNow`) pinning that `today`/`user_metadata` describe the same instant — unchanged by this diff.
- Full suite: `pytest tests/` → 538/538 passing (before and after).
- `ruff check .` → clean.
- `ruff format --check navi_bench/dates.py` → only the same pre-existing, unrelated drift spot at line 152 (already documented in this repo's refactor history as a standing baseline issue, untouched by this diff) — no new formatting issues introduced.

1 file changed, +8/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mSACu7ufDvNchiYztqckT

---
_Generated by [Claude Code](https://claude.ai/code/session_012mSACu7ufDvNchiYztqckT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only annotation and docstring updates; no logic or runtime validation changes.
> 
> **Overview**
> **Typing-only change** to `resolve_city_now` in `navi_bench/dates.py`: the `city_meta` parameter moves from an unparameterized `dict` to `Mapping[str, str]`, with a new import from `collections.abc`.
> 
> The expanded docstring explains that callers pass a Resy or OpenTable `CITY_METADATA` entry and only `"timezone"` and `"location"` are read, so the mapping type covers both shapes (including Resy’s extra keys) without shared concrete types. **Runtime behavior is unchanged**—this documents what callers already pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fdf52e493674262c180b83d05cf3393f5dc5957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->