### PR TITLE
refactor(cli): tighten _build_argparse_kwargs's dict return type

### DIFF
--- a/evaluation/cli.py
+++ b/evaluation/cli.py
@@ -51,8 +51,8 @@ def cli(fn):
     return wrapper
 
 
-def _build_argparse_kwargs(annotation, default, *, nullable: bool = False) -> dict:
-    kwargs = {"default": default}
+def _build_argparse_kwargs(annotation, default, *, nullable: bool = False) -> dict[str, object]:
+    kwargs: dict[str, object] = {"default": default}
 
     origin = get_origin(annotation)
     args = get_args(annotation)


### PR DESCRIPTION
## What
`evaluation/cli.py::_build_argparse_kwargs` builds the kwargs dict forwarded to `argparse.add_argument` (`default`/`nargs`/`type`/`action`) but was annotated with a bare `-> dict`, leaving the value type undocumented.

## Why it's an improvement
This exact "argparse/click-kwargs" shape already has an established idiom elsewhere in this repo: `evaluation/eval_n1.py`'s `_CLICK_KWARGS` is typed `dict[str, dict[str, object]]`. Tightening `_build_argparse_kwargs`'s return type to `dict[str, object]` (and its local `kwargs` variable to match) brings this function's signature in line with that precedent, and matches the general "`Any`/bare-`dict` → concrete type" pattern this repo has repeatedly applied elsewhere (e.g. #265-#267, #270, #273-#275, #279-#281).

## Why it's safe
- `_build_argparse_kwargs` is **not** `@beartype`-decorated, so this is a documentation-only annotation change with zero runtime behavior change.
- Full test suite: 539/539 passing, unchanged (including the existing `tests/test_cli.py::TestBuildArgparseKwargs` characterization tests, which pin every branch's exact return value).
- `ruff check`/`ruff format --check` clean on the touched file.
- 1 file changed, 2 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyTFq6DbUvMn1wSy9Bgms8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyTFq6DbUvMn1wSy9Bgms8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only type annotations on a non-beartype helper; behavior and CLI parsing are unchanged.
> 
> **Overview**
> Tightens typing on **`_build_argparse_kwargs`** in `evaluation/cli.py`: the return type moves from bare **`dict`** to **`dict[str, object]`**, and the local **`kwargs`** variable is annotated the same way.
> 
> This documents the argparse keyword shape (`default`, `nargs`, `type`, `action`, etc.) and aligns with the existing **`dict[str, object]`** pattern used for click kwargs in `evaluation/eval_n1.py`. **No runtime or logic changes**—annotations only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d5759c8d3a51276c9e74cec186a14c7945a3c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->