### PR TITLE
refactor(craigslist): tighten _parse_state's return type from dict to dict[str, list[str]]

### DIFF
--- a/navi_bench/craigslist/craigslist_url_match.py
+++ b/navi_bench/craigslist/craigslist_url_match.py
@@ -33,11 +33,13 @@ class CraigslistUrlMatch(ResetsViaState):
         super().__init__()
         self.gt_urls = gt_urls
 
-        self._gt_states = [[self._parse_state(url) for url in urls] for urls in gt_urls]
+        self._gt_states: list[list[dict[str, list[str]]]] = [
+            [self._parse_state(url) for url in urls] for urls in gt_urls
+        ]
         self._reset_state()
 
     def _reset_state(self) -> None:
-        self._intermediate_url_to_state = {}
+        self._intermediate_url_to_state: dict[str, dict[str, list[str]]] = {}
 
     def __repr__(self) -> str:
         return repr_with_attr(self, "gt_urls")
@@ -75,7 +77,15 @@ class CraigslistUrlMatch(ResetsViaState):
         return FinalResult(score=score, reasoning=reasoning)
 
     @staticmethod
-    def _parse_state(url: str) -> dict:
+    def _parse_state(url: str) -> dict[str, list[str]]:
+        """Parse a URL's query string into its filtered param map (see ``parse_filtered_query_params``).
+
+        Both callers (``__init__`` building ``_gt_states``, ``update`` populating
+        ``_intermediate_url_to_state``) and ``compute``'s ``find_equal_value_entry`` comparison
+        rely on this being a plain string-keyed, string-list-valued dict -- the same shape
+        ``parse_filtered_query_params`` already declares -- so the previously bare ``dict``
+        return annotation undersold the actual, always-true contract.
+        """
         return parse_filtered_query_params(urlparse(url).query, IGNORE_URL_PARAMS)
 
 


### PR DESCRIPTION
`_parse_state` delegates entirely to `parse_filtered_query_params`, which already declares (and always returns) `dict[str, list[str]]`, but the previously bare `dict` return annotation undersold that contract. Both call sites (`__init__` building `_gt_states`, `update` populating `_intermediate_url_to_state`) and `compute`'s `find_equal_value_entry` comparison rely on exactly this string-keyed, string-list-valued shape, so this also annotates those two instance attributes to match. Same category as the recently-merged #265-#270/#273 `Any`/`dict` param-tightening PRs.

`CraigslistUrlMatch` is `@beartype`-decorated, so unlike the prior `dates.py` tightening this is runtime-enforced, not documentation-only — verified safe by exercising `_parse_state`/`update`/`compute` directly under beartype after the change (no violation, since the returned dict always matches the new annotation).

**Verification**
- Full suite: 539/539 passing (was 539/539 before; log's last recorded baseline was 538/538, one test was added since)
- `ruff check` / `ruff format --check` clean on the touched file
- Manual runtime smoke test confirming beartype accepts the tightened annotation on real calls

1 file changed, +13/-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTrzJ1rP8rQmib3Rs9WfQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTrzJ1rP8rQmib3Rs9WfQS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only refactor with no behavioral changes; beartype already validates the same dict shape at runtime.
> 
> **Overview**
> Tightens type annotations on **`CraigslistUrlMatch`** so URL query state is explicitly **`dict[str, list[str]]`**, matching what **`parse_filtered_query_params`** already returns.
> 
> **`_parse_state`** now returns **`dict[str, list[str]]`** (was bare **`dict`**) and gains a short docstring explaining the contract for **`_gt_states`**, **`_intermediate_url_to_state`**, and **`find_equal_value_entry`**. The **`_gt_states`** and **`_intermediate_url_to_state`** instance attributes are annotated to the same shape. No runtime logic changes—only typing and documentation; **`@beartype`** on the class makes the stricter types enforceable at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c69df93e4b078f0839a0647027c60f7e175279b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->