### PR TITLE
Fix stale dict return type on opentable/resy generate_task_config_random

### DIFF
--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -696,7 +696,7 @@ def generate_task_config_random(
     party_size_range: tuple[int, int] | None = None,
     seed: int | None = None,
     url: str = "https://www.opentable.com",
-) -> dict:
+) -> BaseTaskConfig:
     """
     Generate task fields dynamically at runtime.
 
@@ -712,7 +712,7 @@ def generate_task_config_random(
         seed: Random seed for deterministic generation (optional)
 
     Returns:
-        Dict with 'task', 'eval_config', and 'user_metadata' fields to be merged into task object
+        The generated task config.
     """
     # Set random seed if provided for deterministic generation
     if seed is not None:

--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -930,7 +930,7 @@ def generate_task_config_random(
     time: str | None = None,
     seed: int | None = None,
     url: str = "https://resy.com",
-) -> dict:
+) -> BaseTaskConfig:
     """
     Generate task fields dynamically at runtime.
 
@@ -949,7 +949,7 @@ def generate_task_config_random(
         seed: Random seed for deterministic generation (optional)
 
     Returns:
-        Dict with 'task', 'eval_config', and 'user_metadata' fields to be merged into task object
+        The generated task config.
     """
     # Set random seed if provided for deterministic generation
     if seed is not None:


### PR DESCRIPTION
## What

Both `generate_task_config_random` functions (`navi_bench/opentable/opentable_info_gathering.py`, `navi_bench/resy/resy_url_match.py`) were annotated `-> dict`, but each already returns `build_task_config(...)`, which returns a `BaseTaskConfig` — matching their sibling `generate_task_config`/`generate_task_config_deterministic` functions in the same files, which correctly declare `-> BaseTaskConfig`.

## Why it's an improvement

The `dict` annotation was stale from before these functions were refactored onto the shared `build_task_config` helper; the docstrings still described a plain dict payload ("Dict with 'task', 'eval_config', and 'user_metadata' fields") that no longer matches what's actually returned. Tightened both annotations to `BaseTaskConfig` (already imported in both files) and updated the docstrings to match.

## Why it's safe

- `BaseTaskConfig` is not a `dict` subclass, so this is a genuine type/documentation correction, not just narrowing an already-correct type. Neither function is `@beartype`-decorated, so there's no runtime enforcement to worry about — this only affects static typing/documentation accuracy.
- No functional change — the function bodies are untouched.
- `pytest -q`: 539/539 passing, identical before and after.
- `ruff check` / `ruff format --check`: clean on both touched files.

2 files changed, +4/-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj1pj35MkTqWRfQNgRZNmg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sj1pj35MkTqWRfQNgRZNmg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static typing only; function bodies are unchanged.
> 
> **Overview**
> Corrects stale typing on **`generate_task_config_random`** in OpenTable and Resy: both functions already return **`build_task_config(...)`** (a **`BaseTaskConfig`**), but were still annotated **`-> dict`** with docstrings describing a plain dict merge payload.
> 
> The PR changes only return annotations to **`-> BaseTaskConfig`** and shortens the **Returns** doc lines to match—aligned with **`generate_task_config_deterministic`** in the same modules. **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36775b1295c469ef5fedb4269b71875f4aa5eb8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->