### PR TITLE
refactor(browser): key LOCATION_COORDS off navi_bench.city_locations constants

### DIFF
--- a/evaluation/browser.py
+++ b/evaluation/browser.py
@@ -9,6 +9,7 @@ from loguru import logger
 from playwright.async_api import Browser, BrowserContext, Error as PlaywrightError, Page, Playwright
 
 from navi_bench.base import BaseTaskConfig, read_sidecar, safe_evaluate
+from navi_bench.city_locations import BOSTON, LOS_ANGELES, NEW_YORK, SAN_FRANCISCO
 
 
 @runtime_checkable
@@ -20,11 +21,17 @@ class BrowserBuildConfig(Protocol):
     browser_viewport_height: int
 
 
+# Keyed by `UserMetadata.location`. The four cities also covered by `navi_bench.city_locations`
+# (the shared source of truth resy's and opentable's `CITY_METADATA` build their `location`
+# values from, see that module's docstring) key off those same constants here, so this dict
+# can't silently stop matching -- and geolocation silently stop being set -- if one of those
+# canonical location strings ever changes. Vancouver isn't produced by any domain matcher's
+# CITY_METADATA, so it stays a plain literal.
 LOCATION_COORDS = {
-    "Boston, MA, United States": (42.3601, -71.0589),
-    "New York, NY, United States": (40.7128, -74.0060),
-    "San Francisco, CA, United States": (37.7749, -122.4194),
-    "Los Angeles, CA, United States": (34.0522, -118.2437),
+    BOSTON["location"]: (42.3601, -71.0589),
+    NEW_YORK["location"]: (40.7128, -74.0060),
+    SAN_FRANCISCO["location"]: (37.7749, -122.4194),
+    LOS_ANGELES["location"]: (34.0522, -118.2437),
     "Vancouver, BC, Canada": (49.2827, -123.1207),
 }
 


### PR DESCRIPTION
## What

`evaluation/browser.py`'s `LOCATION_COORDS` dict hardcoded four city location strings as literal dict keys:

```python
LOCATION_COORDS = {
    "Boston, MA, United States": (42.3601, -71.0589),
    "New York, NY, United States": (40.7128, -74.0060),
    "San Francisco, CA, United States": (37.7749, -122.4194),
    "Los Angeles, CA, United States": (34.0522, -118.2437),
    "Vancouver, BC, Canada": (49.2827, -123.1207),
}
```

These four strings are byte-for-byte identical to the `location` values `navi_bench/city_locations.py` already centralizes as the single source of truth for resy's and opentable's `CITY_METADATA` dicts (extracted in #268 specifically to prevent this kind of string from drifting across files). This PR keys `LOCATION_COORDS` off those same `BOSTON`/`NEW_YORK`/`SAN_FRANCISCO`/`LOS_ANGELES` constants instead of re-hardcoding the literal strings, e.g.:

```python
LOCATION_COORDS = {
    BOSTON["location"]: (42.3601, -71.0589),
    NEW_YORK["location"]: (40.7128, -74.0060),
    SAN_FRANCISCO["location"]: (37.7749, -122.4194),
    LOS_ANGELES["location"]: (34.0522, -118.2437),
    "Vancouver, BC, Canada": (49.2827, -123.1207),  # not produced by any CITY_METADATA, stays literal
}
```

## Why this is an improvement

`LOCATION_COORDS` is looked up by `task_config.user_metadata.location`, and that location string ultimately comes from resy's/opentable's `CITY_METADATA` entries, which already source their `location` field from `navi_bench.city_locations`. Before this change, if one of those canonical location strings were ever edited in `city_locations.py` (e.g. a formatting fix), `LOCATION_COORDS`'s literal keys would silently stop matching, and the browser would silently stop applying the geolocation override for that city — no error, just quietly wrong behavior. Keying off the shared constants makes that impossible by construction. This is the same category of fix as the already-merged #268 (which did the equivalent consolidation for `CITY_METADATA` itself).

## Why it's safe

- Purely mechanical: dict *keys* change from literal strings to constant lookups whose values are asserted identical to those same strings; the dict's actual contents (and therefore all runtime behavior) are unchanged.
- Verified the resulting dict is `==` to the original hardcoded dict.
- `ruff check`/`ruff format --check` clean.
- Full test suite: 539/539 passing (no test references `LOCATION_COORDS` directly, so none needed updating).
- 1 file changed (`evaluation/browser.py`), +11/-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuG1eM32DWhMEdYWwC1rn5


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuG1eM32DWhMEdYWwC1rn5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical key refactor with identical runtime dict contents; no change to geolocation logic beyond preventing silent key mismatches on future string edits.
> 
> **Overview**
> **`LOCATION_COORDS` in `evaluation/browser.py` now uses shared city constants for dict keys** instead of duplicating the same four location strings that `navi_bench.city_locations` already defines for Resy/OpenTable metadata.
> 
> Boston, New York, San Francisco, and Los Angeles are keyed via `BOSTON["location"]`, etc., so a future edit to the canonical `location` string cannot leave browser geolocation lookups out of sync with task `user_metadata.location`. Vancouver remains a literal key because it is not part of that shared module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20412a5f8f5ab216c0f0774c54f9803aaaa09c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->