### PR TITLE
Tighten two bare `list` return annotations to concrete types

### DIFF
--- a/evaluation/stats.py
+++ b/evaluation/stats.py
@@ -164,7 +164,7 @@ def show_results(dataset: list[DatasetItem], results: list[BaseModel | Crashed])
             _fmt(_avg_score(entries, crashed_score=1.0)),
         )
 
-    def _metrics_row(label: str, entries: list[tuple[float, bool]]) -> list:
+    def _metrics_row(label: str, entries: list[tuple[float, bool]]) -> list[str | int]:
         """Build a ``table_rows`` entry: ``[label, n_finished, n_crashed, lower, excluding, upper]``.
 
         Shared by the per-domain, per-difficulty, and overall row builders below, which each

--- a/navi_bench/opentable/opentable_info_gathering.py
+++ b/navi_bench/opentable/opentable_info_gathering.py
@@ -415,7 +415,7 @@ class OpenTableInfoGathering(ResetsViaState):
         return matched
 
     @staticmethod
-    def _singleton_choices(query: MultiCandidateQuery, key: str) -> list:
+    def _singleton_choices(query: MultiCandidateQuery, key: str) -> list[str | int | None]:
         """Return ``query[key]`` if it's a non-empty list, else ``[None]``.
 
         Shared by the four ``restaurant_names``/``party_sizes``/``dates``/``times`` lookups in


### PR DESCRIPTION
## Structural issue

Two functions returned a bare `list` annotation even though each constructs a known, bounded shape:

- `evaluation/stats.py::_metrics_row` always returns `[label, *_compute_metrics(entries)]`, where `label: str` and `_compute_metrics` returns `tuple[int, int, str, str, str]` — so the result is always `list[str | int]`.
- `navi_bench/opentable/opentable_info_gathering.py::_singleton_choices` returns either `query[key]` (a `list[str]` for `restaurant_names`/`dates`/`times` or `list[int]` for `party_sizes`, per `MultiCandidateQuery`'s field types) or the `[None]` default — so `list[str | int | None]` covers every branch.

## Why it's an improvement

This is the same "tighten a bare `dict`/`Any`/`list` to the concrete type the function actually constructs" pattern already applied repeatedly across this repo (#265-267, #270, #273-275, #279, #280) — just not yet to these two spots. Precise return types make each function's real contract legible at the call site instead of `list`'s "anything goes."

## Why it's safe

- Zero behavior change — annotation-only, no logic touched.
- `OpenTableInfoGathering` is `@beartype`-decorated, so `_singleton_choices`'s new return type is runtime-enforced. Verified directly by exercising the live beartype-wrapped method with all four key variants (str lists for `restaurant_names`/`dates`/`times`, an int list for `party_sizes`, and the `[None]` default) — all pass. `_metrics_row` lives in a non-beartype module, so its change is documentation-only.
- Full test suite: 539/539 passing, unchanged.
- `ruff check`/`ruff format --check` clean (only the 2 known pre-existing, unrelated drift spots in `eval_n1.py`/`dates.py` remain, untouched by this diff).
- 2 files touched, 2 lines changed total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLtds38ZnZSb8agGShyYhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLtds38ZnZSb8agGShyYhb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes with no behavior impact; beartype on OpenTable may reject incorrectly typed returns that were already impossible in practice.
> 
> **Overview**
> Replaces two bare `list` return annotations with concrete element types, matching the repo’s ongoing typing cleanup.
> 
> In **`evaluation/stats.py`**, `_metrics_row` is now annotated as `list[str | int]` because it always returns a label plus the five-tuple from `_compute_metrics` (counts and formatted score strings). In **`opentable_info_gathering.py`**, `_singleton_choices` is now `list[str | int | None]` to reflect `MultiCandidateQuery` list fields or the `[None]` placeholder used in the exhaustion `product` loop.
> 
> **No runtime or logic changes**—only type hints. The OpenTable helper runs under `@beartype`, so the stricter return type is enforced there; the stats helper remains documentation-only for static checkers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb8f68fe886f96512ab7e1784b800c246ca0224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->