### PR TITLE
refactor(base): extract dispatch_render_mode helper for resy/opentable mode dispatch

### DIFF
--- a/navi_bench/base.py
+++ b/navi_bench/base.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Protocol, TypedDict, TypeVar, Union, get_args, get_origin, runtime_checkable
+from typing import Any, Literal, Protocol, TypedDict, TypeVar, Union, get_args, get_origin, runtime_checkable
 from urllib.parse import ParseResult, parse_qs, urlparse
 
 from datasets import Features, Value
@@ -211,6 +211,26 @@ def unwrap_single_template_query(
     assert len(template_query) == 1, group_message
     assert len(template_query[0]) == 1, item_message
     return template_query[0][0]
+
+
+def dispatch_render_mode(
+    mode: Literal["any", "all"],
+    *,
+    any_fn: Callable[[], _T],
+    all_fn: Callable[[], _T],
+) -> _T:
+    """Dispatch to ``any_fn``/``all_fn`` by ``mode``, raising the shared "Invalid mode" error otherwise.
+
+    Centralizes the ``if mode == "any": ... elif mode == "all": ... else: raise ValueError(...)``
+    three-way dispatch that opentable's and resy's ``generate_task_config_deterministic`` each
+    repeated verbatim; callers pass zero-arg closures capturing their own (already-different)
+    argument lists.
+    """
+    if mode == "any":
+        return any_fn()
+    if mode == "all":
+        return all_fn()
+    raise ValueError(f"Invalid mode: {mode}")
 
 
 def omni_import(path: str):

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -17,6 +17,7 @@ from navi_bench.base import (
     BaseTaskConfig,
     ResetsViaState,
     build_task_config,
+    dispatch_render_mode,
     fractional_coverage_score,
     hour_to_12h_period,
     read_sidecar_with_shared_js_prefix,
@@ -889,13 +890,12 @@ def generate_task_config_deterministic(
     resolved_placeholders, _ = initialize_placeholder_map(user_metadata, values)
 
     rendered_task = render_task_statement(task, resolved_placeholders)
-    if mode == "any":
+    queries = dispatch_render_mode(
+        mode,
         # any mode: replace each placeholder with the actual dates
-        queries = _render_placeholders_in_queries_any(queries, resolved_placeholders)
-    elif mode == "all":
-        queries = _render_placeholders_in_queries_all(queries, resolved_placeholders)
-    else:
-        raise ValueError(f"Invalid mode: {mode}")
+        any_fn=lambda: _render_placeholders_in_queries_any(queries, resolved_placeholders),
+        all_fn=lambda: _render_placeholders_in_queries_all(queries, resolved_placeholders),
+    )
 
     return build_task_config(
         url=url,

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -20,6 +20,7 @@ from navi_bench.base import (
     all_or_nothing_coverage_result,
     basic_normalize_url,
     build_task_config,
+    dispatch_render_mode,
     hour_to_12h_period,
     read_sidecar,
     read_sidecar_with_shared_js_prefix,
@@ -1111,16 +1112,13 @@ def generate_task_config_deterministic(
 
     rendered_task = render_task_statement(task, resolved_placeholders)
 
-    if mode == "any":
+    queries = dispatch_render_mode(
+        mode,
         # any mode: replace each placeholder with the actual dates
-        queries = _render_placeholders_in_queries_any(queries, resolved_placeholders, base_date, booking_window)
-
-    elif mode == "all":
+        any_fn=lambda: _render_placeholders_in_queries_any(queries, resolved_placeholders, base_date, booking_window),
         # all mode: expand the queries to enumerate all combinations
-        queries = _render_placeholders_in_queries_all(queries, resolved_placeholders, base_date, booking_window)
-
-    else:
-        raise ValueError(f"Invalid mode: {mode}")
+        all_fn=lambda: _render_placeholders_in_queries_all(queries, resolved_placeholders, base_date, booking_window),
+    )
 
     return build_task_config(
         url=url,


### PR DESCRIPTION
## What

`navi_bench/resy/resy_url_match.py` and `navi_bench/opentable/opentable_info_gathering.py`'s `generate_task_config_deterministic` each ended with the identical three-way dispatch/validation block:

```python
if mode == "any":
    queries = _render_placeholders_in_queries_any(...)
elif mode == "all":
    queries = _render_placeholders_in_queries_all(...)
else:
    raise ValueError(f"Invalid mode: {mode}")
```

Only the trailing args passed to the `_any`/`_all` helpers differ (resy threads through `base_date`/`booking_window`, opentable doesn't).

Added a shared `dispatch_render_mode(mode, *, any_fn, all_fn)` to `navi_bench/base.py` — right next to the existing `unwrap_single_template_query` helper, which already consolidates a different piece of duplicated resy/opentable query logic — that does the `if`/`elif`/`else` + `ValueError` once. Each call site now passes its own two zero-arg closures capturing its already-different argument lists. 3 files, +33/-15.

## Why it's safe

No behavior change — same three branches (`mode == "any"` / `mode == "all"` / else), same `ValueError` message, mechanically extracted. Verified via:
- `tests/test_resy_url_match.py` + `tests/test_opentable_info_gathering.py` — **133/133 passing**.
- `ruff check` / `ruff format --check` (clean).
- `py_compile` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtatUhdULcNKw38yVFpLEt

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtatUhdULcNKw38yVFpLEt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with identical branches and error handling; no intended behavior change beyond shared helper wiring.
> 
> **Overview**
> Extracts duplicated **`any` / `all` render-mode branching** from OpenTable and Resy `generate_task_config_deterministic` into shared **`dispatch_render_mode`** in `navi_bench/base.py`.
> 
> Call sites now pass **`any_fn`** and **`all_fn`** lambdas that invoke their existing `_render_placeholders_in_queries_*` helpers with domain-specific arguments (Resy still passes `base_date` and `booking_window`; OpenTable does not). Invalid `mode` still raises the same **`ValueError(f"Invalid mode: {mode}")`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2609f4c828626b96e42eb907ee6abdc83d802f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->