### PR TITLE
refactor(google_flights): tighten generate_task_config's values param to dict[str, str]

### DIFF
--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -203,7 +203,7 @@ def generate_task_config(
     timestamp: int | None = None,
     url: str = "https://www.google.com/travel/flights",
     gt_info: list[dict] | None = None,
-    values: dict | None = None,
+    values: dict[str, str] | None = None,
 ) -> BaseTaskConfig:
     gt_info = gt_info or []
     values = values or {}


### PR DESCRIPTION
## What

`google_flights_search_match.generate_task_config`'s `values` parameter was typed as a bare `dict`, even though it is passed straight through to `navi_bench.dates.initialize_placeholder_map(user_metadata, values)`, whose `values` parameter is typed `dict[str, str]` (a mapping of placeholder name -> relative-date description string, e.g. `{"date": "{now() + timedelta(158)}"}`).

## Why it's an improvement

The other two callers of the same `initialize_placeholder_map` helper — `opentable_info_gathering.generate_task_config_deterministic` and `resy_url_match.generate_task_config_deterministic` — already declare this identical parameter as `values: dict[str, str] | None = None`. `google_flights_search_match.generate_task_config` is the one remaining instance of the same "placeholder values" parameter left as a broad, untyped `dict`. This tightens it to match its two siblings and its only consumer's actual signature, continuing the same `Any`/broad-type -> concrete-type narrowing pattern already applied elsewhere in this module (e.g. recent PRs #268-#270).

## Why it's safe

- Purely a type-annotation change — no runtime behavior differs (this module is `@beartype`-decorated at the class level, not on this free function, so there's no new runtime enforcement either; it's a documentation-only tightening).
- Verified every value ever placed into `values` in this file is a plain description string (the demo's `"values": {"date": "{now() + timedelta(158)}"}"`), consistent with `dict[str, str]`.
- `generate_task_config` has no other call sites in this repo (only referenced via its own `__main__` demo and via `_target_` dataset-config strings resolved at runtime through `instantiate()`, which is untyped `Any`-based dispatch and unaffected by this annotation).
- 539/539 tests pass unchanged, `ruff check` and `ruff format --check` clean (no new formatting diffs).

1 file changed, 1 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GHfFgkkSxr4PsFxQHFXSk

---
_Generated by [Claude Code](https://claude.ai/code/session_012GHfFgkkSxr4PsFxQHFXSk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line type annotation with no logic or runtime enforcement changes.
> 
> **Overview**
> Narrows the **`values`** parameter on **`generate_task_config`** in `google_flights_search_match.py` from an untyped **`dict | None`** to **`dict[str, str] | None`**, matching **`initialize_placeholder_map`** (placeholder name → relative-date description string) and the same parameter on OpenTable/Resy **`generate_task_config_deterministic`** helpers.
> 
> This is **annotation-only**—call sites and runtime behavior are unchanged; it documents the intended shape of placeholder overrides (e.g. demo **`{"date": "{now() + timedelta(158)}"}`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ef07a34d1140596d6b344c6113ac6440e4736c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->