### PR TITLE
Tighten generate_visualization_html's result param to BaseModel

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -1,6 +1,8 @@
 import json
 from html import escape as _escape_html
 
+from pydantic import BaseModel
+
 from yutori.navigator import NAVIGATOR_COORDINATE_SCALE
 
 
@@ -518,7 +520,7 @@ def _build_steps(
 def generate_visualization_html(
     task_id: str,
     messages: list[dict],
-    result: object | None,
+    result: BaseModel | None,
     coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
     coord_space_height: int = NAVIGATOR_COORDINATE_SCALE,
 ) -> str:
@@ -526,11 +528,11 @@ def generate_visualization_html(
 
     steps, system_prompt, user_query = _build_steps(messages, coord_space_width, coord_space_height)
 
-    # Generate HTML
-    result_score = getattr(result, "score", None) if result else None
-    result_json = (
-        json.dumps(result.model_dump(mode="json"), indent=2) if result and hasattr(result, "model_dump") else None
-    )
+    # Generate HTML. Every BaseMetric.compute() result is a pydantic BaseModel with a
+    # required `score` field (see navi_bench.base.FinalResult and its siblings), so once
+    # `result` itself is present neither attribute lookup can fail.
+    result_score = result.score if result else None
+    result_json = json.dumps(result.model_dump(mode="json"), indent=2) if result else None
 
     html = f"""<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## The structural issue

`evaluation/vis.py::generate_visualization_html` typed its `result` parameter as `object | None` and read it through defensive duck-typing:

```python
result_score = getattr(result, "score", None) if result else None
result_json = (
    json.dumps(result.model_dump(mode="json"), indent=2) if result and hasattr(result, "model_dump") else None
)
```

But `result` is never actually an arbitrary `object`. Every `BaseMetric.compute()` implementation across the five domain matchers (apartments/craigslist/google_flights/opentable/resy) plus `CustomTaskCaptureMetric` returns a pydantic `BaseModel` subclass with a **required** `score: float` field — confirmed by reading all six concrete result classes. `evaluation/recorder.py::ContentRecorder.save_html`, the function one call-site up that builds the kwargs passed into `generate_visualization_html`, already types this same value as `result: BaseModel | None = None`. `generate_visualization_html` was the one remaining place in the chain still carrying the wider, unnecessary `object` type.

This is the same category as several already-merged PRs in this repo tightening `Any`/broad-type params to their actual concrete type (#265, #266, #267, #270, #272–#275), and the same reasoning that landed #269 (`demo.py`'s result-printing tightening), which established that `score` is always present on every evaluator result and doesn't need a `getattr` fallback. `model_dump` is inherited from `pydantic.BaseModel` itself, so `hasattr(result, "model_dump")` is provably always `True` whenever `result` is not `None` — the same "permanently-true guard" shape #269 removed for the `details` field.

## Why this is an improvement

- Removes duck-typing against an interface wider than what ever actually flows through the function.
- Makes the parameter's real contract explicit and consistent with its caller (`save_html`) one layer up.
- Drops a guard clause (`hasattr(result, "model_dump")`) that can never evaluate `False` given the real call sites, which was making the code harder to read without adding any actual safety.

## Why this is safe

- `generate_visualization_html` is **not** `@beartype`-decorated, so the annotation change is documentation-only — zero runtime behavior change from the signature.
- Body change is a strict simplification with identical runtime output in every case that occurs in practice: `result is None` → both branches unchanged; `result` present → `result.score` and `result.model_dump(...)` were always reachable before (the `getattr`/`hasattr` fallbacks never actually fired), so direct access produces the exact same values.
- The existing test `tests/test_vis.py::TestTopLevelSectionsEndToEnd::test_system_prompt_and_user_query_and_result` already constructs a local `BaseModel` subclass (`class _Result(BaseModel): score: float = 1.0`) and passes it as `result`, independently confirming this is the type actually expected here.
- Both production call sites (`evaluation/eval_n1.py`) pass `evaluator.compute()`'s return value directly with no intermediate wrapping.
- Full test suite: 539/539 passing before and after. `ruff check` / `ruff format --check` clean on the touched file.

1 file changed, +8/-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSvSZY7338x8ztt9v5HXfX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSvSZY7338x8ztt9v5HXfX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only tightening and equivalent result serialization for eval HTML output; no auth, data, or runtime enforcement changes.
> 
> **Overview**
> Narrows `generate_visualization_html`'s `result` parameter from `object | None` to **`BaseModel | None`**, aligning it with `ContentRecorder.save_html` and the pydantic models returned by metric `compute()`.
> 
> When a result is present, the HTML builder now reads **`result.score`** and **`result.model_dump(mode="json")`** directly instead of `getattr` / `hasattr` duck-typing. A short comment documents that evaluator results always expose `score` via those BaseModel subclasses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd0ddfadb13a6d79bed8b1f4c90c8d605c6e96d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->