### PR TITLE
fix(resy): interpolate gt_time in _evaluate_condition's no-neighbors debug log

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -514,8 +514,8 @@ class ResyUrlMatch(ResetsViaState):
 
         if prev_time is None and next_time is None:
             logger.debug(
-                "ResyUrlMatch._evaluate_condition no neighbors for gt_time=%s (unlikely scenario treated as success)",
-                state.gt_time,
+                "ResyUrlMatch._evaluate_condition no neighbors for "
+                f"gt_time={state.gt_time} (unlikely scenario treated as success)"
             )
             return True, "gt_time_outside_available_range"
 

--- a/tests/test_resy_url_match.py
+++ b/tests/test_resy_url_match.py
@@ -24,9 +24,12 @@ from datetime import date
 import pytest
 from conftest import FakeEvaluatePage, run_async as _run
 
+from loguru import logger
+
 from navi_bench.resy import resy_url_match
 from navi_bench.resy.resy_url_match import (
     RESTAURANT_METADATA,
+    AvailabilitySlot,
     ResyQueryState,
     ResyUrlMatch,
     _BOUNDARY_REASON_MESSAGE_TEMPLATES,
@@ -580,6 +583,40 @@ class TestUpdateConditionalMatch:
         _run_update(match, url=_GT_URL, has_no_availability=False, availabilities=[])
 
         assert match._coverage_reasons[0] is None
+
+
+class TestEvaluateConditionNoNeighborsLogMessage:
+    """Regression test for a silently-broken debug log: the "no neighbors" branch of
+    ``_evaluate_condition`` used to build its message with old ``%s``-style placeholders
+    (``"gt_time=%s", state.gt_time``), but loguru renders messages via ``str.format`` rather
+    than ``%``-formatting, so ``gt_time`` never interpolated and the literal text "%s" was
+    logged instead of the actual value. Reaching this branch requires ``last_known_times`` to
+    contain a time that is numerically equal to ``gt_time`` in seconds-of-day but a different
+    string (e.g. "09:00:00" vs "9:00:00"), so it neither sorts before nor after -- the
+    "unlikely scenario" the branch's own message describes.
+    """
+
+    def test_gt_time_is_interpolated_into_the_message(self):
+        state = ResyQueryState(
+            group_index=0,
+            alt_index=0,
+            gt_url="url",
+            base_without_time="url",
+            gt_time="9:00:00",
+            last_known_times=["09:00:00"],
+        )
+        availabilities = [AvailabilitySlot(time="10:00:00", is_visible=True)]
+
+        messages: list[str] = []
+        sink_id = logger.add(messages.append, format="{message}", level="DEBUG")
+        try:
+            result = ResyUrlMatch._evaluate_condition(state=state, url_time=None, availabilities=availabilities)
+        finally:
+            logger.remove(sink_id)
+
+        assert result == (True, "gt_time_outside_available_range")
+        assert any("gt_time=9:00:00" in message for message in messages)
+        assert not any("%s" in message for message in messages)
 
 
 class TestCompute:


### PR DESCRIPTION
## What

`ResyUrlMatch._evaluate_condition`'s "no neighbors" debug log built its message with old `%s`-style placeholders:

```python
logger.debug(
    "ResyUrlMatch._evaluate_condition no neighbors for gt_time=%s (unlikely scenario treated as success)",
    state.gt_time,
)
```

## Why

This codebase's logger is loguru, which renders messages via `str.format`, not `%`-formatting (confirmed: every other `logger.*` call in this file already uses f-strings). As a result, `state.gt_time` silently never interpolated — the literal text `%s` was logged instead of the actual value, making this debug line useless for its one purpose (diagnosing the "unlikely scenario" it names).

## How

Switched the message to an f-string, matching every other call site in the file. Pure log-content fix — no control flow, return value, or scoring behavior touched.

## Verification

- Added `TestEvaluateConditionNoNeighborsLogMessage` (`tests/test_resy_url_match.py`), which drives `_evaluate_condition` directly into the "no neighbors" branch (via a `last_known_times` entry that's numerically equal to `gt_time` in seconds-of-day but a different string, so it neither sorts before nor after) and captures the rendered message through a loguru sink.
- Confirmed via `git stash` that this test **fails** against the pre-fix code (message contains the literal `%s`, not the interpolated value) and passes post-fix.
- Full suite: 539/539 passing (538 baseline + 1 new).
- `ruff check` clean; `ruff format --check` shows only the same 2 pre-existing, unrelated drift spots (`eval_n1.py`, `dates.py`) also present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjehL7YTdjyFzQNEG3mF36

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjehL7YTdjyFzQNEG3mF36)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to one debug log line plus a regression test; matcher behavior is unchanged.
> 
> **Overview**
> Fixes a **debug-only logging bug** in `ResyUrlMatch._evaluate_condition` when the "no neighbors" branch runs (`gt_time_outside_available_range`): the message used `%s` plus a separate argument, which **loguru does not apply** (it expects f-strings / `str.format` like the rest of this file), so logs showed the literal `%s` instead of `gt_time`.
> 
> Adds **`TestEvaluateConditionNoNeighborsLogMessage`**, which forces that branch (same seconds-of-day, different time strings in `last_known_times` vs `gt_time`) and asserts the captured DEBUG line includes `gt_time=9:00:00` and no `%s`. **No scoring or control-flow changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 112bb3ad4c89946a83a60ae09b7c253bafa1ebbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->