### PR TITLE
types(resy): add RestaurantMetadata TypedDict for load_restaurant_metadata

### DIFF
--- a/navi_bench/resy/resy_url_match.py
+++ b/navi_bench/resy/resy_url_match.py
@@ -686,6 +686,24 @@ class RestaurantDict(TypedDict):
     days_ahead: int
 
 
+class RestaurantMetadata(TypedDict):
+    """Per-restaurant CSV metadata as returned by :func:`load_restaurant_metadata`.
+
+    Distinct from :class:`RestaurantDict` (the 5-field task-generation input): this is the
+    fuller row shape read from ``resy_restaurant.csv``, where the numeric columns are optional
+    (empty cells parse to ``None``) and closed days are a parsed list.
+    """
+
+    city: str
+    name: str
+    guests_min: int | None
+    guests_max: int | None
+    days_ahead: int | None
+    open_time: str | None
+    close_time: str | None
+    closed_days: list[str]
+
+
 def _parse_optional_int(value: str) -> int | None:
     """Parse a CSV cell as ``int``, or ``None`` when the cell is empty.
 
@@ -696,10 +714,11 @@ def _parse_optional_int(value: str) -> int | None:
     return int(value) if value else None
 
 
-def load_restaurant_metadata() -> dict:
+def load_restaurant_metadata() -> dict[tuple[str, str], RestaurantMetadata]:
     """
     Load restaurant metadata from CSV file.
-    Returns a dictionary mapping (city, restaurant_name_lower) to metadata dict.
+    Returns a dictionary mapping (city, restaurant_name_lower) to a
+    :class:`RestaurantMetadata` dict.
     """
     csv_path = Path(__file__).parent / "resy_restaurant.csv"
     metadata = {}


### PR DESCRIPTION
## What

`navi_bench/resy/resy_url_match.py::load_restaurant_metadata()` returned a bare `dict`, hiding the real shape of each metadata row. This authors a properly-named `RestaurantMetadata` TypedDict for that 8-field shape and annotates the return type as `dict[tuple[str, str], RestaurantMetadata]`.

The 8 fields (exactly what the function already constructs):

| field | type |
|---|---|
| `city`, `name` | `str` |
| `guests_min`, `guests_max`, `days_ahead` | `int \| None` (empty CSV cells parse to `None`) |
| `open_time`, `close_time` | `str \| None` |
| `closed_days` | `list[str]` |

The existing `RestaurantDict` name is deliberately left untouched — it types the unrelated 5-field task-generation input to `generate_task_config_random`, so a new name was needed.

## Why

Improves IDE/editor autocomplete and self-documents the metadata shape consumed by `generate_task_config_random` and `_get_booking_window_limit`, matching the file's existing `InputDict`/`RestaurantDict` TypedDict convention. Sourced from the repo cleanup backlog.

## Safety

Purely additive typing — no runtime behavior change:
- The construction site already builds exactly these fields (verified: runtime dict keys match the TypedDict keys 1:1 across all 39 rows).
- `load_restaurant_metadata` is a module-level function and is **not** `@beartype`-decorated, so the annotation is not enforced at runtime.
- Ruff lint + format clean; all 73 tests in `tests/test_resy_url_match.py` pass.

_Note: the sibling `google_flights_search_match.py` dict shapes flagged in the same backlog item are intentionally left for a separate change — their functions are `@beartype`-decorated, so a TypedDict there would enforce shape at runtime (a behavior change), not just document it._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019CXZTbbbPUJVerMsKbhKMk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static typing and documentation only; no logic or runtime validation changes on `load_restaurant_metadata`.
> 
> **Overview**
> Introduces **`RestaurantMetadata`** as a TypedDict for the eight-field rows loaded from `resy_restaurant.csv`, with docstring clarifying how it differs from the existing five-field **`RestaurantDict`** used for random task generation.
> 
> **`load_restaurant_metadata()`** is now annotated to return `dict[tuple[str, str], RestaurantMetadata]` instead of a bare `dict`, so editors and type checkers see the keyed map shape and optional numeric/time fields without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4f76bbf9da88386d1cedf1e875124f27ce94f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->