### PR TITLE
refactor(vis): tighten _get_action_marker_style's return type from dict to a concrete type

### DIFF
--- a/evaluation/vis.py
+++ b/evaluation/vis.py
@@ -235,7 +235,7 @@ def _get_action_marker_style(
     action: dict,
     coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
     coord_space_height: int = NAVIGATOR_COORDINATE_SCALE,
-) -> dict:
+) -> dict[str, str | float | bool]:
     """Generate CSS positioning for action markers.
 
     Coordinates can be in different scales:


### PR DESCRIPTION
## What

`evaluation/vis.py::_get_action_marker_style` builds a CSS-positioning dict for action markers but declared its return type as bare `dict`, even though every key it can set has a known, narrow type:

- `"type"` / `"ref"` — `str`
- coordinate percentages (`"x"`, `"y"`, `"start_x"`, `"start_y"`, `"end_x"`, `"end_y"`) — `float` (produced by the local `to_pct()` helper's division)
- `"has_drag"` / `"has_point"` / `"has_ref_only"` — `bool`

This retypes the return annotation to `dict[str, str | float | bool]`.

## Why it's an improvement

Same "tighten a bare `dict`/`Any` return type to what the function actually constructs" pattern this repo has already applied repeatedly (#265, #266, #267, #270, #273, #274, #275, #279). The bare `dict` annotation told a reader nothing about the shape callers can rely on; the concrete union documents it exactly.

## Why it's safe

- Purely additive typing/documentation — the function is **not** `@beartype`-decorated, so this changes zero runtime behavior.
- Verified against the existing `TestGetActionMarkerStyle` characterization tests (11 cases pinning exact output for every branch: no-coordinates, ref-only, `coordinates` vs. legacy `center_coordinates` precedence, drag start/end fallbacks, etc.) — all pass unchanged.
- Full suite: 539/539 passing (unchanged).
- `ruff check` / `ruff format --check`: clean on the touched file.
- 1 file, +1/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012jXJaAKBmroATbGnBVVEqA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line annotation change with no runtime or behavioral impact.
> 
> **Overview**
> Narrows the return type of **`_get_action_marker_style`** in `evaluation/vis.py` from bare `dict` to **`dict[str, str | float | bool]`**, matching the keys the helper actually builds (`type`/`ref`, percentage coords, and `has_drag` / `has_point` / `has_ref_only` flags).
> 
> This is **typing-only**—no logic changes—and documents the marker dict shape for callers and static checkers that consume `action_markers` in the eval visualization pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44226fee97c92ae0364d2bf65fb8c5fcee4ab822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->