### PR TITLE
types(google_flights): add GoogleFlightsGtInfo TypedDict for gt_info shape

### DIFF
--- a/navi_bench/google_flights/google_flights_search_match.py
+++ b/navi_bench/google_flights/google_flights_search_match.py
@@ -3,6 +3,7 @@ import binascii
 import urllib.parse
 from collections import defaultdict
 from copy import deepcopy
+from typing import TypedDict
 
 from beartype import beartype
 from loguru import logger
@@ -28,10 +29,26 @@ cd navi_bench/google_flights
 protoc --python_out=. google_flights.proto
 """
 
+# "from"/"to" aren't valid identifiers, so this uses TypedDict's functional syntax.
+GoogleFlightsSegment = TypedDict(
+    "GoogleFlightsSegment",
+    {"from": str, "to": str, "date": str, "max_stops": int},
+    total=False,
+)
+
+
+class GoogleFlightsGtInfo(TypedDict, total=False):
+    """Ground truth flight info, as documented in :meth:`GoogleFlightsSearchMatch.__init__`."""
+
+    segments: list[GoogleFlightsSegment]
+    passengers: list[str]
+    seat: str
+    trip: str
+
 
 @beartype
 class GoogleFlightsSearchMatch(ResetsViaState):
-    def __init__(self, gt_info: list[dict]) -> None:
+    def __init__(self, gt_info: list[GoogleFlightsGtInfo]) -> None:
         """
         Args:
             gt_info: A list of ground truth flight information, where each element is a dictionary
@@ -113,7 +130,7 @@ class GoogleFlightsSearchMatch(ResetsViaState):
         return flight_info
 
     @classmethod
-    def _create_base_info(cls, gt_info: dict) -> Info:
+    def _create_base_info(cls, gt_info: GoogleFlightsGtInfo) -> Info:
         info = Info()
 
         for segment in gt_info["segments"]:
@@ -164,7 +181,9 @@ class GoogleFlightsSearchMatch(ResetsViaState):
         return all_or_nothing_coverage_result("GoogleFlightsUrlMatch", is_info_covered)
 
 
-def resolve_date_references(gt_info: list[dict], resolved_values: dict[str, str | list[str] | None]) -> list[dict]:
+def resolve_date_references(
+    gt_info: list[GoogleFlightsGtInfo], resolved_values: dict[str, str | list[str] | None]
+) -> list[GoogleFlightsGtInfo]:
     """Replace date references like "dateRange.0" with actual dates from resolved_values.
 
     Args:
@@ -202,7 +221,7 @@ def generate_task_config(
     timezone: str,
     timestamp: int | None = None,
     url: str = "https://www.google.com/travel/flights",
-    gt_info: list[dict] | None = None,
+    gt_info: list[GoogleFlightsGtInfo] | None = None,
     values: dict[str, str] | None = None,
 ) -> BaseTaskConfig:
     gt_info = gt_info or []


### PR DESCRIPTION
## What

`navi_bench/google_flights/google_flights_search_match.py` had four signatures all taking the same "ground truth flight info" shape as a bare `list[dict]` / `dict`:

- `GoogleFlightsSearchMatch.__init__(self, gt_info: list[dict])`
- `GoogleFlightsSearchMatch._create_base_info(cls, gt_info: dict) -> Info`
- `resolve_date_references(gt_info: list[dict], ...) -> list[dict]`
- `generate_task_config(..., gt_info: list[dict] | None = None, ...)`

`__init__`'s docstring already documents the exact fixed shape in prose: `segments` (each with `from`/`to`/`date` and an optional `max_stops`), `passengers`, `seat`, and `trip`. This adds a `GoogleFlightsGtInfo` TypedDict (plus a `GoogleFlightsSegment` helper TypedDict, authored with the functional `TypedDict(...)` syntax since `"from"`/`"to"` aren't valid Python identifiers) and retypes all four signatures to use it.

## Why this is an improvement

This mirrors a pattern already applied repeatedly across this repo — `InputDict`/`RestaurantDict`/`RestaurantMetadata` TypedDicts already exist for the other domain matchers' structured dict inputs (resy, opentable), and this exact "tighten a bare `dict`/`Any` param to the concrete type the function already constructs/consumes" refactor has landed as #265-267, #270, #273-275, and #279-282 — just not yet applied to this file's `gt_info` shape, even though it's the most-used structured-dict shape in the file (4 call sites) and already has full prose documentation to draw the type from.

## Why this is safe

- `GoogleFlightsSearchMatch` is `@beartype`-decorated, so `__init__` and `_create_base_info` are runtime-enforced. I verified directly (with a standalone beartype script matching this exact shape: `list[TypedDict]` with `NotRequired`/`total=False`-style optional fields) that beartype's checking here only requires the value be a dict — it does not enforce required-key presence or per-key value types for `TypedDict` params in this beartype version (0.22.9). So this is not a behavior change for any real caller.
- `resolve_date_references` and `generate_task_config` are plain module functions with no `@beartype` decoration — their annotation change is pure documentation, zero runtime effect.
- No call site changes: every existing caller already constructs/consumes dicts matching this exact shape.

## Verified

- Full test suite: **539/539 passing**, unchanged from baseline.
- `tests/test_google_flights_search_match.py`: **21/21 passing**, unchanged.
- `ruff check .`: clean.
- `ruff format --check .`: only the 2 known pre-existing drift spots (`evaluation/eval_n1.py`, `navi_bench/dates.py`), untouched by this change.
- `python -m py_compile` + direct import of the module: clean.

1 file changed, +23/-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnxWSK1NMGJD91mgso2B2W

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnxWSK1NMGJD91mgso2B2W)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only refactor with no logic or caller changes; beartype still treats TypedDict params as plain dicts at runtime.
> 
> **Overview**
> Introduces **`GoogleFlightsSegment`** and **`GoogleFlightsGtInfo`** TypedDicts so ground-truth flight config matches the shape already described in `GoogleFlightsSearchMatch.__init__` (segments with `from`/`to`/`date`/optional `max_stops`, plus `passengers`, `seat`, `trip`). Segment keys use functional `TypedDict(...)` because `from` and `to` are not valid identifiers.
> 
> **Retypes only** — `list[dict]` / `dict` on `GoogleFlightsSearchMatch.__init__`, `_create_base_info`, `resolve_date_references`, and `generate_task_config` now use these types. No call-site or runtime logic changes; aligns with the same TypedDict tightening used for other domain matchers in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89963c7f32c9bc0062e8fd6bc5b16d0ae5662606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->