### PR TITLE
refactor(apartments): tighten _extract_locations_from_query's dict params to dict[str, list[str]]

### DIFF
--- a/navi_bench/apartments/apartments_url_match.py
+++ b/navi_bench/apartments/apartments_url_match.py
@@ -148,8 +148,14 @@ class ApartmentsUrlMatch(ResetsViaState):
         return locations, non_location_parts
 
     @staticmethod
-    def _extract_locations_from_query(query_params: dict) -> tuple[set[str], dict]:
-        """Extract locations from query parameters and return (locations, normalized_params)."""
+    def _extract_locations_from_query(query_params: dict[str, list[str]]) -> tuple[set[str], dict[str, list[str]]]:
+        """Extract locations from query parameters and return (locations, normalized_params).
+
+        The sole caller (``_normalize_url``) always passes ``parse_filtered_query_params``'s
+        result, which is provably ``dict[str, list[str]]`` -- the previously bare ``dict``
+        annotations undersold that actual, always-true contract. Same tightening category as
+        the recently-merged #270/#273/#274.
+        """
         locations = set()
         normalized_params = {}
 


### PR DESCRIPTION
## What

`ApartmentsUrlMatch._extract_locations_from_query`'s parameter and one element of its return tuple were annotated as the bare `dict`:

```python
def _extract_locations_from_query(query_params: dict) -> tuple[set[str], dict]:
```

Its sole caller (`_normalize_url`) always passes `parse_filtered_query_params(...)`'s result, which already declares a concrete `dict[str, list[str]]` return type in `navi_bench/base.py`. The function's own body also proves the same shape for its return value: `values[0]` is indexed (list access) and `normalized_params[key] = values` assigns the same list values straight through. The bare `dict` annotations undersold this always-true contract.

## Why this is an improvement

- Same category as the recently-merged #270 (`resolve_city_now`), #273 (`generate_task_config`), and #274 (`_parse_state`) — tightening a broad/undersold interface to the concrete type it always actually carries.
- Unlike some of those precedents, `ApartmentsUrlMatch` is `@beartype`-decorated, so this isn't documentation-only — it's now a real runtime-enforced contract at this call boundary.
- Improves readability/IDE support for a helper whose only caller and only construction site both already commit to this shape.

## Why this is safe

- Single file, +8/-2, no call-site changes needed (the sole caller already passes exactly this shape).
- No behavior change — pure annotation tightening.
- Verified:
  - Full suite: 539/539 tests passing (unchanged from baseline).
  - `ruff check` / `ruff format --check`: clean.
  - Directly exercised the `@beartype`-enforced boundary at runtime (both via `_normalize_url`'s real call path and a direct call matching the caller's shape) — confirms the new annotation validates against actual runtime values without raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmGgsEmUcd3DZfwGNtzReu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmGgsEmUcd3DZfwGNtzReu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change with a single caller already supplying the same shape; no behavior or call-site edits.
> 
> **Overview**
> Tightens **`ApartmentsUrlMatch._extract_locations_from_query`** so its `query_params` argument and the normalized-params half of its return type are **`dict[str, list[str]]`** instead of bare **`dict`**, matching what **`_normalize_url`** always passes from **`parse_filtered_query_params`**.
> 
> Adds a short docstring noting that contract and aligning with recent annotation-tightening PRs. **No runtime logic changes**; on the **`@beartype`**-decorated class this makes the shape a **runtime-checked** boundary rather than documentation-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e115e4e27cf7fb206b31583177eb1f9391fbc02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->